### PR TITLE
Add tracingOrigins and urlBlocklist to RN Observe plugin

### DIFF
--- a/.changeset/sad-emus-turn.md
+++ b/.changeset/sad-emus-turn.md
@@ -1,0 +1,5 @@
+---
+'@launchdarkly/observability-react-native': patch
+---
+
+add tracingOrigins and urlBlocklist and improve span naming

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,9 +17,3 @@
 <!--
  Backend - Do we need to consider migrations or backfilling data?
 -->
-
-## Does this work require review from our design team?
-
-<!--
- Request review from julian-highlight / our design team
--->

--- a/sdk/@launchdarkly/observability-react-native/CHANGELOG.md
+++ b/sdk/@launchdarkly/observability-react-native/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.0] - 2024-01-XX
+## [0.1.0] - 2025-07-08
 
 ### Added
 - Initial release of @launchdarkly/observability-react-native

--- a/sdk/@launchdarkly/observability-react-native/package.json
+++ b/sdk/@launchdarkly/observability-react-native/package.json
@@ -28,6 +28,7 @@
 		"access": "public"
 	},
 	"dependencies": {
+		"@launchdarkly/observability-shared": "workspace:*",
 		"@opentelemetry/api": "^1.9.0",
 		"@opentelemetry/exporter-trace-otlp-http": "^0.56.0",
 		"@opentelemetry/instrumentation": "^0.57.2",

--- a/sdk/@launchdarkly/observability-react-native/src/api/Options.ts
+++ b/sdk/@launchdarkly/observability-react-native/src/api/Options.ts
@@ -30,6 +30,19 @@ export interface ReactNativeOptions {
 	customHeaders?: Record<string, string>
 
 	/**
+	 * Specifies where the backend of the app lives. If specified, the SDK will attach tracing headers to outgoing requests whose destination URLs match a substring or regexp from this list, so that backend errors can be linked back to the session.
+	 * If 'true' is specified, all requests to the current domain will be matched.
+	 * @example tracingOrigins: ['localhost', /^\//, 'backend.myapp.com']
+	 */
+	tracingOrigins?: boolean | (string | RegExp)[]
+
+	/**
+	 * A list of URLs to block from tracing.
+	 * @example urlBlocklist: ['localhost', 'backend.myapp.com']
+	 */
+	urlBlocklist?: string[]
+
+	/**
 	 * Session timeout in milliseconds.
 	 * @default 30 * 60 * 1000 (30 minutes)
 	 */

--- a/sdk/@launchdarkly/observability-react-native/src/client/InstrumentationManager.ts
+++ b/sdk/@launchdarkly/observability-react-native/src/client/InstrumentationManager.ts
@@ -111,7 +111,7 @@ export class InstrumentationManager {
 	private headers: Record<string, string> = {}
 	private sessionManager?: SessionManager
 
-	constructor(private options: ReactNativeOptions) {
+	constructor(private options: Required<ReactNativeOptions>) {
 		this.serviceName =
 			this.options.serviceName ??
 			'launchdarkly-observability-react-native'

--- a/sdk/@launchdarkly/observability-react-native/src/client/InstrumentationManager.ts
+++ b/sdk/@launchdarkly/observability-react-native/src/client/InstrumentationManager.ts
@@ -95,7 +95,11 @@ export class InstrumentationManager {
 			propagators: [
 				new W3CBaggagePropagator(),
 				new CustomTraceContextPropagator({
-					otlpEndpoint: this.options.otlpEndpoint,
+					internalEndpoints: [
+						`${this.options.otlpEndpoint}/v1/traces`,
+						`${this.options.otlpEndpoint}/v1/logs`,
+						`${this.options.otlpEndpoint}/v1/metrics`,
+					],
 					tracingOrigins: this.options.tracingOrigins,
 					urlBlocklist: this.options.urlBlocklist,
 				}),

--- a/sdk/@launchdarkly/observability-react-native/src/client/ObservabilityClient.ts
+++ b/sdk/@launchdarkly/observability-react-native/src/client/ObservabilityClient.ts
@@ -57,6 +57,8 @@ export class ObservabilityClient {
 			disableLogs: options.disableLogs ?? false,
 			disableMetrics: options.disableMetrics ?? false,
 			disableTraces: options.disableTraces ?? false,
+			tracingOrigins: options.tracingOrigins ?? false,
+			urlBlocklist: options.urlBlocklist ?? [],
 		}
 	}
 
@@ -77,10 +79,11 @@ export class ObservabilityClient {
 				// Old attribute for connecting to LD project. Can be deprecated in the
 				// future in favor of X-LaunchDarkly-Project header.
 				'highlight.project_id': this.sdkKey,
+				'highlight.session_id': sessionAttributes.sessionId,
 				...this.options.resourceAttributes,
-				...sessionAttributes,
 			})
 
+			this.instrumentationManager.setSessionManager(this.sessionManager)
 			this.instrumentationManager.initialize(resource)
 			this.isInitialized = true
 

--- a/sdk/@launchdarkly/observability-react-native/src/otel/CustomBatchSpanProcessor.test.ts
+++ b/sdk/@launchdarkly/observability-react-native/src/otel/CustomBatchSpanProcessor.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi } from 'vitest'
+import { CustomBatchSpanProcessor } from './CustomBatchSpanProcessor'
+import { RECORD_ATTRIBUTE } from '@launchdarkly/observability-shared'
+import { InMemorySpanExporter } from '@opentelemetry/sdk-trace-base'
+import { Tracer, WebTracerProvider } from '@opentelemetry/sdk-trace-web'
+import { ReadableSpan } from '@opentelemetry/sdk-trace-web'
+
+describe('CustomBatchSpanProcessor', () => {
+	let exporter: InMemorySpanExporter
+	let processor: CustomBatchSpanProcessor
+	let provider: WebTracerProvider
+	let tracer: Tracer
+
+	beforeEach(() => {
+		exporter = new InMemorySpanExporter()
+		processor = new CustomBatchSpanProcessor(exporter)
+		provider = new WebTracerProvider()
+		provider.addSpanProcessor(processor)
+		tracer = provider.getTracer('test')
+	})
+
+	it('does not export spans with RECORD_ATTRIBUTE=false', async () => {
+		const span = tracer.startSpan('span')
+		span.setAttribute(RECORD_ATTRIBUTE, false)
+		span.end()
+
+		await processor.forceFlush()
+		const finished = exporter.getFinishedSpans()
+		expect(finished.length).toBe(0)
+	})
+
+	it('exports spans with RECORD_ATTRIBUTE true or undefined', async () => {
+		const span1 = tracer.startSpan('span1')
+		span1.setAttribute(RECORD_ATTRIBUTE, true)
+		span1.end()
+
+		const span2 = tracer.startSpan('span2')
+		span2.end()
+
+		await processor.forceFlush()
+		const finished = exporter.getFinishedSpans()
+		expect(finished.length).toEqual(2)
+		expect(finished.map((s) => s.name)).toContain('span1')
+		expect(finished.map((s) => s.name)).toContain('span2')
+	})
+
+	it('logs when debug is enabled and span is not recorded', async () => {
+		const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+		processor = new CustomBatchSpanProcessor(exporter, {
+			debug: true,
+		})
+		const span = tracer.startSpan('span')
+		span.setAttribute(RECORD_ATTRIBUTE, false)
+		span.end()
+		processor.onEnd(span as unknown as ReadableSpan)
+
+		expect(logSpy).toHaveBeenCalledWith(
+			'[CustomBatchSpanProcessor]',
+			'span set to not record - skipping',
+			'span',
+		)
+		logSpy.mockRestore()
+	})
+})

--- a/sdk/@launchdarkly/observability-react-native/src/otel/CustomBatchSpanProcessor.ts
+++ b/sdk/@launchdarkly/observability-react-native/src/otel/CustomBatchSpanProcessor.ts
@@ -1,0 +1,32 @@
+import { RECORD_ATTRIBUTE } from '@launchdarkly/observability-shared'
+import {
+	BatchSpanProcessor,
+	BufferConfig,
+	ReadableSpan,
+	SpanExporter,
+} from '@opentelemetry/sdk-trace-web'
+
+export class CustomBatchSpanProcessor extends BatchSpanProcessor {
+	constructor(
+		exporter: SpanExporter,
+		private options?: BufferConfig & { debug?: boolean },
+	) {
+		const { debug, ...rest } = options ?? {}
+		super(exporter, rest)
+	}
+
+	onEnd(span: ReadableSpan): void {
+		if (span.attributes[RECORD_ATTRIBUTE] === false) {
+			this._log('span set to not record - skipping', span.name)
+			return // don't record spans that are marked as not to be recorded
+		}
+
+		super.onEnd(span)
+	}
+
+	private _log(...data: any[]): void {
+		if (this.options?.debug) {
+			console.log('::: [CustomBatchSpanProcessor]', ...data)
+		}
+	}
+}

--- a/sdk/@launchdarkly/observability-react-native/src/otel/CustomBatchSpanProcessor.ts
+++ b/sdk/@launchdarkly/observability-react-native/src/otel/CustomBatchSpanProcessor.ts
@@ -26,7 +26,7 @@ export class CustomBatchSpanProcessor extends BatchSpanProcessor {
 
 	private _log(...data: any[]): void {
 		if (this.options?.debug) {
-			console.log('::: [CustomBatchSpanProcessor]', ...data)
+			console.log('[CustomBatchSpanProcessor]', ...data)
 		}
 	}
 }

--- a/sdk/@launchdarkly/observability-react-native/src/otel/DeduplicatingExporter.test.ts
+++ b/sdk/@launchdarkly/observability-react-native/src/otel/DeduplicatingExporter.test.ts
@@ -1,0 +1,193 @@
+import {
+	DeduplicatingExporter,
+	FETCH_LIB,
+	XHR_LIB,
+} from './DeduplicatingExporter'
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http'
+import { ReadableSpan } from '@opentelemetry/sdk-trace-web'
+import { ExportResult } from '@opentelemetry/core'
+import { describe, it, expect } from 'vitest'
+
+class TestExporter extends OTLPTraceExporter {
+	public exported: ReadableSpan[][] = []
+	export(spans: ReadableSpan[], cb: (res: ExportResult) => void): void {
+		this.exported.push(spans)
+		cb({ code: 0 })
+	}
+	shutdown() {
+		return Promise.resolve()
+	}
+	forceFlush() {
+		return Promise.resolve()
+	}
+}
+
+function makeSpan({
+	traceId,
+	spanId,
+	parentSpanId,
+	instrumentationLibraryName,
+	url,
+	method,
+	name = 'test-span',
+}: {
+	traceId: string
+	spanId: string
+	parentSpanId?: string
+	instrumentationLibraryName: string
+	url?: string
+	method?: string
+	name?: string
+}): ReadableSpan {
+	return {
+		name,
+		spanContext: () => ({ traceId, spanId }),
+		parentSpanId,
+		instrumentationLibrary: {
+			name: instrumentationLibraryName,
+			version: '1.0.0',
+		},
+		attributes: {
+			...(url ? { 'http.url': url } : {}),
+			...(method ? { 'http.method': method } : {}),
+		},
+	} as ReadableSpan
+}
+
+describe('DeduplicatingExporter', () => {
+	it('exports non-HTTP spans as-is', () => {
+		const testExporter = new TestExporter()
+		const dedup = new DeduplicatingExporter(testExporter)
+		const span = makeSpan({
+			traceId: '1',
+			spanId: 'a',
+			instrumentationLibraryName: FETCH_LIB,
+		})
+		dedup.export([span], () => {})
+		expect(testExporter.exported.length).toBe(1)
+		expect(testExporter.exported[0].length).toBe(1)
+		expect(testExporter.exported[0][0]).toBe(span)
+	})
+
+	it('deduplicates XHR when fetch span exists', () => {
+		const testExporter = new TestExporter()
+		const dedup = new DeduplicatingExporter(testExporter)
+		const fetchSpan = makeSpan({
+			traceId: '1',
+			spanId: 'a',
+			instrumentationLibraryName: FETCH_LIB,
+			url: 'http://x',
+			method: 'GET',
+		})
+		const xhrSpan = makeSpan({
+			traceId: '1',
+			spanId: 'b',
+			parentSpanId: 'a',
+			instrumentationLibraryName: XHR_LIB,
+			url: 'http://x',
+			method: 'GET',
+		})
+		dedup.export([fetchSpan, xhrSpan], () => {})
+		expect(testExporter.exported.length).toBe(1)
+		expect(testExporter.exported[0].length).toBe(1)
+		expect(testExporter.exported[0][0]).toBe(fetchSpan)
+	})
+
+	it('replaces XHR with fetch if fetch comes after', () => {
+		const testExporter = new TestExporter()
+		const dedup = new DeduplicatingExporter(testExporter)
+		const xhrSpan = makeSpan({
+			traceId: '1',
+			spanId: 'b',
+			parentSpanId: 'a',
+			instrumentationLibraryName: XHR_LIB,
+			url: 'http://x',
+			method: 'GET',
+		})
+		const fetchSpan = makeSpan({
+			traceId: '1',
+			spanId: 'a',
+			instrumentationLibraryName: FETCH_LIB,
+			url: 'http://x',
+			method: 'GET',
+		})
+		dedup.export([xhrSpan, fetchSpan], () => {})
+		expect(testExporter.exported.length).toBe(1)
+		expect(testExporter.exported[0].length).toBe(1)
+		expect(testExporter.exported[0][0]).toBe(fetchSpan)
+	})
+
+	it('keeps both fetch and XHR if different traceIds', () => {
+		const testExporter = new TestExporter()
+		const dedup = new DeduplicatingExporter(testExporter)
+		const fetchSpan = makeSpan({
+			traceId: '1',
+			spanId: 'a',
+			instrumentationLibraryName: FETCH_LIB,
+			url: 'http://x',
+			method: 'GET',
+		})
+		const xhrSpan = makeSpan({
+			traceId: '2',
+			spanId: 'b',
+			parentSpanId: 'a',
+			instrumentationLibraryName: XHR_LIB,
+			url: 'http://x',
+			method: 'GET',
+		})
+		dedup.export([fetchSpan, xhrSpan], () => {})
+		expect(testExporter.exported.length).toBe(1)
+		expect(testExporter.exported[0].length).toBe(2)
+		expect(testExporter.exported[0]).toContain(fetchSpan)
+		expect(testExporter.exported[0]).toContain(xhrSpan)
+	})
+
+	it('keeps both fetch and XHR if different reqId', () => {
+		const testExporter = new TestExporter()
+		const dedup = new DeduplicatingExporter(testExporter)
+		const fetchSpan = makeSpan({
+			traceId: '1',
+			spanId: 'a',
+			instrumentationLibraryName: FETCH_LIB,
+			url: 'http://x',
+			method: 'GET',
+		})
+		const xhrSpan = makeSpan({
+			traceId: '1',
+			spanId: 'b',
+			parentSpanId: 'c',
+			instrumentationLibraryName: XHR_LIB,
+			url: 'http://x',
+			method: 'GET',
+		})
+		dedup.export([fetchSpan, xhrSpan], () => {})
+		expect(testExporter.exported.length).toBe(1)
+		expect(testExporter.exported[0].length).toBe(2)
+		expect(testExporter.exported[0]).toContain(fetchSpan)
+		expect(testExporter.exported[0]).toContain(xhrSpan)
+	})
+
+	it('exports multiple unrelated HTTP spans', () => {
+		const testExporter = new TestExporter()
+		const dedup = new DeduplicatingExporter(testExporter)
+		const span1 = makeSpan({
+			traceId: '1',
+			spanId: 'a',
+			instrumentationLibraryName: FETCH_LIB,
+			url: 'http://a',
+			method: 'GET',
+		})
+		const span2 = makeSpan({
+			traceId: '2',
+			spanId: 'b',
+			instrumentationLibraryName: FETCH_LIB,
+			url: 'http://b',
+			method: 'POST',
+		})
+		dedup.export([span1, span2], () => {})
+		expect(testExporter.exported.length).toBe(1)
+		expect(testExporter.exported[0].length).toBe(2)
+		expect(testExporter.exported[0]).toContain(span1)
+		expect(testExporter.exported[0]).toContain(span2)
+	})
+})

--- a/sdk/@launchdarkly/observability-react-native/src/otel/DeduplicatingExporter.ts
+++ b/sdk/@launchdarkly/observability-react-native/src/otel/DeduplicatingExporter.ts
@@ -1,0 +1,84 @@
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http'
+import { ReadableSpan } from '@opentelemetry/sdk-trace-web'
+import { SpanExporter } from '@opentelemetry/sdk-trace-web'
+import { ExportResult } from '@opentelemetry/core'
+
+const FETCH_LIB = '@opentelemetry/instrumentation-fetch'
+const XHR_LIB = '@opentelemetry/instrumentation-xml-http-request'
+
+export class DeduplicatingExporter implements SpanExporter {
+	constructor(
+		private readonly delegate: OTLPTraceExporter,
+		private readonly debug?: boolean,
+	) {}
+
+	export(spans: ReadableSpan[], cb: (res: ExportResult) => void): void {
+		const seenSpans = new Map<string, ReadableSpan>()
+		const dedupedSpans: ReadableSpan[] = []
+
+		for (const span of spans) {
+			const sc = span.spanContext()
+			const traceId = sc.traceId
+			const lib = span.instrumentationLibrary.name
+			const url = span.attributes['http.url']
+			const method = span.attributes['http.method']
+
+			if (!url || !method) {
+				this._log('non-http span - continuing', span.name)
+				dedupedSpans.push(span)
+				continue
+			}
+
+			const reqId =
+				lib === XHR_LIB && span.parentSpanId
+					? span.parentSpanId // xhr requests can have a parent span from fetch instrumentation
+					: sc.spanId
+
+			const key = `${traceId}|${reqId}`
+			const existing = seenSpans.get(key)
+
+			if (!existing) {
+				this._log('non-existing span - adding', span.name)
+				seenSpans.set(key, span)
+				dedupedSpans.push(span)
+				continue
+			}
+
+			const existingLib = existing.instrumentationLibrary.name
+
+			if (existingLib === FETCH_LIB && lib === XHR_LIB) {
+				this._log('fetch span seen - dropping xhr', span.name)
+				continue
+			}
+
+			if (existingLib === XHR_LIB && lib === FETCH_LIB) {
+				this._log('xhr span seen - replacing with fetch', span.name)
+				const idx = dedupedSpans.indexOf(existing)
+
+				if (idx !== -1) {
+					// Replace the XHR span with the fetch span
+					dedupedSpans[idx] = span
+				}
+
+				seenSpans.set(key, span)
+				continue
+			}
+		}
+
+		this.delegate.export(dedupedSpans, cb)
+	}
+
+	shutdown() {
+		return this.delegate.shutdown()
+	}
+
+	forceFlush() {
+		return this.delegate.forceFlush()
+	}
+
+	private _log(...data: any[]): void {
+		if (this.debug) {
+			console.log('::: [DeduplicatingExporter]', ...data)
+		}
+	}
+}

--- a/sdk/@launchdarkly/observability-react-native/src/otel/DeduplicatingExporter.ts
+++ b/sdk/@launchdarkly/observability-react-native/src/otel/DeduplicatingExporter.ts
@@ -47,12 +47,18 @@ export class DeduplicatingExporter implements SpanExporter {
 			const existingLib = existing.instrumentationLibrary.name
 
 			if (existingLib === FETCH_LIB && lib === XHR_LIB) {
-				this._log('fetch span seen - dropping xhr', span.name)
+				this._log(
+					'incoming XHR w/ fetch span seen - dropping XHR',
+					span.name,
+				)
 				continue
 			}
 
 			if (existingLib === XHR_LIB && lib === FETCH_LIB) {
-				this._log('xhr span seen - replacing with fetch', span.name)
+				this._log(
+					'incoming fetch w/ XHR span seen - replacing with fetch',
+					span.name,
+				)
 				const idx = dedupedSpans.indexOf(existing)
 
 				if (idx !== -1) {

--- a/sdk/@launchdarkly/observability-react-native/src/otel/DeduplicatingExporter.ts
+++ b/sdk/@launchdarkly/observability-react-native/src/otel/DeduplicatingExporter.ts
@@ -3,8 +3,8 @@ import { ReadableSpan } from '@opentelemetry/sdk-trace-web'
 import { SpanExporter } from '@opentelemetry/sdk-trace-web'
 import { ExportResult } from '@opentelemetry/core'
 
-const FETCH_LIB = '@opentelemetry/instrumentation-fetch'
-const XHR_LIB = '@opentelemetry/instrumentation-xml-http-request'
+export const FETCH_LIB = '@opentelemetry/instrumentation-fetch'
+export const XHR_LIB = '@opentelemetry/instrumentation-xml-http-request'
 
 export class DeduplicatingExporter implements SpanExporter {
 	constructor(

--- a/sdk/@launchdarkly/observability-react-native/src/otel/DeduplicatingExporter.ts
+++ b/sdk/@launchdarkly/observability-react-native/src/otel/DeduplicatingExporter.ts
@@ -84,7 +84,7 @@ export class DeduplicatingExporter implements SpanExporter {
 
 	private _log(...data: any[]): void {
 		if (this.debug) {
-			console.log('::: [DeduplicatingExporter]', ...data)
+			console.log('[DeduplicatingExporter]', ...data)
 		}
 	}
 }

--- a/sdk/@launchdarkly/observability-shared/LICENSE
+++ b/sdk/@launchdarkly/observability-shared/LICENSE
@@ -1,0 +1,3 @@
+UNLICENSED
+
+This package is for internal LaunchDarkly use only and is not licensed for external distribution or use.

--- a/sdk/@launchdarkly/observability-shared/README.md
+++ b/sdk/@launchdarkly/observability-shared/README.md
@@ -1,0 +1,12 @@
+# @launchdarkly/observability-shared
+
+**Internal Only – Not for Public Use**
+
+This package contains shared utilities, types, and code used by LaunchDarkly Observability SDKs. It is intended for internal use only and should not be published or consumed outside of LaunchDarkly SDK development.
+
+## Usage
+Import from this package within other LaunchDarkly Observability SDKs:
+
+```ts
+import { someSharedUtil } from '@launchdarkly/observability-shared';
+```

--- a/sdk/@launchdarkly/observability-shared/package.json
+++ b/sdk/@launchdarkly/observability-shared/package.json
@@ -1,0 +1,20 @@
+{
+	"name": "@launchdarkly/observability-shared",
+	"type": "module",
+	"main": "./src/index.ts",
+	"exports": {
+		".": "./src/index.ts"
+	},
+	"scripts": {
+		"build": "tsc",
+		"dev": "tsc --watch"
+	},
+	"devDependencies": {
+		"typescript": "^5.8.3"
+	},
+	"dependencies": {
+		"@opentelemetry/api": "^1.9.0",
+		"@opentelemetry/core": "^2.0.1",
+		"@opentelemetry/sdk-trace-web": "^2.0.1"
+	}
+}

--- a/sdk/@launchdarkly/observability-shared/package.json
+++ b/sdk/@launchdarkly/observability-shared/package.json
@@ -15,6 +15,7 @@
 	"dependencies": {
 		"@opentelemetry/api": "^1.9.0",
 		"@opentelemetry/core": "^2.0.1",
-		"@opentelemetry/sdk-trace-web": "^2.0.1"
+		"@opentelemetry/sdk-trace-web": "^2.0.1",
+		"graphql": "^16.11.0"
 	}
 }

--- a/sdk/@launchdarkly/observability-shared/src/index.ts
+++ b/sdk/@launchdarkly/observability-shared/src/index.ts
@@ -1,4 +1,4 @@
 export { RECORD_ATTRIBUTE } from './instrumentation/constants'
 export { CustomTraceContextPropagator } from './instrumentation/propagator'
-export { TracingOrigins } from './instrumentation/types'
+export type { TracingOrigins } from './instrumentation/types'
 export { getCorsUrlsPattern, getSpanName } from './instrumentation/utils'

--- a/sdk/@launchdarkly/observability-shared/src/index.ts
+++ b/sdk/@launchdarkly/observability-shared/src/index.ts
@@ -1,4 +1,4 @@
 export { RECORD_ATTRIBUTE } from './instrumentation/constants'
 export { CustomTraceContextPropagator } from './instrumentation/propagator'
 export { TracingOrigins } from './instrumentation/types'
-export { getCorsUrlsPattern } from './instrumentation/utils'
+export { getCorsUrlsPattern, getSpanName } from './instrumentation/utils'

--- a/sdk/@launchdarkly/observability-shared/src/index.ts
+++ b/sdk/@launchdarkly/observability-shared/src/index.ts
@@ -1,0 +1,4 @@
+export { RECORD_ATTRIBUTE } from './instrumentation/constants'
+export { CustomTraceContextPropagator } from './instrumentation/propagator'
+export { TracingOrigins } from './instrumentation/types'
+export { getCorsUrlsPattern } from './instrumentation/utils'

--- a/sdk/@launchdarkly/observability-shared/src/instrumentation/constants.ts
+++ b/sdk/@launchdarkly/observability-shared/src/instrumentation/constants.ts
@@ -1,0 +1,1 @@
+export const RECORD_ATTRIBUTE = 'launchdarkly.record'

--- a/sdk/@launchdarkly/observability-shared/src/instrumentation/propagator.ts
+++ b/sdk/@launchdarkly/observability-shared/src/instrumentation/propagator.ts
@@ -12,14 +12,14 @@ type CustomTraceContextPropagatorConfig = {
 }
 
 export class CustomTraceContextPropagator extends W3CTraceContextPropagator {
-	private highlightEndpoints: string[]
+	private internalEndpoints: string[]
 	private tracingOrigins: CustomTraceContextPropagatorConfig['tracingOrigins']
 	private urlBlocklist: CustomTraceContextPropagatorConfig['urlBlocklist']
 
 	constructor(config: CustomTraceContextPropagatorConfig) {
 		super()
 
-		this.highlightEndpoints = [
+		this.internalEndpoints = [
 			`${config.otlpEndpoint}/v1/traces`,
 			`${config.otlpEndpoint}/v1/logs`,
 			`${config.otlpEndpoint}/v1/metrics`,
@@ -42,7 +42,7 @@ export class CustomTraceContextPropagator extends W3CTraceContextPropagator {
 		if (typeof url === 'string') {
 			const shouldRecord = shouldRecordRequest(
 				url,
-				this.highlightEndpoints,
+				this.internalEndpoints,
 				this.tracingOrigins,
 				this.urlBlocklist,
 			)

--- a/sdk/@launchdarkly/observability-shared/src/instrumentation/propagator.ts
+++ b/sdk/@launchdarkly/observability-shared/src/instrumentation/propagator.ts
@@ -6,7 +6,7 @@ import { ReadableSpan } from '@opentelemetry/sdk-trace-web'
 import type { TracingOrigins } from './types'
 
 type CustomTraceContextPropagatorConfig = {
-	otlpEndpoint: string
+	internalEndpoints: string[]
 	tracingOrigins: TracingOrigins
 	urlBlocklist: string[]
 }
@@ -19,11 +19,7 @@ export class CustomTraceContextPropagator extends W3CTraceContextPropagator {
 	constructor(config: CustomTraceContextPropagatorConfig) {
 		super()
 
-		this.internalEndpoints = [
-			`${config.otlpEndpoint}/v1/traces`,
-			`${config.otlpEndpoint}/v1/logs`,
-			`${config.otlpEndpoint}/v1/metrics`,
-		]
+		this.internalEndpoints = config.internalEndpoints
 		this.tracingOrigins = config.tracingOrigins
 		this.urlBlocklist = config.urlBlocklist
 	}

--- a/sdk/@launchdarkly/observability-shared/src/instrumentation/propagator.ts
+++ b/sdk/@launchdarkly/observability-shared/src/instrumentation/propagator.ts
@@ -1,0 +1,66 @@
+import { W3CTraceContextPropagator } from '@opentelemetry/core'
+import * as api from '@opentelemetry/api'
+import { shouldNetworkRequestBeTraced, shouldRecordRequest } from './utils'
+import { RECORD_ATTRIBUTE } from './constants'
+import { ReadableSpan } from '@opentelemetry/sdk-trace-web'
+import type { TracingOrigins } from './types'
+
+type CustomTraceContextPropagatorConfig = {
+	otlpEndpoint: string
+	tracingOrigins: TracingOrigins
+	urlBlocklist: string[]
+}
+
+export class CustomTraceContextPropagator extends W3CTraceContextPropagator {
+	private highlightEndpoints: string[]
+	private tracingOrigins: CustomTraceContextPropagatorConfig['tracingOrigins']
+	private urlBlocklist: CustomTraceContextPropagatorConfig['urlBlocklist']
+
+	constructor(config: CustomTraceContextPropagatorConfig) {
+		super()
+
+		this.highlightEndpoints = [
+			`${config.otlpEndpoint}/v1/traces`,
+			`${config.otlpEndpoint}/v1/logs`,
+			`${config.otlpEndpoint}/v1/metrics`,
+		]
+		this.tracingOrigins = config.tracingOrigins
+		this.urlBlocklist = config.urlBlocklist
+	}
+
+	inject(
+		context: api.Context,
+		carrier: unknown,
+		setter: api.TextMapSetter,
+	): void {
+		const span = api.trace.getSpan(context)
+		if (!span || !(span as any).attributes) {
+			return
+		}
+
+		const url = (span as unknown as ReadableSpan).attributes['http.url']
+		if (typeof url === 'string') {
+			const shouldRecord = shouldRecordRequest(
+				url,
+				this.highlightEndpoints,
+				this.tracingOrigins,
+				this.urlBlocklist,
+			)
+
+			if (!shouldRecord) {
+				span.setAttribute(RECORD_ATTRIBUTE, false) // used later to avoid additional processing
+			}
+
+			const shouldTrace = shouldNetworkRequestBeTraced(
+				url,
+				this.tracingOrigins ?? [],
+				this.urlBlocklist,
+			)
+			if (!shouldTrace) {
+				return // return early to prevent headers from being injected
+			}
+		}
+
+		super.inject(context, carrier, setter)
+	}
+}

--- a/sdk/@launchdarkly/observability-shared/src/instrumentation/types.ts
+++ b/sdk/@launchdarkly/observability-shared/src/instrumentation/types.ts
@@ -1,0 +1,1 @@
+export type TracingOrigins = boolean | (string | RegExp)[]

--- a/sdk/@launchdarkly/observability-shared/src/instrumentation/utils.ts
+++ b/sdk/@launchdarkly/observability-shared/src/instrumentation/utils.ts
@@ -1,0 +1,110 @@
+import { isLDContextUrl } from '../launchdarkly/urlFilters'
+import { TracingOrigins } from './types'
+
+const isLaunchDarklyEventsNetworkResource = (name: string) => {
+	return ['events.ld.catamorphic.com', 'events.launchdarkly.com'].some(
+		(backendUrl) => name.toLocaleLowerCase().includes(backendUrl),
+	)
+}
+
+const isLaunchDarklyEvalNetworkResource = (name: string) => {
+	return isLDContextUrl(name)
+}
+
+/**
+ * Returns true if the name is a Highlight network resource.
+ * This is used to filter out Highlight requests/responses from showing up on end application's network resources.
+ */
+const isHighlightNetworkResourceFilter = (
+	name: string,
+	highlightEndpoints: string[],
+) =>
+	highlightEndpoints.some((backendUrl) =>
+		name.toLocaleLowerCase().includes(backendUrl),
+	)
+
+// Determines whether we store the network request and show it in the session
+// replay, including the body and headers.
+export const shouldNetworkRequestBeRecorded = (
+	url: string,
+	highlightEndpoints: string[],
+	_tracingOrigins?: boolean | (string | RegExp)[],
+) => {
+	return (
+		!isHighlightNetworkResourceFilter(url, highlightEndpoints) &&
+		!isLaunchDarklyEvalNetworkResource(url) &&
+		!isLaunchDarklyEventsNetworkResource(url)
+	)
+}
+
+// Determines whether we want to attach the x-highlight-request header to the
+// request. We want to avoid adding this to external requests.
+export const shouldNetworkRequestBeTraced = (
+	url: string,
+	tracingOrigins: boolean | (string | RegExp)[],
+	urlBlocklist: string[],
+) => {
+	if (
+		urlBlocklist.some((blockedUrl) =>
+			url.toLowerCase().includes(blockedUrl),
+		)
+	) {
+		return false
+	}
+	let patterns: (string | RegExp)[] = []
+	if (tracingOrigins === true) {
+		patterns = ['localhost', /^\//]
+		if (window?.location?.host) {
+			patterns.push(window.location.host)
+		}
+	} else if (tracingOrigins instanceof Array) {
+		patterns = tracingOrigins
+	}
+
+	let result = false
+	patterns.forEach((pattern) => {
+		if (url.match(pattern)) {
+			result = true
+		}
+	})
+	return result
+}
+
+export const shouldRecordRequest = (
+	url: string,
+	highlightEndpoints: string[],
+	tracingOrigins: TracingOrigins,
+	urlBlocklist: string[],
+) => {
+	const shouldRecordHeaderAndBody = !urlBlocklist?.some((blockedUrl) =>
+		url.toLowerCase().includes(blockedUrl),
+	)
+	if (!shouldRecordHeaderAndBody) {
+		return false
+	}
+
+	return shouldNetworkRequestBeRecorded(
+		url,
+		highlightEndpoints,
+		tracingOrigins,
+	)
+}
+
+// Helper to convert tracingOrigins to a RegExp or array of RegExp
+export function getCorsUrlsPattern(
+	tracingOrigins: TracingOrigins,
+): RegExp | RegExp[] {
+	if (tracingOrigins === true) {
+		const patterns = [/localhost/, /^\//]
+		if (typeof window !== 'undefined' && window.location?.host) {
+			patterns.push(new RegExp(window.location.host))
+		}
+		return patterns
+	} else if (Array.isArray(tracingOrigins)) {
+		return tracingOrigins.map((pattern) =>
+			typeof pattern === 'string' ? new RegExp(pattern) : pattern,
+		)
+	}
+
+	return /^$/ // Match nothing if tracingOrigins is false or undefined
+}

--- a/sdk/@launchdarkly/observability-shared/src/launchdarkly/urlFilters.ts
+++ b/sdk/@launchdarkly/observability-shared/src/launchdarkly/urlFilters.ts
@@ -1,0 +1,26 @@
+// based on https://github.com/launchdarkly/js-core/blob/main/packages/telemetry/browser-telemetry/src/filters/defaultUrlFilter.ts
+
+const pollingRegex = /sdk\/evalx\/[^/]+\/contexts\/(?<context>[^/?]*)\??.*?/
+const streamingRegex = /\/eval\/[^/]+\/(?<context>[^/?]*)\??.*?/
+
+/**
+ * Returns true for LD evaluation URLs that should not be recorded.
+ *
+ * @param url URL to filter.
+ * @returns true when the url is a sensitive url that should not be recorded.
+ */
+export function isLDContextUrl(url: string): boolean {
+	if (url.includes('/sdk/evalx')) {
+		const regexMatch = url.match(pollingRegex)
+		if (regexMatch) {
+			return true
+		}
+	}
+	if (url.includes('/eval/')) {
+		const regexMatch = url.match(streamingRegex)
+		if (regexMatch) {
+			return true
+		}
+	}
+	return false
+}

--- a/sdk/@launchdarkly/observability-shared/tsconfig.json
+++ b/sdk/@launchdarkly/observability-shared/tsconfig.json
@@ -1,0 +1,15 @@
+{
+	"compilerOptions": {
+		"declaration": true,
+		"declarationMap": true,
+		"emitDeclarationOnly": false,
+		"module": "esnext",
+		"moduleResolution": "node",
+		"preserveSymlinks": false,
+		"esModuleInterop": true,
+		"target": "ES2020",
+		"skipLibCheck": true
+	},
+	"include": ["src/**/*"],
+	"exclude": ["node_modules", "dist"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -8598,6 +8598,7 @@ __metadata:
     "@opentelemetry/api": "npm:^1.9.0"
     "@opentelemetry/core": "npm:^2.0.1"
     "@opentelemetry/sdk-trace-web": "npm:^2.0.1"
+    graphql: "npm:^16.11.0"
     typescript: "npm:^5.8.3"
   languageName: unknown
   linkType: soft
@@ -26592,6 +26593,13 @@ __metadata:
   peerDependencies:
     graphql: ">=0.11 <=16"
   checksum: 10/ab528f7451824902eba1b81105386855db4017a7bea523451155962fc3bec17196c83acce856e5955ce6675957a5c89049d4b141fa6f2f4fa88eab4841a57d68
+  languageName: node
+  linkType: hard
+
+"graphql@npm:^16.11.0":
+  version: 16.11.0
+  resolution: "graphql@npm:16.11.0"
+  checksum: 10/e3e1633d0b464bbb3fa41283fae938bd3bac801c350555b3f1a129d99fb3cfe157fa69c1389229dba902731942eb08bdea4b29f1271965feee8779576b26ef01
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11036,14 +11036,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/semantic-conventions@npm:^1.27.0, @opentelemetry/semantic-conventions@npm:^1.28.0, @opentelemetry/semantic-conventions@npm:^1.30.0":
-  version: 1.30.0
-  resolution: "@opentelemetry/semantic-conventions@npm:1.30.0"
-  checksum: 10/78df5976f5bcfd00acaea3e609cf06fdd34517ae8db994ae216aaac16c51af97ac22c534bfcbac5218e0086db83ec5ef6cc045b95626cc6ea807686bea549a41
-  languageName: node
-  linkType: hard
-
-"@opentelemetry/semantic-conventions@npm:^1.29.0":
+"@opentelemetry/semantic-conventions@npm:^1.27.0, @opentelemetry/semantic-conventions@npm:^1.28.0, @opentelemetry/semantic-conventions@npm:^1.29.0, @opentelemetry/semantic-conventions@npm:^1.30.0":
   version: 1.34.0
   resolution: "@opentelemetry/semantic-conventions@npm:1.34.0"
   checksum: 10/1892b4cc69c9e00456c809604a980e32696563e96463ff5f9d07e72d5aca73836a7378090509f28f54445ac6e072d2343a888c9d64d9ce287198e899082ff7aa
@@ -26596,17 +26589,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graphql@npm:^16.11.0":
+"graphql@npm:^16.11.0, graphql@npm:^16.8.1":
   version: 16.11.0
   resolution: "graphql@npm:16.11.0"
   checksum: 10/e3e1633d0b464bbb3fa41283fae938bd3bac801c350555b3f1a129d99fb3cfe157fa69c1389229dba902731942eb08bdea4b29f1271965feee8779576b26ef01
-  languageName: node
-  linkType: hard
-
-"graphql@npm:^16.8.1":
-  version: 16.8.1
-  resolution: "graphql@npm:16.8.1"
-  checksum: 10/7a09d3ec5f75061afe2bd2421a2d53cf37273d2ecaad8f34febea1f1ac205dfec2834aec3419fa0a10fcc9fb345863b2f893562fb07ea825da2ae82f6392893c
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8557,6 +8557,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@launchdarkly/observability-react-native@workspace:sdk/@launchdarkly/observability-react-native"
   dependencies:
+    "@launchdarkly/observability-shared": "workspace:*"
     "@launchdarkly/react-native-client-sdk": "npm:^10.0.0"
     "@opentelemetry/api": "npm:^1.9.0"
     "@opentelemetry/exporter-trace-otlp-http": "npm:^0.56.0"
@@ -8586,6 +8587,17 @@ __metadata:
     prettier: "npm:^3.5.3"
     pretty-quick: "npm:^4.1.1"
     turbo: "npm:^2.5.0"
+    typescript: "npm:^5.8.3"
+  languageName: unknown
+  linkType: soft
+
+"@launchdarkly/observability-shared@workspace:*, @launchdarkly/observability-shared@workspace:sdk/@launchdarkly/observability-shared":
+  version: 0.0.0-use.local
+  resolution: "@launchdarkly/observability-shared@workspace:sdk/@launchdarkly/observability-shared"
+  dependencies:
+    "@opentelemetry/api": "npm:^1.9.0"
+    "@opentelemetry/core": "npm:^2.0.1"
+    "@opentelemetry/sdk-trace-web": "npm:^2.0.1"
     typescript: "npm:^5.8.3"
   languageName: unknown
   linkType: soft
@@ -9854,6 +9866,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@opentelemetry/core@npm:2.0.1, @opentelemetry/core@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "@opentelemetry/core@npm:2.0.1"
+  dependencies:
+    "@opentelemetry/semantic-conventions": "npm:^1.29.0"
+  peerDependencies:
+    "@opentelemetry/api": ">=1.0.0 <1.10.0"
+  checksum: 10/dd891afd427067a9e6c610c36ab5638b0b9e5303ccca7c75ad744f5db53c6162a4b5d9cd2f5a77cdc3e4bda2eae850a4e29983ea244c929b7b872b7e086fc61c
+  languageName: node
+  linkType: hard
+
 "@opentelemetry/exporter-jaeger@npm:^1.30.1":
   version: 1.30.1
   resolution: "@opentelemetry/exporter-jaeger@npm:1.30.1"
@@ -10833,6 +10856,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@opentelemetry/resources@npm:2.0.1":
+  version: 2.0.1
+  resolution: "@opentelemetry/resources@npm:2.0.1"
+  dependencies:
+    "@opentelemetry/core": "npm:2.0.1"
+    "@opentelemetry/semantic-conventions": "npm:^1.29.0"
+  peerDependencies:
+    "@opentelemetry/api": ">=1.3.0 <1.10.0"
+  checksum: 10/282f3831de2755d0fda2d8b6e37f9587ea248066d50c7d2f14c803ac9d5262a0f1db98a4185bcdc5acaeeece0b61f4fce43bc3896a79f1da79045ae4928618bf
+  languageName: node
+  linkType: hard
+
 "@opentelemetry/sdk-logs@npm:0.56.0":
   version: 0.56.0
   resolution: "@opentelemetry/sdk-logs@npm:0.56.0"
@@ -10939,6 +10974,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@opentelemetry/sdk-trace-base@npm:2.0.1":
+  version: 2.0.1
+  resolution: "@opentelemetry/sdk-trace-base@npm:2.0.1"
+  dependencies:
+    "@opentelemetry/core": "npm:2.0.1"
+    "@opentelemetry/resources": "npm:2.0.1"
+    "@opentelemetry/semantic-conventions": "npm:^1.29.0"
+  peerDependencies:
+    "@opentelemetry/api": ">=1.3.0 <1.10.0"
+  checksum: 10/9de1e36bbce9bd7c0563e6395765fffc0f8c78806cb33cc95267e98dffd82de33857a51288073a104c10418b934e51560bcb5dcaf4e63e5c9e096f65cadd42cd
+  languageName: node
+  linkType: hard
+
 "@opentelemetry/sdk-trace-node@npm:1.30.1":
   version: 1.30.1
   resolution: "@opentelemetry/sdk-trace-node@npm:1.30.1"
@@ -10968,6 +11016,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@opentelemetry/sdk-trace-web@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "@opentelemetry/sdk-trace-web@npm:2.0.1"
+  dependencies:
+    "@opentelemetry/core": "npm:2.0.1"
+    "@opentelemetry/sdk-trace-base": "npm:2.0.1"
+  peerDependencies:
+    "@opentelemetry/api": ">=1.0.0 <1.10.0"
+  checksum: 10/49f0dafd416c6fb3355ff7e9be2488e70650e1b8bd5ae6180a4b4230b16b616770cd59591bf2650b849c59e36b8f0278d97f57d090df262d4249ffd427324f08
+  languageName: node
+  linkType: hard
+
 "@opentelemetry/semantic-conventions@npm:1.28.0":
   version: 1.28.0
   resolution: "@opentelemetry/semantic-conventions@npm:1.28.0"
@@ -10979,6 +11039,13 @@ __metadata:
   version: 1.30.0
   resolution: "@opentelemetry/semantic-conventions@npm:1.30.0"
   checksum: 10/78df5976f5bcfd00acaea3e609cf06fdd34517ae8db994ae216aaac16c51af97ac22c534bfcbac5218e0086db83ec5ef6cc045b95626cc6ea807686bea549a41
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/semantic-conventions@npm:^1.29.0":
+  version: 1.34.0
+  resolution: "@opentelemetry/semantic-conventions@npm:1.34.0"
+  checksum: 10/1892b4cc69c9e00456c809604a980e32696563e96463ff5f9d07e72d5aca73836a7378090509f28f54445ac6e072d2343a888c9d64d9ce287198e899082ff7aa
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

* Adds `tracingOrigins` config
* Adds `urlBlocklist` config
* Improves span deduplication logic
* Improves span naming
* Adds debug logging in custom processor and exporter
* Creates an internal package for sharing code between JS client SDKs
* Drops the design question from the PR template

## How did you test this change?

Local click test with debug mode enabled.

## Are there any deployment considerations?

N/A - this is only updating a package that is currently in alpha.