### PR TITLE
fix manual publish step not publishing highlight.run

### DIFF
--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -61,13 +61,7 @@ jobs:
             - name: Publish highlight npm packages
               if: ${{ inputs.release_highlight == true }}
               id: changesets-publish
-              uses: changesets/action@v1
-              with:
-                  publish: yarn publish:highlight
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  NPM_TOKEN: ${{ secrets.NPM_TOKEN_HIGHLIGHT_RUN }}
-                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_HIGHLIGHT_RUN }}
+              run: yarn publish:highlight
 
             - uses: launchdarkly/gh-actions/actions/release-secrets@release-secrets-v1.2.0
               if: ${{ inputs.release_launchdarkly == true }}
@@ -85,8 +79,7 @@ jobs:
             - name: Publish
               if: ${{ inputs.release_launchdarkly == true }}
               shell: bash
-              run: |
-                  ./scripts/publish-npm.sh
+              run: ./scripts/publish-npm.sh
               env:
                   LD_RELEASE_IS_PRERELEASE: ${{ inputs.prerelease }}
                   LD_RELEASE_IS_DRYRUN: ${{ inputs.dry-run }}

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -85,8 +85,7 @@ jobs:
             - name: Publish
               if: github.ref == 'refs/heads/main'
               shell: bash
-              run: |
-                  ./scripts/publish-npm.sh
+              run: ./scripts/publish-npm.sh
               env:
                   LD_RELEASE_IS_PRERELEASE: ${{ inputs.prerelease }}
                   LD_RELEASE_IS_DRYRUN: ${{ inputs.dry-run }}


### PR DESCRIPTION
## Summary

With no changesets present, manual publish would do nothing for the highlight SDKs.

<img width="1193" alt="Screenshot 2025-05-16 at 19 01 48" src="https://github.com/user-attachments/assets/f303c0d2-c7fc-4b15-94f4-b51aebe2c5d0" />

## How did you test this change?

Corrected behavior tested by [kicking off](https://github.com/launchdarkly/observability-sdk/actions/runs/15079659237) manual publish.

## Are there any deployment considerations?

no

## Does this work require review from our design team?

no
