### PR TITLE
chore: Set package name for go plugin.

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -18,6 +18,7 @@
 		},
 		"go": {
 			"release-type": "go",
+			"package-name": "go",
 			"tag-separator": "/",
 			"bump-minor-pre-major": true,
 			"release-as": "0.1.0",


### PR DESCRIPTION
## Summary

The go package needs a prefix to prevent future conflicts and also handle the path.

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
