### PR TITLE
wrap plugin initialization with try / catch to limit impact of internal errors

### DIFF
--- a/.changeset/hot-days-raise.md
+++ b/.changeset/hot-days-raise.md
@@ -1,0 +1,7 @@
+---
+'highlight.run': patch
+'@launchdarkly/observability': patch
+'@launchdarkly/session-replay': patch
+---
+
+wrap plugin initialization with try / catch to limit impact of internal errors

--- a/sdk/highlight-run/src/__tests__/sdk.test.ts
+++ b/sdk/highlight-run/src/__tests__/sdk.test.ts
@@ -62,6 +62,21 @@ describe('SDK', () => {
 
 			expect(mockSnapshot).toHaveBeenCalledWith(canvas)
 		})
+
+		it('should construct despite error', async () => {
+			vi.stubGlobal('localStorage', {
+				getItem: vi.fn(() => {
+					throw new Error('get error')
+				}),
+				setItem: vi.fn(() => {
+					throw new Error('get error')
+				}),
+			})
+			const { Record } = await import('../plugins/record')
+			const sdk = new Record('1')
+			expect(sdk.record).toBeUndefined()
+			vi.unstubAllGlobals()
+		})
 	})
 
 	describe('Observe Methods', () => {

--- a/sdk/highlight-run/src/__tests__/sdk.test.ts
+++ b/sdk/highlight-run/src/__tests__/sdk.test.ts
@@ -1,10 +1,12 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { LDObserve } from '../sdk/LDObserve'
 import { LDRecord } from '../sdk/LDRecord'
 import type { OTelMetric as Metric } from '../client/types/types'
 import type { Attributes } from '@opentelemetry/api'
 import { ObserveSDK } from '../sdk/observe'
 import { RecordSDK } from '../sdk/record'
+import { globalStorage } from '../client/utils/storage'
+import { Record } from '../plugins/record'
 
 describe('SDK', () => {
 	let observe: typeof LDObserve
@@ -63,16 +65,32 @@ describe('SDK', () => {
 			expect(mockSnapshot).toHaveBeenCalledWith(canvas)
 		})
 
-		it('should construct despite error', async () => {
+		it('should construct despite error with storage fallback', async () => {
 			vi.stubGlobal('localStorage', {
 				getItem: vi.fn(() => {
 					throw new Error('get error')
 				}),
 				setItem: vi.fn(() => {
-					throw new Error('get error')
+					throw new Error('set error')
 				}),
 			})
-			const { Record } = await import('../plugins/record')
+			const sdk = new Record('1')
+			expect(sdk.record).toBeDefined()
+			vi.unstubAllGlobals()
+		})
+
+		it('should construct despite error', async () => {
+			vi.spyOn(globalStorage, 'getItem').mockImplementation(() => {
+				throw new Error('get error')
+			})
+			vi.stubGlobal('localStorage', {
+				getItem: vi.fn(() => {
+					throw new Error('get error')
+				}),
+				setItem: vi.fn(() => {
+					throw new Error('set error')
+				}),
+			})
 			const sdk = new Record('1')
 			expect(sdk.record).toBeUndefined()
 			vi.unstubAllGlobals()

--- a/sdk/highlight-run/src/client/utils/storage.ts
+++ b/sdk/highlight-run/src/client/utils/storage.ts
@@ -1,5 +1,6 @@
 import Cookies from 'js-cookie'
 import { SESSION_PUSH_THRESHOLD } from '../constants/sessions'
+import { internalLog } from '../../sdk/util'
 
 export enum LocalStorageKeys {
 	CLIENT_ID = 'highlightClientID',
@@ -45,7 +46,7 @@ export class CookieStorage {
 	}
 }
 
-let globalStorage = new Storage()
+export const globalStorage = new Storage()
 export const cookieStorage = new CookieStorage()
 
 const getPersistentStorage = () => {
@@ -70,17 +71,47 @@ export const setCookieWriteEnabled = (enabled: boolean) => {
 }
 
 export const getItem = (key: string) => {
-	return getPersistentStorage().getItem(key)
+	try {
+		return getPersistentStorage().getItem(key)
+	} catch (e) {
+		internalLog(
+			`storage`,
+			'debug',
+			`failed to get item ${key}; using global storage`,
+			e,
+		)
+		return globalStorage.getItem(key)
+	}
 }
 
 export const setItem = (key: string, value: string) => {
 	cookieStorage.setItem(key, value)
-	return getPersistentStorage().setItem(key, value)
+	try {
+		return getPersistentStorage().setItem(key, value)
+	} catch (e) {
+		internalLog(
+			`storage`,
+			'debug',
+			`failed to set item ${key}; using global storage`,
+			e,
+		)
+		return globalStorage.setItem(key, value)
+	}
 }
 
 export const removeItem = (key: string) => {
 	cookieStorage.removeItem(key)
-	return getPersistentStorage().removeItem(key)
+	try {
+		return getPersistentStorage().removeItem(key)
+	} catch (e) {
+		internalLog(
+			`storage`,
+			'debug',
+			`failed to remove item ${key}; using global storage`,
+			e,
+		)
+		return globalStorage.removeItem(key)
+	}
 }
 
 export const monkeyPatchLocalStorage = (

--- a/sdk/highlight-run/src/plugins/common.ts
+++ b/sdk/highlight-run/src/plugins/common.ts
@@ -9,38 +9,44 @@ import {
 	setSessionSecureID,
 } from '../client/utils/sessionStorage/highlightSession'
 import { GenerateSecureID } from '../client'
+import { recordWarning } from '../sdk/util'
 
 export class Plugin<T extends RecordOptions | ObserveOptions> {
 	protected sessionSecureID!: string
 	constructor(options?: T) {
-		if (options?.storageMode) {
-			setStorageMode(options?.storageMode)
-		}
-		setCookieWriteEnabled(!!options?.sessionCookie)
+		try {
+			if (options?.storageMode) {
+				setStorageMode(options?.storageMode)
+			}
+			setCookieWriteEnabled(!!options?.sessionCookie)
 
-		if (options?.sessionCookie) {
-			loadCookieSessionData()
-		} else {
-			setCookieWriteEnabled(false)
-		}
+			if (options?.sessionCookie) {
+				loadCookieSessionData()
+			} else {
+				setCookieWriteEnabled(false)
+			}
 
-		const persistentSessionSecureID = getPersistentSessionSecureID()
-		let previousSession = getPreviousSessionData(persistentSessionSecureID)
-		if (previousSession?.sessionSecureID) {
-			this.sessionSecureID = previousSession.sessionSecureID
-		} else {
-			this.sessionSecureID = GenerateSecureID()
-			setSessionSecureID(this.sessionSecureID)
-			setSessionData({
-				sessionSecureID: this.sessionSecureID,
-				projectID: 0,
-				payloadID: 1,
-				sessionStartTime: Date.now(),
-			})
+			const persistentSessionSecureID = getPersistentSessionSecureID()
+			let previousSession = getPreviousSessionData(
+				persistentSessionSecureID,
+			)
+			if (previousSession?.sessionSecureID) {
+				this.sessionSecureID = previousSession.sessionSecureID
+			} else {
+				this.sessionSecureID = GenerateSecureID()
+				setSessionSecureID(this.sessionSecureID)
+				setSessionData({
+					sessionSecureID: this.sessionSecureID,
+					projectID: 0,
+					payloadID: 1,
+					sessionStartTime: Date.now(),
+				})
+			}
+		} catch (error) {
+			recordWarning(
+				`Error initializing @launchdarkly observability plugin`,
+				error,
+			)
 		}
-		console.log('Plugin initializing', this, {
-			sessionSecureID: this.sessionSecureID,
-			previousSession,
-		})
 	}
 }

--- a/sdk/highlight-run/src/plugins/common.ts
+++ b/sdk/highlight-run/src/plugins/common.ts
@@ -9,7 +9,7 @@ import {
 	setSessionSecureID,
 } from '../client/utils/sessionStorage/highlightSession'
 import { GenerateSecureID } from '../client'
-import { recordWarning } from '../sdk/util'
+import { internalLog } from '../sdk/util'
 
 export class Plugin<T extends RecordOptions | ObserveOptions> {
 	protected sessionSecureID!: string
@@ -43,8 +43,9 @@ export class Plugin<T extends RecordOptions | ObserveOptions> {
 				})
 			}
 		} catch (error) {
-			recordWarning(
+			internalLog(
 				`Error initializing @launchdarkly observability plugin`,
+				'error',
 				error,
 			)
 		}

--- a/sdk/highlight-run/src/plugins/observe.ts
+++ b/sdk/highlight-run/src/plugins/observe.ts
@@ -41,14 +41,14 @@ export class Observe extends Plugin<ObserveOptions> implements LDPlugin {
 				typeof document === 'undefined'
 			) {
 				console.warn(
-					'Session Replay is not initializing because it is not supported in this environment.',
+					'@launchdarkly/observability is not initializing because it is not supported in this environment.',
 				)
 				return
 			}
 			// Don't initialize if an projectID is not set.
 			if (!projectID) {
-				console.info(
-					'Highlight is not initializing because projectID was passed undefined.',
+				console.warn(
+					'@launchdarkly/observability is not initializing because projectID was passed undefined.',
 				)
 				return
 			}
@@ -68,7 +68,7 @@ export class Observe extends Plugin<ObserveOptions> implements LDPlugin {
 						? options.networkRecording
 						: undefined,
 				tracingOrigins: options?.tracingOrigins,
-				serviceName: options?.serviceName ?? 'highlight-browser',
+				serviceName: options?.serviceName ?? 'browser',
 				instrumentations: options?.otel?.instrumentations,
 			}
 			this.observe = new ObserveSDK(clientOptions)

--- a/sdk/highlight-run/src/plugins/observe.ts
+++ b/sdk/highlight-run/src/plugins/observe.ts
@@ -28,7 +28,7 @@ import {
 	ATTR_TELEMETRY_SDK_VERSION,
 } from '@opentelemetry/semantic-conventions'
 import { Attributes } from '@opentelemetry/api'
-import { recordWarning } from '../sdk/util'
+import { internalLog } from '../sdk/util'
 
 export class Observe extends Plugin<ObserveOptions> implements LDPlugin {
 	observe: ObserveAPI | undefined
@@ -74,8 +74,9 @@ export class Observe extends Plugin<ObserveOptions> implements LDPlugin {
 			this.observe = new ObserveSDK(clientOptions)
 			LDObserve.load(this.observe)
 		} catch (error) {
-			recordWarning(
+			internalLog(
 				`Error initializing @launchdarkly/observability SDK`,
+				'error',
 				error,
 			)
 		}

--- a/sdk/highlight-run/src/plugins/observe.ts
+++ b/sdk/highlight-run/src/plugins/observe.ts
@@ -34,40 +34,43 @@ export class Observe extends Plugin<ObserveOptions> implements LDPlugin {
 	observe: ObserveAPI | undefined
 
 	constructor(projectID?: string | number, options?: ObserveOptions) {
-		// Don't run init when called outside of the browser.
-		if (typeof window === 'undefined' || typeof document === 'undefined') {
-			console.warn(
-				'Session Replay is not initializing because it is not supported in this environment.',
-			)
-			return
-		}
-		// Don't initialize if an projectID is not set.
-		if (!projectID) {
-			console.info(
-				'Highlight is not initializing because projectID was passed undefined.',
-			)
-			return
-		}
-		super(options)
-		const clientOptions: BrowserTracingConfig = {
-			backendUrl:
-				options?.backendUrl ??
-				'https://pub.observability.app.launchdarkly.com',
-			otlpEndpoint:
-				options?.otel?.otlpEndpoint ??
-				'https://otel.observability.app.launchdarkly.com',
-			projectId: projectID,
-			sessionSecureId: this.sessionSecureID,
-			environment: options?.environment ?? 'production',
-			networkRecordingOptions:
-				typeof options?.networkRecording === 'object'
-					? options.networkRecording
-					: undefined,
-			tracingOrigins: options?.tracingOrigins,
-			serviceName: options?.serviceName ?? 'highlight-browser',
-			instrumentations: options?.otel?.instrumentations,
-		}
 		try {
+			// Don't run init when called outside of the browser.
+			if (
+				typeof window === 'undefined' ||
+				typeof document === 'undefined'
+			) {
+				console.warn(
+					'Session Replay is not initializing because it is not supported in this environment.',
+				)
+				return
+			}
+			// Don't initialize if an projectID is not set.
+			if (!projectID) {
+				console.info(
+					'Highlight is not initializing because projectID was passed undefined.',
+				)
+				return
+			}
+			super(options)
+			const clientOptions: BrowserTracingConfig = {
+				backendUrl:
+					options?.backendUrl ??
+					'https://pub.observability.app.launchdarkly.com',
+				otlpEndpoint:
+					options?.otel?.otlpEndpoint ??
+					'https://otel.observability.app.launchdarkly.com',
+				projectId: projectID,
+				sessionSecureId: this.sessionSecureID,
+				environment: options?.environment ?? 'production',
+				networkRecordingOptions:
+					typeof options?.networkRecording === 'object'
+						? options.networkRecording
+						: undefined,
+				tracingOrigins: options?.tracingOrigins,
+				serviceName: options?.serviceName ?? 'highlight-browser',
+				instrumentations: options?.otel?.instrumentations,
+			}
 			this.observe = new ObserveSDK(clientOptions)
 			LDObserve.load(this.observe)
 		} catch (error) {

--- a/sdk/highlight-run/src/plugins/record.ts
+++ b/sdk/highlight-run/src/plugins/record.ts
@@ -9,7 +9,7 @@ import { LDRecord } from '../sdk/LDRecord'
 import type { RecordOptions } from '../client/types/record'
 import { Plugin } from './common'
 import { getCanonicalKey } from '../integrations/launchdarkly'
-import { recordWarning } from '../sdk/util'
+import { internalLog } from '../sdk/util'
 
 export class Record extends Plugin<RecordOptions> implements LDPlugin {
 	record: RecordSDK | undefined
@@ -69,8 +69,9 @@ export class Record extends Plugin<RecordOptions> implements LDPlugin {
 				setupAmplitudeIntegration(options.integrations.amplitude)
 			}
 		} catch (error) {
-			recordWarning(
+			internalLog(
 				`Error initializing @launchdarkly/session-replay SDK`,
+				'error',
 				error,
 			)
 		}

--- a/sdk/highlight-run/src/plugins/record.ts
+++ b/sdk/highlight-run/src/plugins/record.ts
@@ -1,6 +1,6 @@
 import { type HighlightClassOptions } from '../client'
 import type { LDPlugin, LDPluginEnvironmentMetadata } from './plugin'
-import type { Hook, LDClient } from '../integrations/launchdarkly'
+import { getCanonicalKey, Hook, LDClient } from '../integrations/launchdarkly'
 import { RecordSDK } from '../sdk/record'
 import firstloadVersion from '../__generated/version'
 import { setupMixpanelIntegration } from '../integrations/mixpanel'
@@ -8,7 +8,6 @@ import { setupAmplitudeIntegration } from '../integrations/amplitude'
 import { LDRecord } from '../sdk/LDRecord'
 import type { RecordOptions } from '../client/types/record'
 import { Plugin } from './common'
-import { getCanonicalKey } from '../integrations/launchdarkly'
 import { internalLog } from '../sdk/util'
 
 export class Record extends Plugin<RecordOptions> implements LDPlugin {
@@ -22,20 +21,20 @@ export class Record extends Plugin<RecordOptions> implements LDPlugin {
 				typeof document === 'undefined'
 			) {
 				console.warn(
-					'Session Replay is not initializing because it is not supported in this environment.',
+					'@launchdarkly/session-replay is not initializing because it is not supported in this environment.',
 				)
 				return
 			}
 			if (typeof Worker === 'undefined') {
 				console.warn(
-					'Session Replay is not initializing because Worker is not supported.',
+					'@launchdarkly/session-replay is not initializing because Worker is not supported.',
 				)
 				return
 			}
 			// Don't initialize if an projectID is not set.
 			if (!projectID) {
 				console.warn(
-					'Session Replay is not initializing because projectID was passed undefined.',
+					'@launchdarkly/session-replay is not initializing because projectID was passed undefined.',
 				)
 				return
 			}

--- a/sdk/highlight-run/src/plugins/record.ts
+++ b/sdk/highlight-run/src/plugins/record.ts
@@ -15,61 +15,64 @@ export class Record extends Plugin<RecordOptions> implements LDPlugin {
 	record: RecordSDK | undefined
 
 	constructor(projectID?: string | number, options?: RecordOptions) {
-		// Don't run init when called outside of the browser.
-		if (typeof window === 'undefined' || typeof document === 'undefined') {
-			console.warn(
-				'Session Replay is not initializing because it is not supported in this environment.',
-			)
-			return
-		}
-		if (typeof Worker === 'undefined') {
-			console.warn(
-				'Session Replay is not initializing because Worker is not supported.',
-			)
-			return
-		}
-		// Don't initialize if an projectID is not set.
-		if (!projectID) {
-			console.warn(
-				'Session Replay is not initializing because projectID was passed undefined.',
-			)
-			return
-		}
-		super(options)
-		const client_options: HighlightClassOptions = {
-			...options,
-			organizationID: projectID,
-			firstloadVersion,
-			environment: options?.environment || 'production',
-			appVersion: options?.version,
-			sessionSecureID: this.sessionSecureID,
-		}
-
 		try {
+			// Don't run init when called outside of the browser.
+			if (
+				typeof window === 'undefined' ||
+				typeof document === 'undefined'
+			) {
+				console.warn(
+					'Session Replay is not initializing because it is not supported in this environment.',
+				)
+				return
+			}
+			if (typeof Worker === 'undefined') {
+				console.warn(
+					'Session Replay is not initializing because Worker is not supported.',
+				)
+				return
+			}
+			// Don't initialize if an projectID is not set.
+			if (!projectID) {
+				console.warn(
+					'Session Replay is not initializing because projectID was passed undefined.',
+				)
+				return
+			}
+			super(options)
+			const client_options: HighlightClassOptions = {
+				...options,
+				organizationID: projectID,
+				firstloadVersion,
+				environment: options?.environment || 'production',
+				appVersion: options?.version,
+				sessionSecureID: this.sessionSecureID,
+			}
+
 			this.record = new RecordSDK(client_options)
 			if (!options?.manualStart) {
 				void this.record.start()
 			}
 			LDRecord.load(this.record)
+
+			if (
+				!options?.integrations?.mixpanel?.disabled &&
+				options?.integrations?.mixpanel?.projectToken
+			) {
+				setupMixpanelIntegration(options.integrations.mixpanel)
+			}
+
+			if (
+				!options?.integrations?.amplitude?.disabled &&
+				options?.integrations?.amplitude?.apiKey
+			) {
+				setupAmplitudeIntegration(options.integrations.amplitude)
+			}
 		} catch (error) {
 			recordWarning(
 				`Error initializing @launchdarkly/session-replay SDK`,
 				error,
 			)
-		}
-
-		if (
-			!options?.integrations?.mixpanel?.disabled &&
-			options?.integrations?.mixpanel?.projectToken
-		) {
-			setupMixpanelIntegration(options.integrations.mixpanel)
-		}
-
-		if (
-			!options?.integrations?.amplitude?.disabled &&
-			options?.integrations?.amplitude?.apiKey
-		) {
-			setupAmplitudeIntegration(options.integrations.amplitude)
 		}
 	}
 

--- a/sdk/highlight-run/src/plugins/record.ts
+++ b/sdk/highlight-run/src/plugins/record.ts
@@ -9,6 +9,7 @@ import { LDRecord } from '../sdk/LDRecord'
 import type { RecordOptions } from '../client/types/record'
 import { Plugin } from './common'
 import { getCanonicalKey } from '../integrations/launchdarkly'
+import { recordWarning } from '../sdk/util'
 
 export class Record extends Plugin<RecordOptions> implements LDPlugin {
 	record!: RecordSDK
@@ -44,7 +45,14 @@ export class Record extends Plugin<RecordOptions> implements LDPlugin {
 			sessionSecureID: this.sessionSecureID,
 		}
 
-		this.record = new RecordSDK(client_options)
+		try {
+			this.record = new RecordSDK(client_options)
+		} catch (error) {
+			recordWarning(
+				`Error initializing @launchdarkly/session-replay SDK`,
+				error,
+			)
+		}
 		if (!options?.manualStart) {
 			void this.record.start()
 		}

--- a/sdk/highlight-run/src/plugins/record.ts
+++ b/sdk/highlight-run/src/plugins/record.ts
@@ -1,6 +1,11 @@
 import { type HighlightClassOptions } from '../client'
 import type { LDPlugin, LDPluginEnvironmentMetadata } from './plugin'
-import { getCanonicalKey, Hook, LDClient } from '../integrations/launchdarkly'
+import {
+	getCanonicalKey,
+	getCanonicalObj,
+	Hook,
+	LDClient,
+} from '../integrations/launchdarkly'
 import { RecordSDK } from '../sdk/record'
 import firstloadVersion from '../__generated/version'
 import { setupMixpanelIntegration } from '../integrations/mixpanel'
@@ -102,10 +107,15 @@ export class Record extends Plugin<RecordOptions> implements LDPlugin {
 						[]) {
 						hook.afterIdentify?.(hookContext, data, _result)
 					}
+					const key = getCanonicalKey(hookContext.context)
+					const obj = getCanonicalObj(hookContext.context)
 					this.record?.identify(
-						getCanonicalKey(hookContext.context),
+						typeof obj === 'string'
+							? obj
+							: (obj['user']?.toString() ?? key),
 						{
-							key: getCanonicalKey(hookContext.context),
+							key,
+							...(typeof obj === 'object' ? obj : {}),
 							timeout: hookContext.timeout,
 						},
 						'LaunchDarkly',

--- a/sdk/highlight-run/src/sdk/buffer.ts
+++ b/sdk/highlight-run/src/sdk/buffer.ts
@@ -1,5 +1,5 @@
 import { Logger } from '../client/logger'
-import { recordWarning } from './util'
+import { internalLog } from './util'
 
 type Event = { method: string; args: any[] }
 
@@ -18,8 +18,9 @@ export class BufferedClass<T extends object> {
 			try {
 				return (this._sdk as any)[method](...args)
 			} catch (error) {
-				recordWarning(
+				internalLog(
 					`Error executing buffered call to ${method}:`,
+					'error',
 					error,
 				)
 			}
@@ -37,8 +38,9 @@ export class BufferedClass<T extends object> {
 		} else {
 			if (!this._exceededCapacity) {
 				this._exceededCapacity = true
-				recordWarning(
+				internalLog(
 					'Exceeded event queue capacity. Increase capacity to avoid dropping events.',
+					'warn',
 				)
 			}
 			this._droppedEvents += 1
@@ -54,8 +56,9 @@ export class BufferedClass<T extends object> {
 			try {
 				;(this._sdk as any)[method](...args)
 			} catch (error) {
-				recordWarning(
+				internalLog(
 					`Error executing buffered call to ${method}:`,
+					'error',
 					error,
 				)
 			}

--- a/sdk/highlight-run/src/sdk/buffer.ts
+++ b/sdk/highlight-run/src/sdk/buffer.ts
@@ -1,4 +1,5 @@
 import { Logger } from '../client/logger'
+import { recordWarning } from './util'
 
 type Event = { method: string; args: any[] }
 
@@ -14,7 +15,14 @@ export class BufferedClass<T extends object> {
 	protected _bufferCall(method: string, args: any[]) {
 		if (this._isLoaded) {
 			// If already loaded, execute the method directly
-			return (this._sdk as any)[method](...args)
+			try {
+				return (this._sdk as any)[method](...args)
+			} catch (error) {
+				recordWarning(
+					`Error executing buffered call to ${method}:`,
+					error,
+				)
+			}
 		} else {
 			// Otherwise buffer the call
 			this._enqueue({ method, args })
@@ -29,7 +37,7 @@ export class BufferedClass<T extends object> {
 		} else {
 			if (!this._exceededCapacity) {
 				this._exceededCapacity = true
-				this._logger.warn(
+				recordWarning(
 					'Exceeded event queue capacity. Increase capacity to avoid dropping events.',
 				)
 			}
@@ -46,7 +54,7 @@ export class BufferedClass<T extends object> {
 			try {
 				;(this._sdk as any)[method](...args)
 			} catch (error) {
-				console.error(
+				recordWarning(
 					`Error executing buffered call to ${method}:`,
 					error,
 				)

--- a/sdk/highlight-run/src/sdk/observe.ts
+++ b/sdk/highlight-run/src/sdk/observe.ts
@@ -55,7 +55,7 @@ import { CustomSampler } from '../client/otel/sampling/CustomSampler'
 import { getSdk, Sdk } from '../client/graph/generated/operations'
 import { GraphQLClient } from 'graphql-request'
 import { getGraphQLRequestWrapper } from '../client/utils/graph'
-import { recordWarning } from './util'
+import { internalLog } from './util'
 
 export class ObserveSDK implements Observe {
 	private readonly sessionSecureID: string
@@ -103,8 +103,9 @@ export class ObserveSDK implements Observe {
 			})
 			this.sampler.setConfig(res.sampling)
 		} catch (e) {
-			recordWarning(
+			internalLog(
 				'sampling',
+				'warn',
 				`LaunchDarkly Observability: Failed to configure sampling: ${e}`,
 			)
 		}

--- a/sdk/highlight-run/src/sdk/record.ts
+++ b/sdk/highlight-run/src/sdk/record.ts
@@ -89,7 +89,7 @@ import { MessageType, PropertyType } from '../client/workers/types'
 import { Attributes } from '@opentelemetry/api'
 import { IntegrationClient } from '../integrations'
 import { Record } from '../api/record'
-import { recordWarning } from './util'
+import { internalLog } from './util'
 import type { HighlightClassOptions } from '../client'
 import { Highlight } from '../client'
 import type { Hook, LDClient } from '../integrations/launchdarkly'
@@ -189,8 +189,9 @@ export class RecordSDK implements Record {
 					e.data.response.payload,
 				)
 			} else if (e.data.response?.type === MessageType.Stop) {
-				recordWarning(
+				internalLog(
 					'worker.onmessage',
+					'warn',
 					'Stopping recording due to worker failure',
 					e.data.response,
 				)
@@ -643,7 +644,7 @@ SessionSecureID: ${this.sessionData.sessionSecureID}`,
 						this.options.debug.domRecording)
 						? {
 								debug: this.logger.log,
-								warn: recordWarning,
+								warn: internalLog.bind('RecordSDK', 'warn'),
 							}
 						: undefined,
 			})
@@ -681,10 +682,7 @@ SessionSecureID: ${this.sessionData.sessionSecureID}`,
 			this.state = 'Recording'
 			this.manualStopped = false
 		} catch (e) {
-			if (this._isOnLocalHost) {
-				console.error(e)
-				recordWarning('initializeSession', e)
-			}
+			internalLog('initializeSession _setupWindowListeners', 'warn', e)
 		}
 	}
 
@@ -937,10 +935,7 @@ SessionSecureID: ${this.sessionData.sessionSecureID}`,
 				window.removeEventListener('beforeunload', unloadListener),
 			)
 		} catch (e) {
-			if (this._isOnLocalHost) {
-				console.error(e)
-				recordWarning('initializeSession _setupWindowListeners', e)
-			}
+			internalLog('initializeSession _setupWindowListeners', 'warn', e)
 		}
 
 		const unloadListener = () => {
@@ -1128,10 +1123,7 @@ SessionSecureID: ${this.sessionData.sessionSecureID}`,
 			this.sessionData.lastPushTime = Date.now()
 			setSessionData(this.sessionData)
 		} catch (e) {
-			if (this._isOnLocalHost) {
-				console.error(e)
-				recordWarning('_save', e)
-			}
+			internalLog('_save', 'warn', e)
 		}
 		if (this.state === 'Recording') {
 			if (this.pushPayloadTimerId) {

--- a/sdk/highlight-run/src/sdk/record.ts
+++ b/sdk/highlight-run/src/sdk/record.ts
@@ -325,7 +325,7 @@ export class RecordSDK implements Record {
 		)
 		this.environment = options.environment ?? 'production'
 		this.appVersion = options.appVersion
-		this.serviceName = options.serviceName ?? ''
+		this.serviceName = options.serviceName ?? 'browser'
 
 		if (typeof options.organizationID === 'string') {
 			this.organizationID = options.organizationID

--- a/sdk/highlight-run/src/sdk/util.ts
+++ b/sdk/highlight-run/src/sdk/util.ts
@@ -1,7 +1,14 @@
-import { LDObserve } from './LDObserve'
-
 export const recordWarning = (context: string, ...msg: any) => {
 	const prefix = `[@launchdarkly plugins] warning: (${context}): `
 	console.warn(prefix, msg)
-	LDObserve.recordLog(`${prefix}${msg}`, 'warn')
+	void reportLog(prefix, msg)
+}
+
+const reportLog = async (prefix: string, msg: any) => {
+	try {
+		const { LDObserve } = await import('./LDObserve')
+		LDObserve.recordLog(`${prefix}${msg}`, 'warn')
+	} catch (e) {
+		// ignore error  reporting log
+	}
 }

--- a/sdk/highlight-run/src/sdk/util.ts
+++ b/sdk/highlight-run/src/sdk/util.ts
@@ -1,6 +1,10 @@
-export const recordWarning = (context: string, ...msg: any) => {
-	const prefix = `[@launchdarkly plugins] warning: (${context}): `
-	console.warn(prefix, ...msg)
+export const internalLog = (
+	context: string,
+	level: keyof Console,
+	...msg: any
+) => {
+	const prefix = `[@launchdarkly plugins]: (${context}): `
+	console[level].apply(console, [prefix, ...msg])
 	void reportLog(prefix, ...msg)
 }
 

--- a/sdk/highlight-run/src/sdk/util.ts
+++ b/sdk/highlight-run/src/sdk/util.ts
@@ -1,10 +1,10 @@
 export const recordWarning = (context: string, ...msg: any) => {
 	const prefix = `[@launchdarkly plugins] warning: (${context}): `
-	console.warn(prefix, msg)
-	void reportLog(prefix, msg)
+	console.warn(prefix, ...msg)
+	void reportLog(prefix, ...msg)
 }
 
-const reportLog = async (prefix: string, msg: any) => {
+const reportLog = async (prefix: string, ...msg: any) => {
 	try {
 		const { LDObserve } = await import('./LDObserve')
 		LDObserve.recordLog(`${prefix}${msg}`, 'warn')


### PR DESCRIPTION
## Summary

Ensure that observability plugin initialization does not propagate internal errors.
Improves logging of internal SDK errors.
Adds a fallback mechanism for the localStorage lookup to fall back to in-memory storage
to prevent the plugin from failing completely in the case of out of quota.

## How did you test this change?

new unit test
testing local storage logic in e2e react-router app

## Are there any deployment considerations?

changeset
will update gonfalon and revert https://app.ld.catamorphic.com/projects/default/flags/observability-sdk-project-id/targeting?env=catamorphic&env=production&env=staging&selected-env=production

## Does this work require review from our design team?

no
