### PR TITLE
Prevent log spam for storage methods and check if storage is defined.

### DIFF
--- a/sdk/highlight-run/src/sdk/util.ts
+++ b/sdk/highlight-run/src/sdk/util.ts
@@ -1,3 +1,6 @@
+// Object for tracking previously logged messages.
+const loggedIds = Object.create(null)
+
 export const internalLog = (
 	context: string,
 	level: keyof Console,
@@ -6,6 +9,31 @@ export const internalLog = (
 	const prefix = `[@launchdarkly plugins]: (${context}): `
 	console[level].apply(console, [prefix, ...msg])
 	void reportLog(prefix, ...msg)
+}
+
+/**
+ * Utility to help avoid logging the same message multiple times.
+ *
+ * This is helpful to prevent spamming the logs with sticky error conditions.
+ * For example if local storage cannot be written to, then each attempt to
+ * write would fail, and logging each time would spam the logs.
+ *
+ * @param logOnceId - A message with this ID will only be logged one time for the given context.
+ * @param context - The context of the message.
+ * @param level - The level of the message.
+ * @param msg - The message to log.
+ */
+export const internalLogOnce = (
+	context: string,
+	logOnceId: string,
+	level: keyof Console,
+	...msg: any
+) => {
+	if (loggedIds[`${context}-${logOnceId}`]) {
+		return
+	}
+	loggedIds[`${context}-${logOnceId}`] = true
+	internalLog(context, level, ...msg)
 }
 
 const reportLog = async (prefix: string, ...msg: any) => {


### PR DESCRIPTION
## Summary

Adding the ability to log once to prevent log spam.
Adding persistent storage availability checks.

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?

<!--
 Request review from julian-highlight / our design team
-->
