### PR TITLE
Independent concurrency groups for monorepo build and docs.

### DIFF
--- a/.github/workflows/manual-publish-docs.yml
+++ b/.github/workflows/manual-publish-docs.yml
@@ -17,7 +17,6 @@ on:
                 type: string
 
 permissions:
-    id-token: write
     contents: write
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,4 +1,4 @@
-name: Monorepo
+name: Publish Docs
 
 on:
     push:

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,0 +1,28 @@
+name: Monorepo
+
+on:
+    push:
+        branches: ['main', 'rlamb/monorepo-concurrency-group']
+
+permissions:
+    contents: write
+
+jobs:
+    publish-highlight-run-docs:
+        concurrency: ${{ github.workflow }}-${{ github.ref }}-publish-highlight-run-docs
+        name: Publish Highlight.run Docs
+        # if: github.ref == 'refs/heads/main'
+        uses: ./.github/workflows/manual-publish-docs.yml
+        with:
+            workspace_path: sdk/highlight-run
+
+    publish-observability-node-docs:
+        concurrency: ${{ github.workflow }}-${{ github.ref }}-publish-observability-node-docs
+        # Run the docs publish after the highlight.run docs are published.
+        needs: publish-highlight-run-docs
+        # Runs the job even if the highlight.run docs publish fails.
+        # if: ${{ always() && !cancelled() && github.ref == 'refs/heads/main'}}
+        name: Publish @launchdarkly/observability-node Docs
+        uses: ./.github/workflows/manual-publish-docs.yml
+        with:
+            workspace_path: sdk/@launchdarkly/observability-node

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -2,7 +2,7 @@ name: Publish Docs
 
 on:
     push:
-        branches: ['main', 'rlamb/monorepo-concurrency-group']
+        branches: ['main']
 
 permissions:
     contents: write
@@ -11,7 +11,7 @@ jobs:
     publish-highlight-run-docs:
         concurrency: ${{ github.workflow }}-${{ github.ref }}-publish-highlight-run-docs
         name: Publish Highlight.run Docs
-        # if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main'
         uses: ./.github/workflows/manual-publish-docs.yml
         with:
             workspace_path: sdk/highlight-run
@@ -21,7 +21,7 @@ jobs:
         # Run the docs publish after the highlight.run docs are published.
         needs: publish-highlight-run-docs
         # Runs the job even if the highlight.run docs publish fails.
-        # if: ${{ always() && !cancelled() && github.ref == 'refs/heads/main'}}
+        if: ${{ always() && !cancelled() && github.ref == 'refs/heads/main'}}
         name: Publish @launchdarkly/observability-node Docs
         uses: ./.github/workflows/manual-publish-docs.yml
         with:

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -13,9 +13,11 @@ permissions:
     pull-requests: write
     issues: read
 
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
 jobs:
     yarn-monorepo:
-        concurrency: ${{ github.workflow }}-${{ github.ref }}
+
         name: Build Yarn Turborepo
         timeout-minutes: 60
         runs-on: ubuntu-22.04-8core-32gb
@@ -93,22 +95,3 @@ jobs:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   NPM_TOKEN: ${{ secrets.NPM_TOKEN_HIGHLIGHT_RUN }}
                   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_HIGHLIGHT_RUN }}
-
-    publish-highlight-run-docs:
-        concurrency: ${{ github.workflow }}-${{ github.ref }}-publish-highlight-run-docs
-        name: Publish Highlight.run Docs
-        # if: github.ref == 'refs/heads/main'
-        uses: ./.github/workflows/manual-publish-docs.yml
-        with:
-            workspace_path: sdk/highlight-run
-
-    publish-observability-node-docs:
-        concurrency: ${{ github.workflow }}-${{ github.ref }}-publish-observability-node-docs
-        # Run the docs publish after the highlight.run docs are published.
-        needs: publish-highlight-run-docs
-        # Runs the job even if the highlight.run docs publish fails.
-        # if: ${{ always() && !cancelled() && github.ref == 'refs/heads/main'}}
-        name: Publish @launchdarkly/observability-node Docs
-        uses: ./.github/workflows/manual-publish-docs.yml
-        with:
-            workspace_path: sdk/@launchdarkly/observability-node

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -97,7 +97,7 @@ jobs:
     publish-highlight-run-docs:
         concurrency: ${{ github.workflow }}-${{ github.ref }}-publish-highlight-run-docs
         name: Publish Highlight.run Docs
-        if: github.ref == 'refs/heads/main'
+        # if: github.ref == 'refs/heads/main'
         uses: ./.github/workflows/manual-publish-docs.yml
         with:
             workspace_path: sdk/highlight-run
@@ -107,7 +107,7 @@ jobs:
         # Run the docs publish after the highlight.run docs are published.
         needs: publish-highlight-run-docs
         # Runs the job even if the highlight.run docs publish fails.
-        if: ${{ always() && !cancelled() && github.ref == 'refs/heads/main'}}
+        # if: ${{ always() && !cancelled() && github.ref == 'refs/heads/main'}}
         name: Publish @launchdarkly/observability-node Docs
         uses: ./.github/workflows/manual-publish-docs.yml
         with:

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -13,9 +13,9 @@ permissions:
     pull-requests: write
     issues: read
 
-concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
     yarn-monorepo:
+        concurrency: ${{ github.workflow }}-${{ github.ref }}
         name: Build Yarn Turborepo
         timeout-minutes: 60
         runs-on: ubuntu-22.04-8core-32gb
@@ -95,6 +95,7 @@ jobs:
                   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_HIGHLIGHT_RUN }}
 
     publish-highlight-run-docs:
+        concurrency: ${{ github.workflow }}-${{ github.ref }}-publish-highlight-run-docs
         name: Publish Highlight.run Docs
         if: github.ref == 'refs/heads/main'
         uses: ./.github/workflows/manual-publish-docs.yml
@@ -102,6 +103,7 @@ jobs:
             workspace_path: sdk/highlight-run
 
     publish-observability-node-docs:
+        concurrency: ${{ github.workflow }}-${{ github.ref }}-publish-observability-node-docs
         # Run the docs publish after the highlight.run docs are published.
         needs: publish-highlight-run-docs
         # Runs the job even if the highlight.run docs publish fails.

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -14,10 +14,8 @@ permissions:
     issues: read
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
-
 jobs:
     yarn-monorepo:
-
         name: Build Yarn Turborepo
         timeout-minutes: 60
         runs-on: ubuntu-22.04-8core-32gb


### PR DESCRIPTION
## Summary

Attempt to resolve concurrency group issue.
Representative build: https://github.com/launchdarkly/observability-sdk/actions/runs/16329406252

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
