### PR TITLE
[OB-139] add new evaluation attributes reported by @launchdarkly/observability

### DIFF
--- a/.changeset/poor-trains-speak.md
+++ b/.changeset/poor-trains-speak.md
@@ -1,0 +1,5 @@
+---
+'highlight.run': patch
+---
+
+add new evaluation attributes reported by @launchdarkly/observability

--- a/sdk/highlight-run/src/integrations/launchdarkly/index.ts
+++ b/sdk/highlight-run/src/integrations/launchdarkly/index.ts
@@ -128,7 +128,7 @@ export function setupLaunchDarklyIntegration(
 				)
 			}
 
-			hClient.startSpan(FEATURE_FLAG_SPAN_NAME, eventAttributes, (s) => {
+			hClient.startSpan(FEATURE_FLAG_SPAN_NAME, (s) => {
 				if (s) {
 					s.addEvent(FEATURE_FLAG_SCOPE, eventAttributes)
 				}

--- a/sdk/highlight-run/src/integrations/launchdarkly/index.ts
+++ b/sdk/highlight-run/src/integrations/launchdarkly/index.ts
@@ -24,12 +24,12 @@ export const FEATURE_FLAG_SPAN_NAME = 'evaluation'
 
 export const FEATURE_FLAG_ENV_ATTR = `${FEATURE_FLAG_SCOPE}.set.id`
 export const FEATURE_FLAG_KEY_ATTR = `${FEATURE_FLAG_SCOPE}.key`
-export const FEATURE_FLAG_CONTEXT_ATTR = `${FEATURE_FLAG_SCOPE}.context`
-export const FEATURE_FLAG_CONTEXT_ID_ATTR = `${FEATURE_FLAG_CONTEXT_ATTR}.id`
+export const FEATURE_FLAG_CONTEXT_ATTR = `${FEATURE_FLAG_SCOPE}.contextKeys`
+export const FEATURE_FLAG_CONTEXT_ID_ATTR = `${FEATURE_FLAG_SCOPE}.context.id`
 export const FEATURE_FLAG_VALUE_ATTR = `${FEATURE_FLAG_SCOPE}.result.value`
 export const FEATURE_FLAG_PROVIDER_ATTR = `${FEATURE_FLAG_SCOPE}.provider.name`
-export const FEATURE_FLAG_IN_EXPERIMENT_ATTR = `${FEATURE_FLAG_SCOPE}.result.reason.in_experiment`
-export const FEATURE_FLAG_VARIATION_INDEX_ATTR = `${FEATURE_FLAG_SCOPE}.result.variation_index`
+export const FEATURE_FLAG_IN_EXPERIMENT_ATTR = `${FEATURE_FLAG_SCOPE}.result.reason.inExperiment`
+export const FEATURE_FLAG_VARIATION_INDEX_ATTR = `${FEATURE_FLAG_SCOPE}.result.variationIndex`
 export const FEATURE_FLAG_APP_ID_ATTR = `${LD_SCOPE}.application.id`
 export const FEATURE_FLAG_APP_VERSION_ATTR = `${LD_SCOPE}.application.version`
 
@@ -114,9 +114,19 @@ export function setupLaunchDarklyIntegration(
 				[FEATURE_FLAG_PROVIDER_ATTR]: 'LaunchDarkly',
 				[FEATURE_FLAG_KEY_ATTR]: hookContext.flagKey,
 				[FEATURE_FLAG_VALUE_ATTR]: JSON.stringify(detail.value),
-				[FEATURE_FLAG_IN_EXPERIMENT_ATTR]: detail.reason?.inExperiment,
-				[FEATURE_FLAG_VARIATION_INDEX_ATTR]:
-					detail.variationIndex ?? undefined,
+				// only set the following keys when values are truthy
+				...(detail.reason?.inExperiment
+					? {
+							[FEATURE_FLAG_IN_EXPERIMENT_ATTR]:
+								detail.reason.inExperiment,
+						}
+					: {}),
+				...(detail.variationIndex
+					? {
+							[FEATURE_FLAG_VARIATION_INDEX_ATTR]:
+								detail.variationIndex,
+						}
+					: {}),
 			}
 
 			if (hookContext.context) {

--- a/sdk/highlight-run/src/integrations/launchdarkly/index.ts
+++ b/sdk/highlight-run/src/integrations/launchdarkly/index.ts
@@ -20,19 +20,18 @@ export type { Hook, LDClient }
 
 export const FEATURE_FLAG_SCOPE = 'feature_flag'
 export const LD_SCOPE = 'launchdarkly'
+export const FEATURE_FLAG_SPAN_NAME = 'evaluation'
+
 export const FEATURE_FLAG_ENV_ATTR = `${FEATURE_FLAG_SCOPE}.set.id`
 export const FEATURE_FLAG_KEY_ATTR = `${FEATURE_FLAG_SCOPE}.key`
 export const FEATURE_FLAG_CONTEXT_ATTR = `${FEATURE_FLAG_SCOPE}.context`
-export const FEATURE_FLAG_CONTEXT_KEY_ATTR = `${FEATURE_FLAG_CONTEXT_ATTR}.key`
+export const FEATURE_FLAG_CONTEXT_ID_ATTR = `${FEATURE_FLAG_CONTEXT_ATTR}.id`
+export const FEATURE_FLAG_VARIANT_ATTR = `${FEATURE_FLAG_SCOPE}.result.variant`
 export const FEATURE_FLAG_PROVIDER_ATTR = `${FEATURE_FLAG_SCOPE}.provider.name`
-export const FEATURE_FLAG_VARIANT_ATTR = `${FEATURE_FLAG_SCOPE}.variant`
-export const FEATURE_FLAG_RESULT_VARIANT_ATTR = `${FEATURE_FLAG_SCOPE}.result.variant`
-export const FEATURE_FLAG_PROVIDER_NAME_ATTR = `${FEATURE_FLAG_SCOPE}.provider_name`
-export const FEATURE_FLAG_IN_EXPERIMENT_ATTR = `${FEATURE_FLAG_SCOPE}.result.reason.inExperiment`
-export const FEATURE_FLAG_VARIATION_INDEX_ATTR = `${FEATURE_FLAG_SCOPE}.result.variationIndex`
+export const FEATURE_FLAG_IN_EXPERIMENT_ATTR = `${FEATURE_FLAG_SCOPE}.result.reason.in_experiment`
+export const FEATURE_FLAG_VARIATION_INDEX_ATTR = `${FEATURE_FLAG_SCOPE}.result.variation_index`
 export const FEATURE_FLAG_APP_ID_ATTR = `${LD_SCOPE}.application.id`
 export const FEATURE_FLAG_APP_VERSION_ATTR = `${LD_SCOPE}.application.version`
-export const FEATURE_FLAG_SPAN_NAME = 'evaluation'
 
 export const LD_INITIALIZE_EVENT = '$ld:telemetry:session:init'
 export const LD_ERROR_EVENT = '$ld:telemetry:error'
@@ -112,12 +111,9 @@ export function setupLaunchDarklyIntegration(
 		},
 		afterEvaluation: (hookContext, data, detail) => {
 			const eventAttributes: Attributes = {
+				[FEATURE_FLAG_PROVIDER_ATTR]: 'LaunchDarkly',
 				[FEATURE_FLAG_KEY_ATTR]: hookContext.flagKey,
-				[FEATURE_FLAG_PROVIDER_NAME_ATTR]: 'LaunchDarkly',
 				[FEATURE_FLAG_VARIANT_ATTR]: JSON.stringify(detail.value),
-				[FEATURE_FLAG_RESULT_VARIANT_ATTR]: JSON.stringify(
-					detail.value,
-				),
 				[FEATURE_FLAG_IN_EXPERIMENT_ATTR]: detail.reason?.inExperiment,
 				[FEATURE_FLAG_VARIATION_INDEX_ATTR]:
 					detail.variationIndex ?? undefined,
@@ -127,8 +123,9 @@ export function setupLaunchDarklyIntegration(
 				eventAttributes[FEATURE_FLAG_CONTEXT_ATTR] = JSON.stringify(
 					getCanonicalObj(hookContext.context),
 				)
-				eventAttributes[FEATURE_FLAG_CONTEXT_KEY_ATTR] =
-					getCanonicalKey(hookContext.context)
+				eventAttributes[FEATURE_FLAG_CONTEXT_ID_ATTR] = getCanonicalKey(
+					hookContext.context,
+				)
 			}
 
 			hClient.startSpan(FEATURE_FLAG_SPAN_NAME, eventAttributes, (s) => {

--- a/sdk/highlight-run/src/integrations/launchdarkly/index.ts
+++ b/sdk/highlight-run/src/integrations/launchdarkly/index.ts
@@ -26,7 +26,7 @@ export const FEATURE_FLAG_ENV_ATTR = `${FEATURE_FLAG_SCOPE}.set.id`
 export const FEATURE_FLAG_KEY_ATTR = `${FEATURE_FLAG_SCOPE}.key`
 export const FEATURE_FLAG_CONTEXT_ATTR = `${FEATURE_FLAG_SCOPE}.context`
 export const FEATURE_FLAG_CONTEXT_ID_ATTR = `${FEATURE_FLAG_CONTEXT_ATTR}.id`
-export const FEATURE_FLAG_VARIANT_ATTR = `${FEATURE_FLAG_SCOPE}.result.variant`
+export const FEATURE_FLAG_VALUE_ATTR = `${FEATURE_FLAG_SCOPE}.result.value`
 export const FEATURE_FLAG_PROVIDER_ATTR = `${FEATURE_FLAG_SCOPE}.provider.name`
 export const FEATURE_FLAG_IN_EXPERIMENT_ATTR = `${FEATURE_FLAG_SCOPE}.result.reason.in_experiment`
 export const FEATURE_FLAG_VARIATION_INDEX_ATTR = `${FEATURE_FLAG_SCOPE}.result.variation_index`
@@ -113,7 +113,7 @@ export function setupLaunchDarklyIntegration(
 			const eventAttributes: Attributes = {
 				[FEATURE_FLAG_PROVIDER_ATTR]: 'LaunchDarkly',
 				[FEATURE_FLAG_KEY_ATTR]: hookContext.flagKey,
-				[FEATURE_FLAG_VARIANT_ATTR]: JSON.stringify(detail.value),
+				[FEATURE_FLAG_VALUE_ATTR]: JSON.stringify(detail.value),
 				[FEATURE_FLAG_IN_EXPERIMENT_ATTR]: detail.reason?.inExperiment,
 				[FEATURE_FLAG_VARIATION_INDEX_ATTR]:
 					detail.variationIndex ?? undefined,

--- a/sdk/highlight-run/src/plugins/observe.ts
+++ b/sdk/highlight-run/src/plugins/observe.ts
@@ -10,7 +10,7 @@ import {
 	FEATURE_FLAG_PROVIDER_ATTR,
 	FEATURE_FLAG_SCOPE,
 	FEATURE_FLAG_SPAN_NAME,
-	FEATURE_FLAG_VARIANT_ATTR,
+	FEATURE_FLAG_VALUE_ATTR,
 	FEATURE_FLAG_VARIATION_INDEX_ATTR,
 	getCanonicalKey,
 	getCanonicalObj,
@@ -125,9 +125,7 @@ export class Observe extends Plugin<ObserveOptions> implements LDPlugin {
 
 					const eventAttributes: Attributes = {
 						[FEATURE_FLAG_KEY_ATTR]: hookContext.flagKey,
-						[FEATURE_FLAG_VARIANT_ATTR]: JSON.stringify(
-							detail.value,
-						),
+						[FEATURE_FLAG_VALUE_ATTR]: JSON.stringify(detail.value),
 						[FEATURE_FLAG_IN_EXPERIMENT_ATTR]:
 							detail.reason?.inExperiment,
 						[FEATURE_FLAG_VARIATION_INDEX_ATTR]:

--- a/sdk/highlight-run/src/plugins/observe.ts
+++ b/sdk/highlight-run/src/plugins/observe.ts
@@ -133,18 +133,12 @@ export class Observe extends Plugin<ObserveOptions> implements LDPlugin {
 						eventAttributes[FEATURE_FLAG_CONTEXT_ID_ATTR] =
 							getCanonicalKey(hookContext.context)
 					}
-
-					this.observe.startSpan(
-						FEATURE_FLAG_SPAN_NAME,
-						{
-							attributes: { ...metaAttrs, ...eventAttributes },
-						},
-						(s) => {
-							if (s) {
-								s.addEvent(FEATURE_FLAG_SCOPE, eventAttributes)
-							}
-						},
-					)
+					const attributes = { ...metaAttrs, ...eventAttributes }
+					this.observe.startSpan(FEATURE_FLAG_SPAN_NAME, (s) => {
+						if (s) {
+							s.addEvent(FEATURE_FLAG_SCOPE, attributes)
+						}
+					})
 
 					return data
 				},

--- a/sdk/highlight-run/src/plugins/observe.ts
+++ b/sdk/highlight-run/src/plugins/observe.ts
@@ -85,11 +85,11 @@ export class Observe extends Plugin<ObserveOptions> implements LDPlugin {
 			[FEATURE_FLAG_ENV_ATTR]: metadata.clientSideId,
 			[FEATURE_FLAG_PROVIDER_ATTR]: 'LaunchDarkly',
 			...(metadata.application?.id
-				? { FEATURE_FLAG_APP_ID_ATTR: metadata.application.id }
+				? { [FEATURE_FLAG_APP_ID_ATTR]: metadata.application.id }
 				: {}),
 			...(metadata.application?.version
 				? {
-						FEATURE_FLAG_APP_VERSION_ATTR:
+						[FEATURE_FLAG_APP_VERSION_ATTR]:
 							metadata.application.version,
 					}
 				: {}),

--- a/sdk/highlight-run/src/plugins/observe.ts
+++ b/sdk/highlight-run/src/plugins/observe.ts
@@ -3,7 +3,7 @@ import {
 	FEATURE_FLAG_APP_ID_ATTR,
 	FEATURE_FLAG_APP_VERSION_ATTR,
 	FEATURE_FLAG_CONTEXT_ATTR,
-	FEATURE_FLAG_CONTEXT_KEY_ATTR,
+	FEATURE_FLAG_CONTEXT_ID_ATTR,
 	FEATURE_FLAG_ENV_ATTR,
 	FEATURE_FLAG_IN_EXPERIMENT_ATTR,
 	FEATURE_FLAG_KEY_ATTR,
@@ -130,7 +130,7 @@ export class Observe extends Plugin<ObserveOptions> implements LDPlugin {
 					if (hookContext.context) {
 						eventAttributes[FEATURE_FLAG_CONTEXT_ATTR] =
 							JSON.stringify(getCanonicalObj(hookContext.context))
-						eventAttributes[FEATURE_FLAG_CONTEXT_KEY_ATTR] =
+						eventAttributes[FEATURE_FLAG_CONTEXT_ID_ATTR] =
 							getCanonicalKey(hookContext.context)
 					}
 

--- a/sdk/highlight-run/src/plugins/observe.ts
+++ b/sdk/highlight-run/src/plugins/observe.ts
@@ -1,22 +1,25 @@
 import type { LDPlugin, LDPluginEnvironmentMetadata } from './plugin'
-import type { Hook, LDClient } from '../integrations/launchdarkly'
-import { Observe as ObserveAPI } from '../api/observe'
-import { ObserveSDK } from '../sdk/observe'
-import { LDObserve } from '../sdk/LDObserve'
 import {
 	FEATURE_FLAG_APP_ID_ATTR,
 	FEATURE_FLAG_APP_VERSION_ATTR,
 	FEATURE_FLAG_CONTEXT_ATTR,
 	FEATURE_FLAG_CONTEXT_KEY_ATTR,
 	FEATURE_FLAG_ENV_ATTR,
+	FEATURE_FLAG_IN_EXPERIMENT_ATTR,
 	FEATURE_FLAG_KEY_ATTR,
 	FEATURE_FLAG_PROVIDER_ATTR,
 	FEATURE_FLAG_SCOPE,
 	FEATURE_FLAG_SPAN_NAME,
 	FEATURE_FLAG_VARIANT_ATTR,
+	FEATURE_FLAG_VARIATION_INDEX_ATTR,
 	getCanonicalKey,
 	getCanonicalObj,
+	Hook,
+	LDClient,
 } from '../integrations/launchdarkly'
+import { Observe as ObserveAPI } from '../api/observe'
+import { ObserveSDK } from '../sdk/observe'
+import { LDObserve } from '../sdk/LDObserve'
 import type { ObserveOptions } from '../client/types/observe'
 import { Plugin } from './common'
 import {
@@ -118,6 +121,10 @@ export class Observe extends Plugin<ObserveOptions> implements LDPlugin {
 						[FEATURE_FLAG_VARIANT_ATTR]: JSON.stringify(
 							detail.value,
 						),
+						[FEATURE_FLAG_IN_EXPERIMENT_ATTR]:
+							detail.reason?.inExperiment,
+						[FEATURE_FLAG_VARIATION_INDEX_ATTR]:
+							detail.variationIndex ?? undefined,
 					}
 
 					if (hookContext.context) {
@@ -130,8 +137,7 @@ export class Observe extends Plugin<ObserveOptions> implements LDPlugin {
 					this.observe.startSpan(
 						FEATURE_FLAG_SPAN_NAME,
 						{
-							...metaAttrs,
-							attributes: eventAttributes,
+							attributes: { ...metaAttrs, ...eventAttributes },
 						},
 						(s) => {
 							if (s) {

--- a/sdk/highlight-run/src/plugins/observe.ts
+++ b/sdk/highlight-run/src/plugins/observe.ts
@@ -83,9 +83,16 @@ export class Observe extends Plugin<ObserveOptions> implements LDPlugin {
 			[ATTR_TELEMETRY_SDK_NAME]: metadata.sdk.name,
 			[ATTR_TELEMETRY_SDK_VERSION]: metadata.sdk.version,
 			[FEATURE_FLAG_ENV_ATTR]: metadata.clientSideId,
-			[FEATURE_FLAG_APP_ID_ATTR]: metadata.application?.id,
-			[FEATURE_FLAG_APP_VERSION_ATTR]: metadata.application?.version,
 			[FEATURE_FLAG_PROVIDER_ATTR]: 'LaunchDarkly',
+			...(metadata.application?.id
+				? { FEATURE_FLAG_APP_ID_ATTR: metadata.application.id }
+				: {}),
+			...(metadata.application?.version
+				? {
+						FEATURE_FLAG_APP_VERSION_ATTR:
+							metadata.application.version,
+					}
+				: {}),
 		}
 		return [
 			{

--- a/sdk/highlight-run/src/plugins/observe.ts
+++ b/sdk/highlight-run/src/plugins/observe.ts
@@ -126,10 +126,19 @@ export class Observe extends Plugin<ObserveOptions> implements LDPlugin {
 					const eventAttributes: Attributes = {
 						[FEATURE_FLAG_KEY_ATTR]: hookContext.flagKey,
 						[FEATURE_FLAG_VALUE_ATTR]: JSON.stringify(detail.value),
-						[FEATURE_FLAG_IN_EXPERIMENT_ATTR]:
-							detail.reason?.inExperiment,
-						[FEATURE_FLAG_VARIATION_INDEX_ATTR]:
-							detail.variationIndex ?? undefined,
+						// only set the following keys when values are truthy
+						...(detail.reason?.inExperiment
+							? {
+									[FEATURE_FLAG_IN_EXPERIMENT_ATTR]:
+										detail.reason.inExperiment,
+								}
+							: {}),
+						...(detail.variationIndex
+							? {
+									[FEATURE_FLAG_VARIATION_INDEX_ATTR]:
+										detail.variationIndex,
+								}
+							: {}),
 					}
 
 					if (hookContext.context) {


### PR DESCRIPTION
## Summary

Ensures the LD integration correctly reports additional `evaluation` span attributes.
See [tech spec](https://docs.google.com/document/d/1X8L0nl0wfEXAXbuq1Onju_cGcOIEHb_mw_6LEKVkhlY/edit?tab=t.0#heading=h.y41mcmkl1t79) for more details.

## How did you test this change?

Local app
![Screenshot 2025-05-15 at 16 25 59](https://github.com/user-attachments/assets/57bfece1-f3d8-44e6-a4e5-47361b815a5b)


## Are there any deployment considerations?

changeset

## Does this work require review from our design team?

no
<!-- ld-jira-link -->
---
Related Jira issue: [OB-139: Add feature_flag.set.id and inExperiment attributes to eval span events](https://launchdarkly.atlassian.net/browse/OB-139)
<!-- end-ld-jira-link -->