### PR TITLE
feat: Add support for environment variable configuration.

### DIFF
--- a/sdk/@launchdarkly/observability-dotnet/src/LaunchDarkly.Observability/BaseBuilder.cs
+++ b/sdk/@launchdarkly/observability-dotnet/src/LaunchDarkly.Observability/BaseBuilder.cs
@@ -18,7 +18,7 @@ namespace LaunchDarkly.Observability
         private const string DefaultOtlpEndpoint = "https://otel.observability.app.launchdarkly.com:4318";
         private const string DefaultBackendUrl = "https://pub.observability.app.launchdarkly.com";
         private string _otlpEndpoint = string.Empty;
-        private string _backendUrl = DefaultBackendUrl;
+        private string _backendUrl = string.Empty;
         private string _serviceName = string.Empty;
         private string _environment = string.Empty;
         private string _serviceVersion = string.Empty;
@@ -36,8 +36,9 @@ namespace LaunchDarkly.Observability
         /// For most configurations, the OTLP endpoint will not need to be set.
         /// </para>
         /// <para>
-        /// If not explicitly set, the OTLP endpoint will be read from the OTEL_EXPORTER_OTLP_ENDPOINT 
-        /// environment variable. Values set with this method take precedence over the environment variable.
+        /// If not explicitly set, set to null, or set to whitespace/empty string, the OTLP endpoint will be read from
+        /// the OTEL_EXPORTER_OTLP_ENDPOINT environment variable. Values set with this method take precedence over the
+        /// environment variable.
         /// </para>
         /// <para>
         /// Setting the endpoint to null will reset the builder value to the default.
@@ -64,15 +65,16 @@ namespace LaunchDarkly.Observability
         /// <returns>A reference to this builder.</returns>
         public TBuilder WithBackendUrl(string backendUrl)
         {
-            _backendUrl = backendUrl ?? DefaultBackendUrl;
+            _backendUrl = backendUrl;
             return (TBuilder)this;
         }
 
         /// <summary>
         /// Set the service name.
         /// <para>
-        /// If not explicitly set, the service name will be read from the OTEL_SERVICE_NAME environment variable.
-        /// Values set with this method take precedence over the environment variable.
+        /// If not explicitly set, set to null, or set to whitespace/empty string, the service name will be read from
+        /// the OTEL_SERVICE_NAME environment variable. Values set with this method take precedence over the environment
+        /// variable.
         /// </para>
         /// </summary>
         /// <param name="serviceName">The logical service name used in telemetry resource attributes.</param>
@@ -246,9 +248,11 @@ namespace LaunchDarkly.Observability
                 EnvironmentVariables.OtelExporterOtlpEndpoint,
                 DefaultOtlpEndpoint);
 
+            var effectiveBackendUrl = string.IsNullOrWhiteSpace(_backendUrl) ? DefaultBackendUrl : _backendUrl;
+
             return new ObservabilityConfig(
                 effectiveOtlpEndpoint,
-                _backendUrl,
+                effectiveBackendUrl,
                 effectiveServiceName,
                 _environment,
                 _serviceVersion,

--- a/sdk/@launchdarkly/observability-dotnet/src/LaunchDarkly.Observability/EnvironmentHelper.cs
+++ b/sdk/@launchdarkly/observability-dotnet/src/LaunchDarkly.Observability/EnvironmentHelper.cs
@@ -17,7 +17,7 @@ namespace LaunchDarkly.Observability
         /// <returns>The resolved value based on the precedence: primary value > environment variable > default value.</returns>
         public static string GetValueOrEnvironment(string value, string environmentVariable, string defaultValue = "")
         {
-            if (!string.IsNullOrEmpty(value))
+            if (!string.IsNullOrWhiteSpace(value))
             {
                 return value;
             }

--- a/sdk/@launchdarkly/observability-dotnet/src/LaunchDarkly.Observability/EnvironmentHelper.cs
+++ b/sdk/@launchdarkly/observability-dotnet/src/LaunchDarkly.Observability/EnvironmentHelper.cs
@@ -1,0 +1,29 @@
+using System;
+
+namespace LaunchDarkly.Observability
+{
+    /// <summary>
+    /// Helper methods for working with environment variables.
+    /// </summary>
+    internal static class EnvironmentHelper
+    {
+        /// <summary>
+        /// Returns the provided value if it's not null or empty, otherwise attempts to get the value from the specified environment variable.
+        /// If the environment variable is also not set, returns the default value.
+        /// </summary>
+        /// <param name="value">The primary value to use.</param>
+        /// <param name="environmentVariable">The name of the environment variable to check if the primary value is null or empty.</param>
+        /// <param name="defaultValue">The default value to use if both the primary value and environment variable are not set.</param>
+        /// <returns>The resolved value based on the precedence: primary value > environment variable > default value.</returns>
+        public static string GetValueOrEnvironment(string value, string environmentVariable, string defaultValue = "")
+        {
+            if (!string.IsNullOrEmpty(value))
+            {
+                return value;
+            }
+
+            var envValue = Environment.GetEnvironmentVariable(environmentVariable);
+            return !string.IsNullOrEmpty(envValue) ? envValue : defaultValue;
+        }
+    }
+}

--- a/sdk/@launchdarkly/observability-dotnet/src/LaunchDarkly.Observability/EnvironmentHelper.cs
+++ b/sdk/@launchdarkly/observability-dotnet/src/LaunchDarkly.Observability/EnvironmentHelper.cs
@@ -23,7 +23,7 @@ namespace LaunchDarkly.Observability
             }
 
             var envValue = Environment.GetEnvironmentVariable(environmentVariable);
-            return !string.IsNullOrEmpty(envValue) ? envValue : defaultValue;
+            return !string.IsNullOrWhiteSpace(envValue) ? envValue : defaultValue;
         }
     }
 }

