### PR TITLE
chore: Use shared action to build and publish to allow manual releases.

### DIFF
--- a/.github/actions/publish-python-sdk/action.yml
+++ b/.github/actions/publish-python-sdk/action.yml
@@ -58,5 +58,5 @@ runs:
 
         - name: Publish package distributions to PyPI
           run: |
-              poetry config pypi-token.pypi ${{ secrets.PYPI_AUTH_TOKEN }}
+              poetry config pypi-token.pypi ${{ env.PYPI_AUTH_TOKEN }}
               poetry publish --build

--- a/.github/actions/publish-python-sdk/action.yml
+++ b/.github/actions/publish-python-sdk/action.yml
@@ -57,7 +57,6 @@ runs:
               echo "package-hashes=$(sha256sum * | base64 -w0)" >> "$GITHUB_OUTPUT"
 
         - name: Publish package distributions to PyPI
-          uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc
-          with:
-              packages-dir: ./${{ inputs.workspace-path }}/dist
-              password: ${{env.PYPI_AUTH_TOKEN}}
+          run: |
+              poetry config pypi-token.pypi ${{ secrets.PYPI_AUTH_TOKEN }}
+              poetry publish --build

--- a/.github/actions/publish-python-sdk/action.yml
+++ b/.github/actions/publish-python-sdk/action.yml
@@ -1,0 +1,63 @@
+name: 'Publish Python SDK'
+description: 'Build and publish Python SDK packages to PyPI'
+
+inputs:
+    workspace-path:
+        description: 'Path to the Python SDK workspace'
+        required: true
+        default: 'sdk/@launchdarkly/observability-python'
+    python-version:
+        description: 'Python version to use'
+        required: false
+        default: '3.10'
+    aws-role-arn:
+        description: 'AWS role ARN for accessing secrets'
+        required: true
+    pypi-token-parameter:
+        description: 'SSM parameter path for PyPI token'
+        required: false
+        default: '/production/common/releasing/pypi/token = PYPI_AUTH_TOKEN'
+
+outputs:
+    package-hashes:
+        description: 'Base64 encoded SHA256 hashes of published packages'
+        value: ${{ steps.package-hashes.outputs.package-hashes }}
+
+runs:
+    using: 'composite'
+    steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+
+        - name: Setup Python
+          uses: actions/setup-python@v5
+          with:
+              python-version: ${{ inputs.python-version }}
+
+        - name: Install poetry
+          uses: abatilo/actions-poetry@7b6d33e44b4f08d7021a1dee3c044e9c253d6439
+
+        - name: Get PyPI token
+          uses: launchdarkly/gh-actions/actions/release-secrets@release-secrets-v1.2.0
+          with:
+              aws_assume_role: ${{ inputs.aws-role-arn }}
+              ssm_parameter_pairs: ${{ inputs.pypi-token-parameter }}
+
+        - name: Build Python plugin
+          shell: bash
+          working-directory: ${{ inputs.workspace-path }}
+          run: |
+              make build
+
+        - name: Hash build files for provenance
+          id: package-hashes
+          shell: bash
+          working-directory: ${{ inputs.workspace-path }}/dist
+          run: |
+              echo "package-hashes=$(sha256sum * | base64 -w0)" >> "$GITHUB_OUTPUT"
+
+        - name: Publish package distributions to PyPI
+          uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc
+          with:
+              packages-dir: ./${{ inputs.workspace-path }}/dist
+              password: ${{env.PYPI_AUTH_TOKEN}}

--- a/.github/actions/publish-python-sdk/action.yml
+++ b/.github/actions/publish-python-sdk/action.yml
@@ -61,4 +61,5 @@ runs:
           shell: bash
           run: |
               poetry config pypi-token.pypi ${{ env.PYPI_AUTH_TOKEN }}
+              rm -rf dist
               poetry publish --build --no-interaction

--- a/.github/actions/publish-python-sdk/action.yml
+++ b/.github/actions/publish-python-sdk/action.yml
@@ -61,4 +61,5 @@ runs:
           shell: bash
           run: |
               poetry config pypi-token.pypi ${{ env.PYPI_AUTH_TOKEN }}
-              poetry publish --build
+              rm -rf dist
+              poetry publish --no-interaction

--- a/.github/actions/publish-python-sdk/action.yml
+++ b/.github/actions/publish-python-sdk/action.yml
@@ -61,5 +61,4 @@ runs:
           shell: bash
           run: |
               poetry config pypi-token.pypi ${{ env.PYPI_AUTH_TOKEN }}
-              rm -rf dist
-              poetry publish --no-interaction
+              poetry publish --build --no-interaction

--- a/.github/actions/publish-python-sdk/action.yml
+++ b/.github/actions/publish-python-sdk/action.yml
@@ -57,6 +57,7 @@ runs:
               echo "package-hashes=$(sha256sum * | base64 -w0)" >> "$GITHUB_OUTPUT"
 
         - name: Publish package distributions to PyPI
+          working-directory: ${{ inputs.workspace-path }}
           shell: bash
           run: |
               poetry config pypi-token.pypi ${{ env.PYPI_AUTH_TOKEN }}

--- a/.github/actions/publish-python-sdk/action.yml
+++ b/.github/actions/publish-python-sdk/action.yml
@@ -57,6 +57,7 @@ runs:
               echo "package-hashes=$(sha256sum * | base64 -w0)" >> "$GITHUB_OUTPUT"
 
         - name: Publish package distributions to PyPI
