### PR TITLE
Add docs publishing for observability-node.

### DIFF
--- a/.github/workflows/manual-publish-docs.yml
+++ b/.github/workflows/manual-publish-docs.yml
@@ -1,20 +1,20 @@
 name: Manual Publish Docs
 on:
-  workflow_dispatch:
-    inputs:
-      workspace_path:
-        description: 'Path to the workspace being released.'
-        required: true
-        type: choice
-        options:
-          - sdk/highlight-run
-          - "sdk/@launchdarkly/observability-node"
-  workflow_call:
-    inputs:
-      workspace_path:
-        description: 'Path to the workspace being released.'
-        required: true
-        type: string
+    workflow_dispatch:
+        inputs:
+            workspace_path:
+                description: 'Path to the workspace being released.'
+                required: true
+                type: choice
+                options:
+                    - sdk/highlight-run
+                    - 'sdk/@launchdarkly/observability-node'
+    workflow_call:
+        inputs:
+            workspace_path:
+                description: 'Path to the workspace being released.'
+                required: true
+                type: string
 
 permissions:
     id-token: write
@@ -42,8 +42,8 @@ jobs:
             - name: 'Set WORKSPACE_NAME variable'
               shell: bash
               run: |
-                WORKSPACE_NAME=$(./scripts/package-name.sh ${{ inputs.workspace_path }})
-                echo "WORKSPACE_NAME=$WORKSPACE_NAME" >> $GITHUB_ENV        
+                  WORKSPACE_NAME=$(./scripts/package-name.sh ${{ inputs.workspace_path }})
+                  echo "WORKSPACE_NAME=$WORKSPACE_NAME" >> $GITHUB_ENV
 
             - name: Build docs
               run: yarn docs --filter ${{ env.WORKSPACE_NAME }}

--- a/.github/workflows/manual-publish-docs.yml
+++ b/.github/workflows/manual-publish-docs.yml
@@ -1,6 +1,20 @@
 name: Manual Publish Docs
 on:
-    workflow_dispatch:
+  workflow_dispatch:
+    inputs:
+      workspace_path:
+        description: 'Path to the workspace being released.'
+        required: true
+        type: choice
+        options:
+          - sdk/highlight-run
+          - "sdk/@launchdarkly/observability-node"
+  workflow_call:
+    inputs:
+      workspace_path:
+        description: 'Path to the workspace being released.'
+        required: true
+        type: string
 
 permissions:
     id-token: write
@@ -25,12 +39,26 @@ jobs:
               env:
                   PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: true
 
-            - name: Build docs
-              run: yarn docs --filter highlight.run
+            - name: 'Set WORKSPACE_NAME variable'
+              shell: bash
+              run: |
+                WORKSPACE_NAME=$(./scripts/package-name.sh ${{ inputs.workspace_path }})
+                echo "WORKSPACE_NAME=$WORKSPACE_NAME" >> $GITHUB_ENV        
 
-            - uses: launchdarkly/gh-actions/actions/publish-pages@publish-pages-v1.0.2
-              name: 'Publish to Github pages'
+            - name: Build docs
+              run: yarn docs --filter ${{ env.WORKSPACE_NAME }}
+
+            - name: Publish Highlight.run as Observability Plugin
+              if: inputs.workspace_path == 'sdk/highlight-run'
+              uses: launchdarkly/gh-actions/actions/publish-pages@publish-pages-v1.0.2
               with:
                   docs_path: sdk/highlight-run/docs
                   output_path: packages/@launchdarkly/observability
+                  github_token: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Publish other JS packages
+              if: inputs.workspace_path != 'sdk/highlight-run'
+              uses: launchdarkly/gh-actions/actions/publish-pages@publish-pages-v1.0.2
+              with:
+                  docs_path: ${{ inputs.workspace_path }}/docs
                   github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/manual-publish-docs.yml
+++ b/.github/workflows/manual-publish-docs.yml
@@ -61,4 +61,5 @@ jobs:
               uses: launchdarkly/gh-actions/actions/publish-pages@publish-pages-v1.0.2
               with:
                   docs_path: ${{ inputs.workspace_path }}/docs
