### PR TITLE
improve console warn forwarding from highlight.run sdk

### DIFF
--- a/.changeset/fair-weeks-spend.md
+++ b/.changeset/fair-weeks-spend.md
@@ -1,0 +1,5 @@
+---
+'highlight.run': patch
+---
+
+improve opentelemetry exporter retry logic to delay retries

--- a/.changeset/huge-squids-yawn.md
+++ b/.changeset/huge-squids-yawn.md
@@ -1,0 +1,5 @@
+---
+'highlight.run': patch
+---
+
+improve internal reporting of warnings and errors to LDObserve

--- a/e2e/react-router/src/routes/root.tsx
+++ b/e2e/react-router/src/routes/root.tsx
@@ -49,7 +49,14 @@ export default function Root() {
 
 	useEffect(() => {
 		const int = setInterval(() => {
-			setSession(LDRecord.getSession()?.url)
+			const url = LDRecord.getSession()?.url
+			setSession(url)
+			console.log('session url', url)
+			LDObserve.recordLog('session url LDObserve', 'info', { url })
+			LDObserve.recordLog(
+				{ message: 'session url LDObserve', url },
+				'info',
+			)
 		}, 1000)
 		return () => {
 			clearInterval(int)

--- a/sdk/highlight-run/src/client/otel/exporter.ts
+++ b/sdk/highlight-run/src/client/otel/exporter.ts
@@ -1,6 +1,10 @@
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http'
 import { OTLPMetricExporter } from '@opentelemetry/exporter-metrics-otlp-http'
-import { MAX_PUBLIC_GRAPH_RETRY_ATTEMPTS } from '../utils/graph'
+import {
+	BACKOFF_DELAY_MS,
+	BASE_DELAY_MS,
+	MAX_PUBLIC_GRAPH_RETRY_ATTEMPTS,
+} from '../utils/graph'
 import { ExportResult, ExportResultCode } from '@opentelemetry/core'
 import { ReadableSpan } from '@opentelemetry/sdk-trace-base'
 import { ExportSampler } from './sampling/ExportSampler'
@@ -54,7 +58,14 @@ export class OTLPTraceExporterBrowserWithXhrRetry extends OTLPTraceExporter {
 					error: result.error,
 				})
 			} else {
-				super.export(items, resultCallback)
+				new Promise((resolve) =>
+					setTimeout(
+						resolve,
+						BASE_DELAY_MS + BACKOFF_DELAY_MS * Math.pow(2, retries),
+					),
+				).then(() => {
+					super.export(items, resultCallback)
+				})
 			}
 		}
 
@@ -84,7 +95,14 @@ export class OTLPMetricExporterBrowser extends OTLPMetricExporter {
 					error: result.error,
 				})
 			} else {
-				super.export(items, resultCallback)
+				new Promise((resolve) =>
+					setTimeout(
+						resolve,
+						BASE_DELAY_MS + BACKOFF_DELAY_MS * Math.pow(2, retries),
+					),
+				).then(() => {
+					super.export(items, resultCallback)
+				})
 			}
 		}
 

