### PR TITLE
improve gonfalon member email reporting

### DIFF
--- a/.changeset/green-eggs-win.md
+++ b/.changeset/green-eggs-win.md
@@ -1,0 +1,6 @@
+---
+'highlight.run': patch
+'@launchdarkly/session-replay': patch
+---
+
+report member.email from context object

--- a/e2e/react-router/src/ldclient.tsx
+++ b/e2e/react-router/src/ldclient.tsx
@@ -24,7 +24,7 @@ const sessionReplaySettings: ConstructorParameters<typeof SessionReplay>[0] = {
 }
 
 export const client = init(
-	'5dbc84672a88c108b14dad13',
+	'548f6741c1efad40031b18ae',
 	{ key: 'unknown' },
 	{
 		// Not including plugins at all would be equivalent to the current LaunchDarkly SDK.

--- a/sdk/highlight-run/src/integrations/launchdarkly/index.ts
+++ b/sdk/highlight-run/src/integrations/launchdarkly/index.ts
@@ -71,10 +71,10 @@ function isMultiContext(context: any): context is LDMultiKindContext {
 // logic for using the memberEmail, when set.
 export function getCanonicalKey(context: LDContext) {
 	if (isMultiContext(context)) {
-		if (context.user) {
-			const user = context.user as LDContextCommon
-			if (user.memberEmail) {
-				return user.memberEmail
+		if (context.member) {
+			const user = context.member as LDContextCommon
+			if (user.email) {
+				return user.email
 			} else {
 				return user.key
 			}


### PR DESCRIPTION
## Summary

Report the LD SDK context `member.email` when available to as the o11y identifier.

## How did you test this change?


<img width="1652" alt="Screenshot 2025-07-01 at 17 44 16" src="https://github.com/user-attachments/assets/4199b08c-7948-4e6d-87d1-5d4bb250a8d9" />

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?

changeset
will bump gonfalon session replay sdk

## Does this work require review from our design team?

no
