### PR TITLE
improve attribute reporting of sdk

### DIFF
--- a/.changeset/spotty-books-lick.md
+++ b/.changeset/spotty-books-lick.md
@@ -1,0 +1,7 @@
+---
+'highlight.run': patch
+'@launchdarkly/observability': patch
+'@launchdarkly/session-replay': patch
+---
+
+ensure omitting project id does not break sdk

--- a/.changeset/twelve-lions-taste.md
+++ b/.changeset/twelve-lions-taste.md
@@ -1,0 +1,7 @@
+---
+'highlight.run': patch
+'@launchdarkly/observability': patch
+'@launchdarkly/session-replay': patch
+---
+
+report all attributes of evaluation reason

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -87,8 +87,8 @@ jobs:
               shell: bash
               run: ./scripts/publish-npm.sh
               env:
-                  LD_RELEASE_IS_PRERELEASE: ${{ inputs.prerelease }}
-                  LD_RELEASE_IS_DRYRUN: ${{ inputs.dry-run }}
+                  LD_RELEASE_IS_PRERELEASE: false
+                  LD_RELEASE_IS_DRYRUN: false
 
             - name: Release changesets
               if: github.ref == 'refs/heads/main'

--- a/sdk/highlight-run/src/integrations/launchdarkly/index.ts
+++ b/sdk/highlight-run/src/integrations/launchdarkly/index.ts
@@ -44,16 +44,6 @@ export const FEATURE_FLAG_VARIATION_INDEX_ATTR = `${FEATURE_FLAG_SCOPE}.result.v
 export const FEATURE_FLAG_APP_ID_ATTR = `${LD_SCOPE}.application.id`
 export const FEATURE_FLAG_APP_VERSION_ATTR = `${LD_SCOPE}.application.version`
 
-const FEATURE_FLAG_REASONS = [
-	'kind',
-	'errorKind',
-	'ruleIndex',
-	'ruleId',
-	'prerequisiteKey',
-	'inExperiment',
-	'bigSegmentsStatus',
-] as const
-
 export const LD_INITIALIZE_EVENT = '$ld:telemetry:session:init'
 export const LD_ERROR_EVENT = '$ld:telemetry:error'
 export const LD_TRACK_EVENT = '$ld:telemetry:track'
@@ -149,11 +139,11 @@ export function setupLaunchDarklyIntegration(
 					: {}),
 			}
 			if (detail.reason) {
-				for (const attr of FEATURE_FLAG_REASONS) {
-					const value = detail.reason[attr]
+				for (const attr in FEATURE_FLAG_REASON_ATTRS) {
+					const k = attr as keyof LDEvaluationReason
+					const value = detail.reason[k]
 					if (value) {
-						eventAttributes[FEATURE_FLAG_REASON_ATTRS[attr]!] =
-							value
+						eventAttributes[FEATURE_FLAG_REASON_ATTRS[k]!] = value
 					}
 				}
 			}

--- a/sdk/highlight-run/src/integrations/launchdarkly/index.ts
+++ b/sdk/highlight-run/src/integrations/launchdarkly/index.ts
@@ -15,6 +15,7 @@ import type {
 	LDContextCommon,
 	LDMultiKindContext,
 } from '@launchdarkly/js-client-sdk'
+import { LDEvaluationReason } from '@launchdarkly/js-sdk-common/dist/cjs/api/data/LDEvaluationReason'
 
 export type { Hook, LDClient }
 
@@ -28,11 +29,30 @@ export const FEATURE_FLAG_CONTEXT_ATTR = `${FEATURE_FLAG_SCOPE}.contextKeys`
 export const FEATURE_FLAG_CONTEXT_ID_ATTR = `${FEATURE_FLAG_SCOPE}.context.id`
 export const FEATURE_FLAG_VALUE_ATTR = `${FEATURE_FLAG_SCOPE}.result.value`
 export const FEATURE_FLAG_PROVIDER_ATTR = `${FEATURE_FLAG_SCOPE}.provider.name`
-export const FEATURE_FLAG_IN_EXPERIMENT_ATTR = `${FEATURE_FLAG_SCOPE}.result.reason.inExperiment`
-export const FEATURE_FLAG_KIND_ATTR = `${FEATURE_FLAG_SCOPE}.result.reason.kind`
+export const FEATURE_FLAG_REASON_ATTRS: {
+	[key in keyof LDEvaluationReason]: string
+} = {
+	kind: `${FEATURE_FLAG_SCOPE}.result.reason.kind`,
+	errorKind: `${FEATURE_FLAG_SCOPE}.result.reason.errorKind`,
+	ruleIndex: `${FEATURE_FLAG_SCOPE}.result.reason.ruleIndex`,
+	ruleId: `${FEATURE_FLAG_SCOPE}.result.reason.ruleId`,
+	prerequisiteKey: `${FEATURE_FLAG_SCOPE}.result.reason.prerequisiteKey`,
+	inExperiment: `${FEATURE_FLAG_SCOPE}.result.reason.inExperiment`,
+	bigSegmentsStatus: `${FEATURE_FLAG_SCOPE}.result.reason.bigSegmentsStatus`,
+}
 export const FEATURE_FLAG_VARIATION_INDEX_ATTR = `${FEATURE_FLAG_SCOPE}.result.variationIndex`
 export const FEATURE_FLAG_APP_ID_ATTR = `${LD_SCOPE}.application.id`
 export const FEATURE_FLAG_APP_VERSION_ATTR = `${LD_SCOPE}.application.version`
+
+const FEATURE_FLAG_REASONS = [
+	'kind',
+	'errorKind',
+	'ruleIndex',
+	'ruleId',
+	'prerequisiteKey',
+	'inExperiment',
+	'bigSegmentsStatus',
+] as const
 
 export const LD_INITIALIZE_EVENT = '$ld:telemetry:session:init'
 export const LD_ERROR_EVENT = '$ld:telemetry:error'
@@ -121,23 +141,21 @@ export function setupLaunchDarklyIntegration(
 				[FEATURE_FLAG_KEY_ATTR]: hookContext.flagKey,
 				[FEATURE_FLAG_VALUE_ATTR]: JSON.stringify(detail.value),
 				// only set the following keys when values are truthy
-				...(detail.reason?.inExperiment
-					? {
-							[FEATURE_FLAG_IN_EXPERIMENT_ATTR]:
-								detail.reason.inExperiment,
-						}
-					: {}),
-				...(detail.reason?.kind
-					? {
-							[FEATURE_FLAG_KIND_ATTR]: detail.reason.kind,
-						}
-					: {}),
 				...(detail.variationIndex
 					? {
 							[FEATURE_FLAG_VARIATION_INDEX_ATTR]:
 								detail.variationIndex,
 						}
 					: {}),
+			}
+			if (detail.reason) {
+				for (const attr of FEATURE_FLAG_REASONS) {
+					const value = detail.reason[attr]
+					if (value) {
+						eventAttributes[FEATURE_FLAG_REASON_ATTRS[attr]!] =
+							value
+					}
+				}
 			}
 
 			if (hookContext.context) {

--- a/sdk/highlight-run/src/plugins/observe.ts
+++ b/sdk/highlight-run/src/plugins/observe.ts
@@ -5,9 +5,9 @@ import {
 	FEATURE_FLAG_CONTEXT_ATTR,
 	FEATURE_FLAG_CONTEXT_ID_ATTR,
 	FEATURE_FLAG_ENV_ATTR,
-	FEATURE_FLAG_IN_EXPERIMENT_ATTR,
 	FEATURE_FLAG_KEY_ATTR,
 	FEATURE_FLAG_PROVIDER_ATTR,
+	FEATURE_FLAG_REASON_ATTRS,
 	FEATURE_FLAG_SCOPE,
 	FEATURE_FLAG_SPAN_NAME,
 	FEATURE_FLAG_VALUE_ATTR,
@@ -30,6 +30,7 @@ import {
 } from '@opentelemetry/semantic-conventions'
 import { Attributes } from '@opentelemetry/api'
 import { internalLog } from '../sdk/util'
+import { LDEvaluationReason } from '@launchdarkly/js-sdk-common/dist/cjs/api/data/LDEvaluationReason'
 
 export class Observe extends Plugin<ObserveOptions> implements LDPlugin {
 	observe: ObserveAPI | undefined
@@ -143,18 +144,22 @@ export class Observe extends Plugin<ObserveOptions> implements LDPlugin {
 						[FEATURE_FLAG_KEY_ATTR]: hookContext.flagKey,
 						[FEATURE_FLAG_VALUE_ATTR]: JSON.stringify(detail.value),
 						// only set the following keys when values are truthy
-						...(detail.reason?.inExperiment
-							? {
-									[FEATURE_FLAG_IN_EXPERIMENT_ATTR]:
-										detail.reason.inExperiment,
-								}
-							: {}),
 						...(detail.variationIndex
 							? {
 									[FEATURE_FLAG_VARIATION_INDEX_ATTR]:
 										detail.variationIndex,
 								}
 							: {}),
+					}
+					if (detail.reason) {
+						for (const attr in FEATURE_FLAG_REASON_ATTRS) {
+							const k = attr as keyof LDEvaluationReason
+							const value = detail.reason[k]
+							if (value) {
+								eventAttributes[FEATURE_FLAG_REASON_ATTRS[k]!] =
+									value
+							}
+						}
 					}
 
 					if (hookContext.context) {

--- a/sdk/highlight-run/src/plugins/observe.ts
+++ b/sdk/highlight-run/src/plugins/observe.ts
@@ -36,6 +36,7 @@ export class Observe extends Plugin<ObserveOptions> implements LDPlugin {
 
 	constructor(projectID?: string | number, options?: ObserveOptions) {
 		try {
+			super(options)
 			// Don't run init when called outside of the browser.
 			if (
 				typeof window === 'undefined' ||
@@ -53,7 +54,6 @@ export class Observe extends Plugin<ObserveOptions> implements LDPlugin {
 				)
 				return
 			}
-			super(options)
 			const clientOptions: BrowserTracingConfig = {
 				backendUrl:
 					options?.backendUrl ??

--- a/sdk/highlight-run/src/plugins/record.ts
+++ b/sdk/highlight-run/src/plugins/record.ts
@@ -20,6 +20,7 @@ export class Record extends Plugin<RecordOptions> implements LDPlugin {
 
 	constructor(projectID?: string | number, options?: RecordOptions) {
 		try {
+			super(options)
 			// Don't run init when called outside of the browser.
 			if (
 				typeof window === 'undefined' ||
@@ -43,7 +44,6 @@ export class Record extends Plugin<RecordOptions> implements LDPlugin {
 				)
 				return
 			}
-			super(options)
 			const client_options: HighlightClassOptions = {
 				...options,
 				organizationID: projectID,


### PR DESCRIPTION
## Summary

* ensure omitting project id does not break sdk
* report all attributes of evaluation reason

## How did you test this change?

before
<img width="1578" alt="Screenshot 2025-05-23 at 15 37 24" src="https://github.com/user-attachments/assets/255a53d5-3f95-497a-8926-f427d114f3d1" />
after
<img width="1565" alt="Screenshot 2025-05-23 at 15 40 49" src="https://github.com/user-attachments/assets/c91f272a-d951-4542-bf5d-df674fdba8e0" />

testing new attrs
<img width="559" alt="Screenshot 2025-05-23 at 15 41 35" src="https://github.com/user-attachments/assets/2fdc5432-9e7b-4420-b8b2-9b4166ced30f" />


## Are there any deployment considerations?

changeset

## Does this work require review from our design team?

no
