### PR TITLE
provide LDContext user.memberEmail to H.identify when available

### DIFF
--- a/.changeset/old-ghosts-call.md
+++ b/.changeset/old-ghosts-call.md
@@ -1,0 +1,5 @@
+---
+'highlight.run': patch
+---
+
+provide LDContext user.memberEmail to H.identify when available

--- a/e2e/react-router/src/ldclient.tsx
+++ b/e2e/react-router/src/ldclient.tsx
@@ -24,7 +24,7 @@ const sessionReplaySettings: ConstructorParameters<typeof SessionReplay>[0] = {
 }
 
 export const client = init(
-	'66d9d3c255856f0fa8fd62d0',
+	'65006c1cfd354512d19019d9',
 	{ key: 'unknown' },
 	{
 		// Not including plugins at all would be equivalent to the current LaunchDarkly SDK.

--- a/sdk/highlight-run/src/integrations/launchdarkly/index.ts
+++ b/sdk/highlight-run/src/integrations/launchdarkly/index.ts
@@ -120,19 +120,17 @@ export function setupLaunchDarklyIntegration(
 			}
 		},
 		afterIdentify: (hookContext, data, result) => {
-			hClient.log('LD.identify', 'INFO', {
+			const metadata = {
 				key: getCanonicalKey(hookContext.context),
 				context: JSON.stringify(getCanonicalObj(hookContext.context)),
 				timeout: hookContext.timeout,
 				[LD_IDENTIFY_RESULT_STATUS]: result.status,
-			})
+			}
+			hClient.log('LD.identify', 'INFO', metadata)
 			if (result.status === 'completed') {
 				hClient.identify(
 					getCanonicalKey(hookContext.context),
-					{
-						key: getCanonicalKey(hookContext.context),
-						timeout: hookContext.timeout,
-					},
+					metadata,
 					'LaunchDarkly',
 				)
 			}

--- a/sdk/highlight-run/src/integrations/launchdarkly/index.ts
+++ b/sdk/highlight-run/src/integrations/launchdarkly/index.ts
@@ -65,8 +65,20 @@ function isMultiContext(context: any): context is LDMultiKindContext {
 	return context.kind === 'multi'
 }
 
+// getCanonicalKey returns the key provided to H.identify based on the LD context.
+// Long term, we will provide context filtering / the ability to control what
+// context attributes are used as the identify key. For now, this hard-codes
+// logic for using the memberEmail, when set.
 export function getCanonicalKey(context: LDContext) {
 	if (isMultiContext(context)) {
+		if (context.user) {
+			const user = context.user as LDContextCommon
+			if (user.memberEmail) {
+				return user.memberEmail
+			} else {
+				return user.key
+			}
+		}
 		return Object.keys(context)
 			.sort()
 			.filter((key) => key !== 'kind')


### PR DESCRIPTION
## Summary

Provide the user.memberEmail as the highlight identifier when available to help
with finding gonfalon sessions for the support use-case.

Long term, we will provide context filtering / the ability to control what
context attributes are used as the identify key.

## How did you test this change?

staging session identified correctly (TODO)

## Are there any deployment considerations?

changeset

## Does this work require review from our design team?

no
