### PR TITLE
cleanup old sessionData_ localStorage values

### DIFF
--- a/.changeset/swift-dodos-watch.md
+++ b/.changeset/swift-dodos-watch.md
@@ -1,0 +1,7 @@
+---
+'highlight.run': patch
+'@launchdarkly/observability': patch
+'@launchdarkly/session-replay': patch
+---
+
+delete sessionData\_ localstorage values to avoid overfilling quota

--- a/sdk/highlight-run/src/client/utils/sessionStorage/highlightSession.ts
+++ b/sdk/highlight-run/src/client/utils/sessionStorage/highlightSession.ts
@@ -76,7 +76,10 @@ export const setSessionData = function (sessionData?: SessionData) {
 	if (!sessionData?.sessionSecureID) return
 	const secureID = sessionData.sessionSecureID!
 	setPersistentSessionSecureID(secureID)
-	setItem(getSessionDataKey(secureID), JSON.stringify(sessionData))
+	const key = getSessionDataKey(secureID)
+	setItem(key, JSON.stringify(sessionData))
+	// delete old session data
+	pruneSessionData(key)
 }
 
 export const loadCookieSessionData = function () {
@@ -89,4 +92,16 @@ export const loadCookieSessionData = function () {
 	try {
 		setSessionData(JSON.parse(sessionDataStr) as SessionData)
 	} catch (e) {}
+}
+
+function pruneSessionData(keepKey: string): void {
+	const prefix = `${SESSION_STORAGE_KEYS.SESSION_DATA}_`
+
+	// Walk backwards so index order isn’t upset by removals.
+	for (let i = localStorage.length - 1; i >= 0; i--) {
+		const key = localStorage.key(i)
+		if (key && key.startsWith(prefix) && key !== keepKey) {
+			localStorage.removeItem(key)
+		}
+	}
 }

--- a/sdk/highlight-run/src/client/utils/sessionStorage/highlightSession.ts
+++ b/sdk/highlight-run/src/client/utils/sessionStorage/highlightSession.ts
@@ -1,5 +1,11 @@
 import { SESSION_PUSH_THRESHOLD } from '../../constants/sessions'
-import { cookieStorage, getItem, removeItem, setItem } from '../storage'
+import {
+	cookieStorage,
+	getItem,
+	removeItem,
+	setItem,
+	getPersistentStorage,
+} from '../storage'
 import { SESSION_STORAGE_KEYS } from './sessionStorageKeys'
 
 export type SessionData = {
@@ -98,15 +104,15 @@ function pruneSessionData(keepKey: string): void {
 	const prefix = `${SESSION_STORAGE_KEYS.SESSION_DATA}_`
 
 	// Walk backwards so index order isn’t upset by removals.
-	for (let i = localStorage.length - 1; i >= 0; i--) {
-		const key = localStorage.key(i)
+	for (let i = getPersistentStorage().length - 1; i >= 0; i--) {
+		const key = getPersistentStorage().key(i)
 		if (key && key.startsWith(prefix) && key !== keepKey) {
 			const sessionData = JSON.parse(getItem(key) || '{}') as SessionData
 			if (
 				sessionData.lastPushTime &&
 				Date.now() - sessionData.lastPushTime >= SESSION_PUSH_THRESHOLD
 			) {
-				localStorage.removeItem(key)
+				removeItem(key)
 			}
 		}
 	}

--- a/sdk/highlight-run/src/client/utils/sessionStorage/highlightSession.ts
+++ b/sdk/highlight-run/src/client/utils/sessionStorage/highlightSession.ts
@@ -101,7 +101,13 @@ function pruneSessionData(keepKey: string): void {
 	for (let i = localStorage.length - 1; i >= 0; i--) {
 		const key = localStorage.key(i)
 		if (key && key.startsWith(prefix) && key !== keepKey) {
-			localStorage.removeItem(key)
+			const sessionData = JSON.parse(getItem(key) || '{}') as SessionData
+			if (
+				sessionData.lastPushTime &&
+				Date.now() - sessionData.lastPushTime >= SESSION_PUSH_THRESHOLD
+			) {
+				localStorage.removeItem(key)
+			}
 		}
 	}
 }

--- a/sdk/highlight-run/src/client/utils/sessionStorage/highlightSession.ts
+++ b/sdk/highlight-run/src/client/utils/sessionStorage/highlightSession.ts
@@ -112,10 +112,16 @@ function pruneSessionData(keepKey: string): void {
 				const sessionData = JSON.parse(
 					getItem(key) || '{}',
 				) as SessionData
-				if (
-					sessionData.lastPushTime &&
+				if (sessionData.lastPushTime === undefined) {
+					internalLogOnce(
+						'highlightSession',
+						'pruneSessionData',
+						'error',
+						`data for key ${key} is not session data`,
+					)
+				} else if (
 					Date.now() - sessionData.lastPushTime >=
-						SESSION_PUSH_THRESHOLD
+					SESSION_PUSH_THRESHOLD
 				) {
 					internalLogOnce(
 						'highlightSession',
@@ -133,7 +139,6 @@ function pruneSessionData(keepKey: string): void {
 					`failed to parse session data for key ${key}`,
 					e,
 				)
-				removeItem(key)
 			}
 		}
 	}

--- a/sdk/highlight-run/src/client/utils/storage.ts
+++ b/sdk/highlight-run/src/client/utils/storage.ts
@@ -13,6 +13,16 @@ let cookieWriteEnabled: boolean = true
 
 class Storage {
 	private storage: { [key: string]: string } = {}
+
+	public get length(): number {
+		return Object.keys(this.storage).length
+	}
+
+	public key(index: number): string | null {
+		const keys = Object.keys(this.storage)
+		return keys[index] ?? null
+	}
+
 	public getItem(key: string) {
 		return this.storage[key] ?? ''
 	}
@@ -49,7 +59,7 @@ export class CookieStorage {
 export const globalStorage = new Storage()
 export const cookieStorage = new CookieStorage()
 
-const getPersistentStorage = () => {
+export const getPersistentStorage = () => {
 	let storage:
 		| Storage
 		| typeof window.localStorage


### PR DESCRIPTION
## Summary

Duplicate tabs would not clean up their old localStorage values, leading to issues where we would
exceed localStorage quota.

## How did you test this change?

local deploy
https://www.loom.com/share/9c351101df184660a24433325f82bba4

## Are there any deployment considerations?

changeset
