### PR TITLE
(docs) add in library structure info

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,10 @@ LaunchDarkly's CI tests will run automatically against all supported versions. T
 
 The library's structure is as follows:
 
+* `sdk/` directory contains all SDKs
+  * `@launchdarkly` directory with `sdk/` contains the `@launchdarkly`-prefixed npm packages
+* `e2e` directory contains end to end tests exercising the SDKs
+* `rrweb` directory hosts the rrweb fork as a git submodule; used by the Session Replay SDK
 
 ## Documenting types and methods
 


### PR DESCRIPTION
## Summary

https://launchdarkly.atlassian.net/browse/DOCS-2547 followup -- this info didn't make it into https://github.com/launchdarkly/observability-sdk/pull/72, but should have. 

## How did you test this change?

manual review

## Are there any deployment considerations?

no

## Does this work require review from our design team?

no
