### PR TITLE
fix JS GHA not auto-publishing LD packages

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -46,6 +46,17 @@ jobs:
                   NEXT_PUBLIC_HIGHLIGHT_PROJECT_ID: 1jdkoe52
                   REACT_APP_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
 
+            - name: Release changesets
+              if: github.ref == 'refs/heads/main'
+              id: changesets-version
+              uses: changesets/action@v1
+              with:
+                  version: yarn changeset version
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  NPM_TOKEN: ${{ secrets.NPM_TOKEN_HIGHLIGHT_RUN }}
+                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_HIGHLIGHT_RUN }}
+
             - name: Configure yarn npm registry credentials
               if: github.ref == 'refs/heads/main'
               run: |
@@ -65,13 +76,24 @@ jobs:
                   NPM_TOKEN: ${{ secrets.NPM_TOKEN_HIGHLIGHT_RUN }}
                   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_HIGHLIGHT_RUN }}
 
-            - name: Release changesets
+            - uses: launchdarkly/gh-actions/actions/release-secrets@release-secrets-v1.2.0
               if: github.ref == 'refs/heads/main'
-              id: changesets-version
-              uses: changesets/action@v1
+              name: 'Get NPM token'
               with:
-                  version: yarn changeset version
+                  aws_assume_role: ${{ vars.AWS_ROLE_ARN }}
+                  ssm_parameter_pairs: '/production/common/releasing/npm/token = NODE_AUTH_TOKEN'
+
+            - name: Configure yarn npm registry credentials for launchdarkly
+              if: github.ref == 'refs/heads/main'
+              run: |
+                  yarn config set npmRegistryServer "https://registry.npmjs.org"
+                  yarn config set npmAuthToken "${NODE_AUTH_TOKEN}"
+
+            - name: Publish
+              if: github.ref == 'refs/heads/main'
+              shell: bash
+              run: |
+                  ./scripts/publish-npm.sh
               env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  NPM_TOKEN: ${{ secrets.NPM_TOKEN_HIGHLIGHT_RUN }}
-                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_HIGHLIGHT_RUN }}
+                  LD_RELEASE_IS_PRERELEASE: ${{ inputs.prerelease }}
+                  LD_RELEASE_IS_DRYRUN: ${{ inputs.dry-run }}


### PR DESCRIPTION
## Summary

`turbo.yml` GHA currently only auto-publishes the highlight SDKs, not the launchdarkly ones.
This is a problem since they are interdependent and should be published together if there are new versions released.

`yarn changeset version` is unrelated to npm publishing (creates PR that will bump versions if changesets are detected)
but should happen first / separately for clarity.

## How did you test this change?

CI

## Are there any deployment considerations?

no

## Does this work require review from our design team?

no
