### PR TITLE
chore: update codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # Repository Maintainers
-* @launchdarkly/team-observability
+* @launchdarkly/team-observability-reviewers


### PR DESCRIPTION
## Summary

Use the new [reviewers team](https://github.com/launchdarkly/terraform/blob/2d0d4a3f2f7168ed82cfe079bdfec5f9219955d2/accounts/github/launchdarkly/iam/permissions/team_observability-reviewers.tf#L4).

## How did you test this change?

CI

## Are there any deployment considerations?

no
