### PR TITLE
fix(go): configure default logger provider

### DIFF
--- a/go/internal/otel/otel.go
+++ b/go/internal/otel/otel.go
@@ -15,6 +15,7 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
 	"go.opentelemetry.io/otel/log"
+	"go.opentelemetry.io/otel/log/global"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/propagation"
 	sdklog "go.opentelemetry.io/otel/sdk/log"
@@ -385,6 +386,7 @@ func StartOTLP() error {
 	instances.Store(newInstances)
 
 	otel.SetTracerProvider(tracerProvider)
+	global.SetLoggerProvider(loggerProvider)
 	otel.SetMeterProvider(meterProvider)
 
 	return nil


### PR DESCRIPTION
## Summary

Configure the global OTEL logger provider.

## How did you test this change?

Logs coming thru with https://github.com/launchdarkly/observability/pull/151
<img width="1690" height="900" alt="Screenshot 2025-08-21 at 17 45 39" src="https://github.com/user-attachments/assets/c6cbb66c-3904-405a-917a-02d7cac3a3d1" />


## Are there any deployment considerations?

will release new go tag
