### PR TITLE
Only run changeset/actions once.

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -51,7 +51,7 @@ jobs:
                   REACT_APP_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
 
             - name: Configure yarn npm registry credentials
-              if: github.ref == 'refs/heads/main'
+              # if: github.ref == 'refs/heads/main'
               run: |
                   yarn config set npmRegistryServer "https://registry.npmjs.org"
                   yarn config set npmAuthToken "${NPM_TOKEN}"
@@ -59,7 +59,7 @@ jobs:
                   NPM_TOKEN: ${{ secrets.NPM_TOKEN_HIGHLIGHT_RUN }}
 
             - name: Publish highlight npm packages
-              if: github.ref == 'refs/heads/main'
+              # if: github.ref == 'refs/heads/main'
               run: yarn publish:highlight
 
             - uses: launchdarkly/gh-actions/actions/release-secrets@release-secrets-v1.2.0
@@ -84,7 +84,7 @@ jobs:
                   LD_RELEASE_IS_DRYRUN: false
 
             - name: Release changesets
-              if: github.ref == 'refs/heads/main'
+              # if: github.ref == 'refs/heads/main'
               id: changesets-version
               uses: changesets/action@v1
               with:

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -51,7 +51,7 @@ jobs:
                   REACT_APP_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
 
             - name: Configure yarn npm registry credentials
-              # if: github.ref == 'refs/heads/main'
+              if: github.ref == 'refs/heads/main'
               run: |
                   yarn config set npmRegistryServer "https://registry.npmjs.org"
                   yarn config set npmAuthToken "${NPM_TOKEN}"
@@ -59,7 +59,7 @@ jobs:
                   NPM_TOKEN: ${{ secrets.NPM_TOKEN_HIGHLIGHT_RUN }}
 
             - name: Publish highlight npm packages
-              # if: github.ref == 'refs/heads/main'
+              if: github.ref == 'refs/heads/main'
               run: yarn publish:highlight
 
             - uses: launchdarkly/gh-actions/actions/release-secrets@release-secrets-v1.2.0
@@ -84,7 +84,7 @@ jobs:
                   LD_RELEASE_IS_DRYRUN: false
 
             - name: Release changesets
-              # if: github.ref == 'refs/heads/main'
+              if: github.ref == 'refs/heads/main'
               id: changesets-version
               uses: changesets/action@v1
               with:

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -60,14 +60,7 @@ jobs:
 
             - name: Publish highlight npm packages
               if: github.ref == 'refs/heads/main'
-              id: changesets-publish
-              uses: changesets/action@v1
-              with:
-                  publish: yarn publish:highlight
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  NPM_TOKEN: ${{ secrets.NPM_TOKEN_HIGHLIGHT_RUN }}
-                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_HIGHLIGHT_RUN }}
+              run: yarn publish:highlight
 
             - uses: launchdarkly/gh-actions/actions/release-secrets@release-secrets-v1.2.0
               if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
## Summary

The `changeset/action` automatically versions, so running it twice in the same workflow causes the second instance to actually publish what should instead just be added to a PR.

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?

<!--
 Request review from julian-highlight / our design team
-->