+                  output_path: ${{ inputs.workspace_path }}
                   github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -96,7 +96,6 @@ jobs:
 
     publish-highlight-run-docs:
         name: Publish Highlight.run Docs
-        # if: github.ref == 'refs/heads/main'
         uses: ./.github/workflows/manual-publish-docs.yml
         with:
             workspace_path: sdk/highlight-run
@@ -104,8 +103,6 @@ jobs:
     publish-observability-node-docs:
         # Run the docs publish after the highlight.run docs are published.
         needs: publish-highlight-run-docs
-        # Runs the job even if the highlight.run docs publish fails.
-        # if: ${{ always() && !cancelled() && github.ref == 'refs/heads/main'}}
         name: Publish @launchdarkly/observability-node Docs
         uses: ./.github/workflows/manual-publish-docs.yml
         with:

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -96,6 +96,7 @@ jobs:
 
     publish-highlight-run-docs:
         name: Publish Highlight.run Docs
+        if: github.ref == 'refs/heads/main'
         uses: ./.github/workflows/manual-publish-docs.yml
         with:
             workspace_path: sdk/highlight-run
@@ -103,6 +104,8 @@ jobs:
     publish-observability-node-docs:
         # Run the docs publish after the highlight.run docs are published.
         needs: publish-highlight-run-docs
+        # Runs the job even if the highlight.run docs publish fails.
+        if: ${{ always() && !cancelled() && github.ref == 'refs/heads/main'}}
         name: Publish @launchdarkly/observability-node Docs
         uses: ./.github/workflows/manual-publish-docs.yml
         with:

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -66,13 +66,13 @@ jobs:
               if: github.ref == 'refs/heads/main'
               uses: ./.github/workflows/manual-publish-docs.yml
               with:
-                workspace_path: sdk/highlight-run
+                  workspace_path: sdk/highlight-run
 
             - name: Publish @launchdarkly/observability-node Docs
               if: github.ref == 'refs/heads/main'
               uses: ./.github/workflows/manual-publish-docs.yml
               with:
-                workspace_path: sdk/@launchdarkly/observability-node
+                  workspace_path: sdk/@launchdarkly/observability-node
 
             - uses: launchdarkly/gh-actions/actions/release-secrets@release-secrets-v1.2.0
               if: github.ref == 'refs/heads/main'

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -62,18 +62,6 @@ jobs:
               if: github.ref == 'refs/heads/main'
               run: yarn publish:highlight
 
-            - name: Publish Highlight.run Docs
-              if: github.ref == 'refs/heads/main'
-              uses: ./.github/workflows/manual-publish-docs.yml
-              with:
-                  workspace_path: sdk/highlight-run
-
-            - name: Publish @launchdarkly/observability-node Docs
-              if: github.ref == 'refs/heads/main'
-              uses: ./.github/workflows/manual-publish-docs.yml
-              with:
-                  workspace_path: sdk/@launchdarkly/observability-node
-
             - uses: launchdarkly/gh-actions/actions/release-secrets@release-secrets-v1.2.0
               if: github.ref == 'refs/heads/main'
               name: 'Get NPM token'
@@ -105,3 +93,20 @@ jobs:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   NPM_TOKEN: ${{ secrets.NPM_TOKEN_HIGHLIGHT_RUN }}
                   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_HIGHLIGHT_RUN }}
+
+    publish-highlight-run-docs:
+        name: Publish Highlight.run Docs
+        if: github.ref == 'refs/heads/main'
+        uses: ./.github/workflows/manual-publish-docs.yml
+        with:
+            workspace_path: sdk/highlight-run
+
+    publish-observability-node-docs:
+        # Run the docs publish after the highlight.run docs are published.
+        needs: publish-highlight-run-docs
+        # Runs the job even if the highlight.run docs publish fails.
+        if: ${{ always() && !failure() && !cancelled() && github.ref == 'refs/heads/main'}}
+        name: Publish @launchdarkly/observability-node Docs
+        uses: ./.github/workflows/manual-publish-docs.yml
+        with:
+            workspace_path: sdk/@launchdarkly/observability-node

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -62,6 +62,18 @@ jobs:
               if: github.ref == 'refs/heads/main'
               run: yarn publish:highlight
 