--- a/sdk/@launchdarkly/observability-dotnet/src/LaunchDarkly.Observability/EnvironmentVariables.cs
+++ b/sdk/@launchdarkly/observability-dotnet/src/LaunchDarkly.Observability/EnvironmentVariables.cs
@@ -1,0 +1,20 @@
+namespace LaunchDarkly.Observability
+{
+    /// <summary>
+    /// Contains constants for environment variable names used by the Observability SDK.
+    /// </summary>
+    internal static class EnvironmentVariables
+    {
+        /// <summary>
+        /// The OpenTelemetry standard environment variable for the service name.
+        /// When not explicitly set via WithServiceName(), this environment variable will be used.
+        /// </summary>
+        public const string OtelServiceName = "OTEL_SERVICE_NAME";
+
+        /// <summary>
+        /// The OpenTelemetry standard environment variable for the OTLP exporter endpoint.
+        /// When not explicitly set via WithOtlpEndpoint(), this environment variable will be used.
+        /// </summary>
+        public const string OtelExporterOtlpEndpoint = "OTEL_EXPORTER_OTLP_ENDPOINT";
+    }
+}

--- a/sdk/@launchdarkly/observability-dotnet/test/LaunchDarkly.Observability.Tests/ObservabilityConfigBuilderTests.cs
+++ b/sdk/@launchdarkly/observability-dotnet/test/LaunchDarkly.Observability.Tests/ObservabilityConfigBuilderTests.cs
@@ -357,18 +357,15 @@ namespace LaunchDarkly.Observability.Test
         }
 
         [Test]
-        public void Build_WithOtlpEndpointSetToNull_UsesDefaultNotEnvironmentVariable()
+        public void Build_WithOtlpEndpointSetToNull_UsesEnvironmentVariableIfSet()
         {
             Environment.SetEnvironmentVariable(EnvironmentVariables.OtelExporterOtlpEndpoint,
                 "https://env-otlp.example.com:4318");
 
-            // Build config with OTLP endpoint explicitly set to null (which resets to default)
             var config = ObservabilityConfig.Builder()
                 .WithOtlpEndpoint(null)
                 .Build("sdk-key");
 
-            // Should use the default value when explicitly set to null, and then check env var
-            // Since null resets to default, and default means "check env var", it should use env var
             Assert.That(config.OtlpEndpoint, Is.EqualTo("https://env-otlp.example.com:4318"));
         }
     }

--- a/sdk/@launchdarkly/observability-dotnet/test/LaunchDarkly.Observability.Tests/ObservabilityPluginBuilderTests.cs
+++ b/sdk/@launchdarkly/observability-dotnet/test/LaunchDarkly.Observability.Tests/ObservabilityPluginBuilderTests.cs
@@ -65,5 +65,55 @@ namespace LaunchDarkly.Observability.Test
 
             Assert.That(plugin, Is.InstanceOf<ObservabilityPlugin>());
         }
+
+        [Test]
+        public void Build_UsesOtelServiceNameEnvironmentVariable_WhenServiceNameNotSet()
+        {
+            // Save the original environment variable value
+            var originalValue = Environment.GetEnvironmentVariable(EnvironmentVariables.OtelServiceName);
+
+            try
+            {
+                // Set the environment variable
+                Environment.SetEnvironmentVariable(EnvironmentVariables.OtelServiceName, "plugin-service-from-env");
+
+                // Build plugin without setting service name explicitly
+                var plugin = ObservabilityPlugin.Builder(_services).Build();
+
+                // Plugin should be created successfully and will use the env var internally
+                Assert.That(plugin, Is.InstanceOf<ObservabilityPlugin>());
+            }
+            finally
+            {
+                // Restore the original environment variable value
+                Environment.SetEnvironmentVariable(EnvironmentVariables.OtelServiceName, originalValue);
+            }
+        }
+
+        [Test]
+        public void Build_PrefersExplicitServiceName_OverEnvironmentVariable()
+        {
+            // Save the original environment variable value
+            var originalValue = Environment.GetEnvironmentVariable(EnvironmentVariables.OtelServiceName);
+
+            try
+            {
+                // Set the environment variable
+                Environment.SetEnvironmentVariable(EnvironmentVariables.OtelServiceName, "plugin-service-from-env");
+
+                // Build plugin with explicit service name
+                var plugin = ObservabilityPlugin.Builder(_services)
+                    .WithServiceName("explicit-plugin-service")
+                    .Build();
+
+                // Plugin should be created successfully and will use the explicit value internally
+                Assert.That(plugin, Is.InstanceOf<ObservabilityPlugin>());
+            }
+            finally
+            {
+                // Restore the original environment variable value
+                Environment.SetEnvironmentVariable(EnvironmentVariables.OtelServiceName, originalValue);
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

Add support for common OTEL environment variables.

The underlying OTEL libraries support most variables, but our default configuration would interfere with these specific ones without explicit support.

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
