### PR TITLE
introduce LDObserve.stop api

### DIFF
--- a/.changeset/hungry-items-clap.md
+++ b/.changeset/hungry-items-clap.md
@@ -1,0 +1,6 @@
+---
+'@launchdarkly/observability': patch
+'@launchdarkly/session-replay': patch
+---
+
+introduce LDObserve.stop api

--- a/e2e/react-router/src/routes/root.tsx
+++ b/e2e/react-router/src/routes/root.tsx
@@ -270,6 +270,20 @@ export default function Root() {
 			>
 				recordObservability
 			</button>
+			<button
+				onClick={async () => {
+					LDRecord.stop()
+				}}
+			>
+				LDRecord.stop()
+			</button>
+			<button
+				onClick={async () => {
+					LDObserve.stop()
+				}}
+			>
+				LDObserve.stop()
+			</button>
 		</div>
 	)
 }

--- a/sdk/highlight-run/src/api/observe.ts
+++ b/sdk/highlight-run/src/api/observe.ts
@@ -11,6 +11,10 @@ export interface Observe {
 	 */
 	start: () => Promise<void>
 	/**
+	 * Stop the observability data capture.
+	 */
+	stop: () => Promise<void>
+	/**
 	 * Record arbitrary metric values via as a Gauge.
 	 * A Gauge records any point-in-time measurement, such as the current CPU utilization %.
 	 * Values with the same metric name and attributes are aggregated via the OTel SDK.

--- a/sdk/highlight-run/src/client/otel/index.ts
+++ b/sdk/highlight-run/src/client/otel/index.ts
@@ -331,6 +331,8 @@ export const setupBrowserTracing = (
 			],
 		}),
 	})
+
+	return providers
 }
 
 class CustomBatchSpanProcessor extends BatchSpanProcessor {

--- a/sdk/highlight-run/src/sdk/LDObserve.ts
+++ b/sdk/highlight-run/src/sdk/LDObserve.ts
@@ -13,6 +13,11 @@ class _LDObserve extends BufferedClass<Observe> implements Observe {
 		return this._sdk.start()
 	}
 
+	stop() {
+		// avoid buffering the stop call
+		return this._sdk.stop()
+	}
+
 	recordGauge(metric: Metric) {
 		return this._bufferCall('recordGauge', [metric])
 	}

--- a/sdk/highlight-run/src/sdk/LDRecord.ts
+++ b/sdk/highlight-run/src/sdk/LDRecord.ts
@@ -15,8 +15,9 @@ class _LDRecord extends BufferedClass<Record> implements Record {
 		return this._sdk.start(options)
 	}
 
-	stop(options?: StartOptions) {
-		return this._bufferCall('stop', [options])
+	stop() {
+		// avoid buffering the stop call
+		return this._sdk.stop()
 	}
 
 	getRecordingState() {


### PR DESCRIPTION
## Summary

Add `LDObserve.stop()` to allow customers to stop observability tracking

## How did you test this change?

local
https://www.loom.com/share/9a5f9c8f10c04813a21bdfebb7a09439

## Are there any deployment considerations?

changeset