+          shell: bash
           run: |
               poetry config pypi-token.pypi ${{ env.PYPI_AUTH_TOKEN }}
               poetry publish --build

--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -100,6 +100,10 @@ jobs:
         outputs:
             package-hashes: ${{ steps.publish.outputs.package-hashes }}
         steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+            - run: git submodule update --init --recursive
+
             - name: Publish Python SDK
               id: publish
               uses: ./.github/actions/publish-python-sdk

--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -18,6 +18,14 @@ on:
                 description: 'Should release @launchdarkly/... packages.'
                 type: boolean
                 required: true
+            release_launchdarkly_python:
+                description: 'Should release @launchdarkly/observability-python package.'
+                type: boolean
+                required: true
+            python_tag_name:
+                description: 'The tag name for the python package. Should be set when publishing a python package.'
+                type: string
+                required: false
 
 permissions:
     id-token: write
@@ -83,3 +91,31 @@ jobs:
               env:
                   LD_RELEASE_IS_PRERELEASE: ${{ inputs.prerelease }}
                   LD_RELEASE_IS_DRYRUN: ${{ inputs.dry-run }}
+
+    publish-python-sdk:
+        runs-on: ubuntu-latest
+        if: ${{ inputs.release_launchdarkly_python == true }}
+        permissions:
+            id-token: write # Used for publishing secrets and documentation.
+        outputs:
+            package-hashes: ${{ steps.publish.outputs.package-hashes }}
+        steps:
+            - name: Publish Python SDK
+              id: publish
+              uses: ./.github/actions/publish-python-sdk
+              with:
+                  workspace-path: sdk/@launchdarkly/observability-python
+                  aws-role-arn: ${{ vars.AWS_ROLE_ARN }}
+
+    publish-python-provenance:
+        needs: ['publish-python-sdk']
+        if: ${{ inputs.release_launchdarkly_python == true }}
+        permissions:
+            actions: read
+            id-token: write
+            contents: write
+        uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
+        with:
+            base64-subjects: '${{ needs.publish-python-sdk.outputs.package-hashes }}'
+            upload-assets: true
+            upload-tag-name: ${{ inputs.python_tag_name }}

--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -37,6 +37,7 @@ permissions:
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
     publish-package:
+        if: ${{ inputs.release_highlight == true || inputs.release_launchdarkly == true }}
         runs-on: ubuntu-22.04-8core-32gb
         steps:
             - name: Checkout

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -30,39 +30,14 @@ jobs:
         needs: ['release-package']
         if: ${{ needs.release-package.outputs.python-plugin-released == 'true' }}
         outputs:
-            package-hashes: ${{ steps.package-hashes.outputs.package-hashes }}
+            package-hashes: ${{ steps.publish.outputs.package-hashes }}
         steps:
-            - uses: actions/setup-python@v5
+            - name: Publish Python SDK
+              id: publish
+              uses: ./.github/actions/publish-python-sdk
               with:
-                  python-version: '3.10'
-
-            - name: Install poetry
-
-              uses: abatilo/actions-poetry@7b6d33e44b4f08d7021a1dee3c044e9c253d6439
-
-            - uses: launchdarkly/gh-actions/actions/release-secrets@release-secrets-v1.2.0
-              name: 'Get PyPI token'
-              with:
-                  aws_assume_role: ${{ vars.AWS_ROLE_ARN }}
-                  ssm_parameter_pairs: '/production/common/releasing/pypi/token = PYPI_AUTH_TOKEN'
-
-            - name: Build Python plugin
-              run: |
-                  cd sdk/@launchdarkly/observability-python
-                  make build
-
-            - name: Hash build files for provenance
-              id: package-hashes
-              shell: bash
-              working-directory: ./sdk/@launchdarkly/observability-python/dist
-              run: |
-                  echo "package-hashes=$(sha256sum * | base64 -w0)" >> "$GITHUB_OUTPUT"
-
-            - name: Publish package distributions to PyPI
-              uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc
-              with:
-                  packages-dir: ./sdk/@launchdarkly/observability-python/dist
-                  password: ${{env.PYPI_AUTH_TOKEN}}
+                  workspace-path: sdk/@launchdarkly/observability-python
+                  aws-role-arn: ${{ vars.AWS_ROLE_ARN }}
 
     release-python-docs:
         runs-on: ubuntu-latest
@@ -75,7 +50,7 @@ jobs:
               with:
                   workspace_path: sdk/@launchdarkly/observability-python
 
-    release-provenance:
+    release-python-provenance:
         needs: ['release-package', 'release-python-plugin']
         if: ${{ needs.release-package.outputs.python-plugin-released == 'true' }}
         permissions:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -32,6 +32,9 @@ jobs:
         outputs:
             package-hashes: ${{ steps.publish.outputs.package-hashes }}
         steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+
             - name: Publish Python SDK
               id: publish
               uses: ./.github/actions/publish-python-sdk

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,0 +1,3 @@
+module github.com/observability-sdk/go
+
+go 1.24.3

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,3 +1,0 @@
-module github.com/observability-sdk/go
-
-go 1.24.3

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,8 +6,7 @@
 			"versioning": "default",
 			"include-v-in-tag": false,
 			"extra-files": ["PROVENANCE.md"],
-			"include-component-in-tag": true,
-			"release-as": "0.1.0"
+			"include-component-in-tag": true
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Allow manual package publish and provenance.
Working build: https://github.com/launchdarkly/observability-sdk/actions/runs/16377594673/job/46281314100
Published package: https://pypi.org/project/launchdarkly-observability/

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