+            - name: Publish Highlight.run Docs
+              if: github.ref == 'refs/heads/main'
+              uses: ./.github/workflows/manual-publish-docs.yml
+              with:
+                workspace_path: sdk/highlight-run
+
+            - name: Publish @launchdarkly/observability-node Docs
+              if: github.ref == 'refs/heads/main'
+              uses: ./.github/workflows/manual-publish-docs.yml
+              with:
+                workspace_path: sdk/@launchdarkly/observability-node
+
             - uses: launchdarkly/gh-actions/actions/release-secrets@release-secrets-v1.2.0
               if: github.ref == 'refs/heads/main'
               name: 'Get NPM token'

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -96,7 +96,7 @@ jobs:
 
     publish-highlight-run-docs:
         name: Publish Highlight.run Docs
-        if: github.ref == 'refs/heads/main'
+        # if: github.ref == 'refs/heads/main'
         uses: ./.github/workflows/manual-publish-docs.yml
         with:
             workspace_path: sdk/highlight-run
@@ -105,7 +105,7 @@ jobs:
         # Run the docs publish after the highlight.run docs are published.
         needs: publish-highlight-run-docs
         # Runs the job even if the highlight.run docs publish fails.
-        if: ${{ always() && !failure() && !cancelled() && github.ref == 'refs/heads/main'}}
+        # if: ${{ always() && !cancelled() && github.ref == 'refs/heads/main'}}
         name: Publish @launchdarkly/observability-node Docs
         uses: ./.github/workflows/manual-publish-docs.yml
         with:

--- a/scripts/package-name.sh
+++ b/scripts/package-name.sh
@@ -1,0 +1,8 @@
+# Given a path get the name of the package.
+# ./scripts/package-name.sh packages/sdk/server-node
+# Produces something like:
+# @launchdarkly/node-server-sdk
+
+set -e
+
+node -p "require('./$1/package.json').name";

--- a/sdk/@launchdarkly/observability-node/README.md
+++ b/sdk/@launchdarkly/observability-node/README.md
@@ -4,6 +4,7 @@
 [![Actions Status][o11y-sdk-ci-badge]][o11y-sdk-ci]
 [![NPM][o11y-sdk-dm-badge]][o11y-sdk-npm-link]
 [![NPM][o11y-sdk-dt-badge]][o11y-sdk-npm-link]
+[![Documentation](https://img.shields.io/static/v1?label=GitHub+Pages&message=API+reference&color=00add8)][o11y-docs-link]
 
 **NB: APIs are subject to change until a 1.x version is released.**
 
@@ -64,3 +65,4 @@ LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply
 [o11y-sdk-npm-link]: https://www.npmjs.com/package/@launchdarkly/observability-node
 [o11y-sdk-dm-badge]: https://img.shields.io/npm/dm/@launchdarkly/observability-node.svg?style=flat-square
 [o11y-sdk-dt-badge]: https://img.shields.io/npm/dt/@launchdarkly/observability-node.svg?style=flat-square
+[o11y-docs-link]: https://launchdarkly.github.io/observability-sdk/sdk/@launchdarkly/observability-node/

--- a/sdk/@launchdarkly/observability-node/package.json
+++ b/sdk/@launchdarkly/observability-node/package.json
@@ -12,7 +12,7 @@
 		"build": "rollup --config rollup.config.mjs",
 		"test": "vitest run",
 		"codegen": "graphql-codegen",
-		"doc": "typedoc --options ./typedoc.json"
+		"docs": "typedoc --options ./typedoc.json"
 	},
 	"main": "./dist/index.cjs",
 	"module": "./dist/index.js",


### PR DESCRIPTION
## Summary

Adds publishing of docs for `@launchdarkly/observability-node`.
https://launchdarkly.github.io/observability-sdk/sdk/@launchdarkly/observability-node/


Automatically publishes docs on turbo repo build.

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
