### PR TITLE
[DOCS-2547] initial draft of CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,10 +48,17 @@ Running `yarn build` in an individual package (`@launchdarkly/observability` or 
 To run all unit tests:
 
 ```shell
-TKTK
+# install dependencies
+yarn
+
+# lint
+yarn format-check
+
+# run all tests
+yarn test
 ```
 
-It is preferable to run tests against TKTK-which versions prior to submitting a pull request. However, LaunchDarkly's CI tests will run automatically against all supported versions.
+LaunchDarkly's CI tests will run automatically against all supported versions. To learn more, read [`.github/workflows/turbo.yml`](.github/workflows/turbo.yml).
 
 ## Code organization
 


### PR DESCRIPTION
## Summary

https://launchdarkly.atlassian.net/browse/DOCS-2547 -- This PR adds basic information on contributing to the repo, starting from the LaunchDarkly boilerplate text.

## How did you test this change?

reviewed GH-rendered markdown

## Are there any deployment considerations?

no

## Does this work require review from our design team?

no
<!-- ld-jira-link -->
---
Related Jira issue: [DOCS-2547: add CONTRIBUTING.md to observability-sdk repo](https://launchdarkly.atlassian.net/browse/DOCS-2547)
<!-- end-ld-jira-link -->