### PR TITLE
fix previous session not being resumed when tab is reloaded

### DIFF
--- a/.changeset/ripe-deer-sneeze.md
+++ b/.changeset/ripe-deer-sneeze.md
@@ -1,0 +1,6 @@
+---
+'@launchdarkly/observability': patch
+'@launchdarkly/session-replay': patch
+---
+
+fix previous session not being resumed when tab is reloaded

--- a/e2e/react-router/src/routes/root.tsx
+++ b/e2e/react-router/src/routes/root.tsx
@@ -24,6 +24,7 @@ const client = init(
 				},
 			}),
 			new SessionReplay('1', {
+				debug: { clientInteractions: true, domRecording: true },
 				privacySetting: 'none',
 				serviceName: 'ryan-test',
 				backendUrl: 'https://pub.observability.ld-stg.launchdarkly.com',

--- a/sdk/highlight-run/src/client/listeners/network-listener/utils/utils.ts
+++ b/sdk/highlight-run/src/client/listeners/network-listener/utils/utils.ts
@@ -1,5 +1,5 @@
 import { getActiveSpan } from '../../../otel'
-import { getNetworkSessionSecureID } from '../../../utils/sessionStorage/highlightSession'
+import { getPersistentSessionSecureID } from '../../../utils/sessionStorage/highlightSession'
 import { RequestResponsePair } from './models'
 import { sanitizeResource } from './network-sanitizer'
 import { isLDContextUrl } from '../../../../integrations/launchdarkly/urlFilters'
@@ -329,7 +329,7 @@ export const createNetworkRequestId = () => {
 
 	const context = getActiveSpan()
 	const traceId = context?.spanContext().traceId
-	return [getNetworkSessionSecureID(), traceId ?? requestId]
+	return [getPersistentSessionSecureID(), traceId ?? requestId]
 }
 
 export const getHighlightRequestHeader = (

--- a/sdk/highlight-run/src/client/utils/sessionStorage/highlightSession.ts
+++ b/sdk/highlight-run/src/client/utils/sessionStorage/highlightSession.ts
@@ -16,17 +16,19 @@ const getSessionDataKey = (sessionID: string): string => {
 	return `${SESSION_STORAGE_KEYS.SESSION_DATA}_${sessionID}`
 }
 
-let networkSessionSecureID: string = ''
-
-export const getNetworkSessionSecureID = (): string => {
-	return networkSessionSecureID
+class Session {
+	static persistentSessionSecureID: string = ''
 }
 
-export const setNetworkSessionSecureID = (secureID: string) => {
+export const getPersistentSessionSecureID = (): string => {
+	return Session.persistentSessionSecureID
+}
+
+export const setPersistentSessionSecureID = (secureID: string) => {
 	// for duplicate tab functionality, secureID is ''
 	// avoid clearing the local secureID used for network request instrumentation
 	if (secureID) {
-		networkSessionSecureID = secureID
+		Session.persistentSessionSecureID = secureID
 	}
 }
 
@@ -66,7 +68,7 @@ export const getPreviousSessionData = (
 export const setSessionData = function (sessionData?: SessionData) {
 	if (!sessionData?.sessionSecureID) return
 	const secureID = sessionData.sessionSecureID!
-	setNetworkSessionSecureID(secureID)
+	setPersistentSessionSecureID(secureID)
 	setItem(getSessionDataKey(secureID), JSON.stringify(sessionData))
 }
 

--- a/sdk/highlight-run/src/sdk/record.ts
+++ b/sdk/highlight-run/src/sdk/record.ts
@@ -439,9 +439,6 @@ export class RecordSDK implements Record {
 			} else {
 				this._recordingStartTime = this.sessionData?.sessionStartTime
 			}
-			// To handle the 'Duplicate Tab' function, remove id from storage until page unload
-			setSessionSecureID('')
-			setSessionData(this.sessionData)
 
 			let clientID = getItem(LocalStorageKeys['CLIENT_ID'])
 
@@ -521,6 +518,9 @@ export class RecordSDK implements Record {
 				}
 			}
 
+			// To handle the 'Duplicate Tab' function, remove id from storage until page unload
+			setSessionSecureID('')
+			setSessionData(this.sessionData)
 			this.logger.log(
 				`Loaded Highlight
 Remote: ${this._backendUrl}


### PR DESCRIPTION
## Summary

Running `@launchdarkly/observability` and `@launchdarkly/session-replay` plugins
concurrently would cause the session id to be cleared by one before the other plugin
would be able to read it. This PR fixes the behavior to make sure that the 
session is shared between the two plugins.

Loading the `@launchdarkly/session-replay` plugin and reloading the page before
the session would initialize would start a new session on the next reload as
the stored session ID would be deleted. This PR also corrects the behavior.

## How did you test this change?

https://www.loom.com/share/c9de3d20c0bf4cfb85910170306241a6?from_recorder=1&focus_title=1

## Are there any deployment considerations?

changeset 

## Does this work require review from our design team?

no