--- a/sdk/highlight-run/src/sdk/observe.ts
+++ b/sdk/highlight-run/src/sdk/observe.ts
@@ -107,7 +107,8 @@ export class ObserveSDK implements Observe {
 
 	recordLog(message: any, level: ConsoleMethods, metadata?: Attributes) {
 		this.startSpan(LOG_SPAN_NAME, (span) => {
-			const msg = stringify(message)
+			const msg =
+				typeof message === 'string' ? message : stringify(message)
 			span?.setAttributes({
 				'highlight.session_id': this.sessionSecureID,
 			})

--- a/sdk/highlight-run/src/sdk/observe.ts
+++ b/sdk/highlight-run/src/sdk/observe.ts
@@ -55,6 +55,7 @@ import { CustomSampler } from '../client/otel/sampling/CustomSampler'
 import { getSdk, Sdk } from '../client/graph/generated/operations'
 import { GraphQLClient } from 'graphql-request'
 import { getGraphQLRequestWrapper } from '../client/utils/graph'
+import { recordWarning } from './util'
 
 export class ObserveSDK implements Observe {
 	private readonly sessionSecureID: string
@@ -97,7 +98,8 @@ export class ObserveSDK implements Observe {
 			})
 			this.sampler.setConfig(res.sampling)
 		} catch (e) {
-			console.warn(
+			recordWarning(
+				'sampling',
 				`LaunchDarkly Observability: Failed to configure sampling: ${e}`,
 			)
 		}
@@ -105,19 +107,20 @@ export class ObserveSDK implements Observe {
 
 	recordLog(message: any, level: ConsoleMethods, metadata?: Attributes) {
 		this.startSpan(LOG_SPAN_NAME, (span) => {
+			const msg = stringify(message)
 			span?.setAttributes({
 				'highlight.session_id': this.sessionSecureID,
 			})
 			span?.addEvent('log', {
 				'log.severity': level,
-				'log.message': message,
+				'log.message': msg,
 				...metadata,
 			})
 			if (level === 'error') {
-				span?.recordException(new Error(message))
+				span?.recordException(new Error(msg))
 				span?.setStatus({
 					code: SpanStatusCode.ERROR,
-					message: message,
+					message: msg,
 				})
 			}
 		})

--- a/sdk/highlight-run/src/sdk/record.ts
+++ b/sdk/highlight-run/src/sdk/record.ts
@@ -89,7 +89,7 @@ import { MessageType, PropertyType } from '../client/workers/types'
 import { Attributes } from '@opentelemetry/api'
 import { IntegrationClient } from '../integrations'
 import { Record } from '../api/record'
-import { HighlightWarning } from './util'
+import { recordWarning } from './util'
 import type { HighlightClassOptions } from '../client'
 import { Highlight } from '../client'
 import type { Hook, LDClient } from '../integrations/launchdarkly'
@@ -189,7 +189,8 @@ export class RecordSDK implements Record {
 					e.data.response.payload,
 				)
 			} else if (e.data.response?.type === MessageType.Stop) {
-				HighlightWarning(
+				recordWarning(
+					'worker.onmessage',
 					'Stopping recording due to worker failure',
 					e.data.response,
 				)
@@ -642,7 +643,7 @@ SessionSecureID: ${this.sessionData.sessionSecureID}`,
 						this.options.debug.domRecording)
 						? {
 								debug: this.logger.log,
-								warn: HighlightWarning,
+								warn: recordWarning,
 							}
 						: undefined,
 			})
@@ -682,7 +683,7 @@ SessionSecureID: ${this.sessionData.sessionSecureID}`,
 		} catch (e) {
 			if (this._isOnLocalHost) {
 				console.error(e)
-				HighlightWarning('initializeSession', e)
+				recordWarning('initializeSession', e)
 			}
 		}
 	}
@@ -938,7 +939,7 @@ SessionSecureID: ${this.sessionData.sessionSecureID}`,
 		} catch (e) {
 			if (this._isOnLocalHost) {
 				console.error(e)
-				HighlightWarning('initializeSession _setupWindowListeners', e)
+				recordWarning('initializeSession _setupWindowListeners', e)
 			}
 		}
 
@@ -1129,7 +1130,7 @@ SessionSecureID: ${this.sessionData.sessionSecureID}`,
 		} catch (e) {
 			if (this._isOnLocalHost) {
 				console.error(e)
-				HighlightWarning('_save', e)
+				recordWarning('_save', e)
 			}
 		}
 		if (this.state === 'Recording') {

--- a/sdk/highlight-run/src/sdk/util.ts
+++ b/sdk/highlight-run/src/sdk/util.ts
@@ -1,3 +1,6 @@
-export const HighlightWarning = (context: string, msg: any) => {
-	console.warn(`highlight.run warning: (${context}): `, msg)
+import { LDObserve } from './LDObserve'
+
+export const recordWarning = (context: string, ...msg: any) => {
+	console.warn(`[@launchdarkly plugins] warning: (${context}): `, msg)
+	LDObserve.recordLog(`${msg}`, 'warn')
 }

--- a/sdk/highlight-run/src/sdk/util.ts
+++ b/sdk/highlight-run/src/sdk/util.ts
@@ -1,6 +1,7 @@
 import { LDObserve } from './LDObserve'
 
 export const recordWarning = (context: string, ...msg: any) => {
-	console.warn(`[@launchdarkly plugins] warning: (${context}): `, msg)
-	LDObserve.recordLog(`${msg}`, 'warn')
+	const prefix = `[@launchdarkly plugins] warning: (${context}): `
+	console.warn(prefix, msg)
+	LDObserve.recordLog(`${prefix}${msg}`, 'warn')
 }


### PR DESCRIPTION
## Summary

* Improve internal logging from the SDK to report warnings to the highlight project of the customer to help troubleshoot recording kill switch triggering
* Add exponential retry backoff to the OTel exporter.

## How did you test this change?

local deploy
<img width="1796" alt="Screenshot 2025-05-16 at 09 51 38" src="https://github.com/user-attachments/assets/c1b95e5e-a610-4703-bbfc-152f4279e166" />

testing retries with network throttling
<img width="654" alt="Screenshot 2025-05-16 at 09 52 14" src="https://github.com/user-attachments/assets/3a1ae0bf-a123-46fb-b2cb-ce9192f176f6" />

## Are there any deployment considerations?

changesets

## Does this work require review from our design team?

no
