### PR TITLE
chore: Correct reusable workflow usage for publishing docs.

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -48,6 +48,7 @@ jobs:
 
     release-python-docs:
         needs: ['release-package', 'release-python-plugin']
+        if: ${{ needs.release-package.outputs.python-plugin-released == 'true' }}
         permissions:
             contents: write
         uses: launchdarkly/observability-sdk/.github/workflows/manual-publish-docs.yml@main
@@ -109,6 +110,7 @@ jobs:
         needs: ['release-package', 'release-dotnet-plugin']
         permissions:
             contents: write
+        if: ${{ needs.release-package.outputs.dotnet-plugin-released == 'true' }}
         uses: launchdarkly/observability-sdk/.github/workflows/manual-publish-docs.yml@main
         with:
             workspace_path: sdk/@launchdarkly/observability-dotnet

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -55,7 +55,6 @@ jobs:
         with:
             workspace_path: sdk/@launchdarkly/observability-python
 
-
     release-python-provenance:
         needs: ['release-package', 'release-python-plugin']
         if: ${{ needs.release-package.outputs.python-plugin-released == 'true' }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -47,15 +47,13 @@ jobs:
                   aws-role-arn: ${{ vars.AWS_ROLE_ARN }}
 
     release-python-docs:
-        runs-on: ubuntu-latest
+        needs: ['release-package', 'release-python-plugin']
         permissions:
             contents: write
-        needs: ['release-python-plugin']
-        steps:
-            - name: Build and Publish Docs
-              uses: launchdarkly/observability-sdk/.github/workflows/manual-publish-docs.yml@main
-              with:
-                  workspace_path: sdk/@launchdarkly/observability-python
+        uses: launchdarkly/observability-sdk/.github/workflows/manual-publish-docs.yml@main
+        with:
+            workspace_path: sdk/@launchdarkly/observability-python
+
 
     release-python-provenance:
         needs: ['release-package', 'release-python-plugin']
@@ -108,16 +106,12 @@ jobs:
                   dry-run: false
 
     release-dotnet-plugin-docs:
-        runs-on: ubuntu-latest
+        needs: ['release-package', 'release-dotnet-plugin']
         permissions:
             contents: write
-        needs: ['release-package', 'release-dotnet-plugin']
-        if: ${{ needs.release-package.outputs.dotnet-plugin-released == 'true' }}
-        steps:
-            - name: Build and Publish Docs
-              uses: launchdarkly/observability-sdk/.github/workflows/manual-publish-docs.yml@main
-              with:
-                  workspace_path: sdk/@launchdarkly/observability-dotnet
+        uses: launchdarkly/observability-sdk/.github/workflows/manual-publish-docs.yml@main
+        with:
+            workspace_path: sdk/@launchdarkly/observability-dotnet
 
     release-dotnet-sdk-provenance:
         needs: ['release-package', 'release-dotnet-plugin']


### PR DESCRIPTION
## Summary

Needed to call the re-usable workflows as jobs, not as steps.

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
