### PR TITLE
docs: adds Dokka Javadoc generation and integration into docs publish…

### DIFF
--- a/e2e/android/app/build.gradle.kts
+++ b/e2e/android/app/build.gradle.kts
@@ -12,7 +12,6 @@ android {
     defaultConfig {
         applicationId = "com.example.androidobservability"
         minSdk = 24
-        targetSdk = 35
         versionCode = 1
         versionName = "1.0"
 

--- a/sdk/@launchdarkly/observability-android/Makefile
+++ b/sdk/@launchdarkly/observability-android/Makefile
@@ -1,0 +1,14 @@
+.PHONY: install build test docs
+
+install:
+	@echo "Install target does nothing for this project"
+
+build:
+	./gradlew :lib:build
+
+test:
+	./gradlew :lib:test
+
+docs:
+	./gradlew :lib:dokkaJavadoc
+	ln -sf lib/docs docs

--- a/sdk/@launchdarkly/observability-android/README.md
+++ b/sdk/@launchdarkly/observability-android/README.md
@@ -1,0 +1,188 @@
+# LaunchDarkly Observability SDK for Android
+
+## Early Access Preview️
+
+**NB: APIs are subject to change until a 1.x version is released.**
+
+## Features
+
+### Automatic Instrumentation
+
+The Android observability plugin automatically instruments:
+- **Activity Lifecycle**: App lifecycle events and transitions
+- **HTTP Requests**: OkHttp and HttpURLConnection requests (requires setup of ByteBuddy compile time plugin and additional dependencies)
+- **Crash Reporting**: Automatic crash reporting and stack traces
+- **Feature Flag Evaluations**: Evaluation events added to your spans.
+- **Session Management**: User session tracking and background timeout handling
+
+## Example Application
+
+A complete example application is available in the [e2e/android](../e2e/android) directory.
+
+## Install
+
+Add the dependency to your app's Gradle file:
+
+```kotlin
+dependencies {
+    implementation("com.launchdarkly:launchdarkly-android-client-sdk:5.+")
+    implementation("com.launchdarkly:launchdarkly-observability-android:0.5.0")
+}
+```
+
+## Usage
+
+### Basic Setup
+
+Add the observability plugin to your LaunchDarkly Android Client SDK configuration:
+
+```kotlin
+import com.launchdarkly.observability.plugin.Observability
+import com.launchdarkly.sdk.android.LDConfig
+import com.launchdarkly.sdk.android.Components
+import com.launchdarkly.sdk.android.LDClient
+
+class MyApplication : Application() {
+    override fun onCreate() {
+        super.onCreate()
+        
+        val ldConfig = LDConfig.Builder(LDConfig.Builder.AutoEnvAttributes.Enabled)
+            .mobileKey("your-mobile-key")
+            .plugins(
+                Components.plugins().setPlugins(
+                    listOf(
+                        Observability(this@MyApplication)
+                    )
+                )
+            )
+            .build()
+            
+        val context = LDContext.builder(ContextKind.DEFAULT, "user-key")
+            .build()
+            
+        LDClient.init(this@MyApplication, ldConfig, context)
+    }
+}
+```
+
+### Configure additional instrumentations
+
+To enable HTTP request instrumentation and user interaction instrumentation, add the following plugin and dependencies to your top level application's Gradle file.
+
+<CodeBlocks>
+<CodeBlock title='Gradle Groovy'>
+
+```java
+plugins {
+    id 'net.bytebuddy.byte-buddy-gradle-plugin' version '1.+'
+}
+
+dependencies {
+    // Android HTTP Url instrumentation
+    implementation 'io.opentelemetry.android.instrumentation:httpurlconnection-library:0.11.0-alpha'
+    byteBuddy 'io.opentelemetry.android.instrumentation:httpurlconnection-agent:0.11.0-alpha'
+
+    // OkHTTP instrumentation
+    implementation 'io.opentelemetry.android.instrumentation:okhttp3-library:0.11.0-alpha'
+    byteBuddy 'io.opentelemetry.android.instrumentation:okhttp3-agent:0.11.0-alpha'
+}
+```
+
+### Advanced Configuration
+
+You can customize the observability plugin with various options:
+
+```kotlin
+import com.launchdarkly.observability.api.Options
+import com.launchdarkly.sdk.android.LDAndroidLogging
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.api.common.Attributes
+
+val observabilityPlugin = Observability(
+    application = this@MyApplication,
+    options = Options(
+        serviceName = "my-android-app",
+        serviceVersion = "1.0.0",
+        debug = true,
+        logAdapter = LDAndroidLogging.adapter(),
+        resourceAttributes = Attributes.of(
+            AttributeKey.stringKey("environment"), "production",
+            AttributeKey.stringKey("team"), "mobile"
+        ),
+        customHeaders = mapOf(
+            "X-Custom-Header" to "custom-value"
+        )
+    )
+)
+```
+
+### Recording Observability Data
+
+After initialization of the LaunchDarkly Android Client SDK, use `LDObserve` to record metrics, logs, errors, and traces:
+
+```kotlin
+import com.launchdarkly.observability.sdk.LDObserve
+import com.launchdarkly.observability.interfaces.Metric
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.api.common.Attributes
+import io.opentelemetry.api.logs.Severity
+
+// Record metrics
+LDObserve.recordMetric(Metric("user_actions", 1.0))
+LDObserve.recordCount(Metric("api_calls", 1.0))
+LDObserve.recordIncr(Metric("page_views", 1.0))
+LDObserve.recordHistogram(Metric("response_time", 150.0))
+LDObserve.recordUpDownCounter(Metric("active_connections", 1.0))
+
+// Record logs
+LDObserve.recordLog(
+    "User performed action",
+    Severity.INFO,
+    Attributes.of(
+        AttributeKey.stringKey("user_id"), "12345",
+        AttributeKey.stringKey("action"), "button_click"
+    )
+)
+
+// Record errors
+LDObserve.recordError(
+    Exception("Something went wrong"),
+    Attributes.of(
+        AttributeKey.stringKey("component"), "payment",
+        AttributeKey.stringKey("error_code"), "PAYMENT_FAILED"
+    )
+)
+
+// Create spans for tracing
+val span = LDObserve.startSpan(
+    "api_request",
+    Attributes.of(
+        AttributeKey.stringKey("endpoint"), "/api/users",
+        AttributeKey.stringKey("method"), "GET"
+    )
+)
+span.makeCurrent().use {
+    // Your code here
+}
+span.end()
+```
+
+
+
+## Contributing
+
+We encourage pull requests and other contributions from the community. Check out our [contributing guidelines](../../CONTRIBUTING.md) for instructions on how to contribute to this SDK.
+
+## About LaunchDarkly
+
+* LaunchDarkly is a continuous delivery platform that provides feature flags as a service and allows developers to iterate quickly and safely. We allow you to easily flag your features and manage them from the LaunchDarkly dashboard.  With LaunchDarkly, you can:
+    * Roll out a new feature to a subset of your users (like a group of users who opt-in to a beta tester group), gathering feedback and bug reports from real-world use cases.
+    * Gradually roll out a feature to an increasing percentage of users, and track the effect that the feature has on key metrics (for instance, how likely is a user to complete a purchase if they have feature A versus feature B?).
+    * Turn off a feature that you realize is causing performance problems in production, without needing to re-deploy, or even restart the application with a changed configuration file.
+    * Grant access to certain features based on user attributes, like payment plan (eg: users on the ‘gold’ plan get access to more features than users in the ‘silver’ plan). Disable parts of your application to facilitate maintenance, without taking everything offline.
+* LaunchDarkly provides feature flag SDKs for a wide variety of languages and technologies. Read [our documentation](https://docs.launchdarkly.com/sdk) for a complete list.
+* Explore LaunchDarkly
+    * [launchdarkly.com](https://www.launchdarkly.com/ "LaunchDarkly Main Website") for more information
+    * [docs.launchdarkly.com](https://docs.launchdarkly.com/  "LaunchDarkly Documentation") for our documentation and SDK reference guides
+    * [apidocs.launchdarkly.com](https://apidocs.launchdarkly.com/  "LaunchDarkly API Documentation") for our API documentation
+    * [launchdarkly.com/blog](https://launchdarkly.com/blog/  "LaunchDarkly Blog Documentation") for the latest product updates

--- a/sdk/@launchdarkly/observability-android/lib/build.gradle.kts
+++ b/sdk/@launchdarkly/observability-android/lib/build.gradle.kts
@@ -1,3 +1,5 @@
+import java.net.URL
+
 plugins {
     // Apply the Android library plugin
     id("com.android.library")
@@ -6,6 +8,9 @@ plugins {
 
     // Apply the Kotlin Android plugin for Android-compatible Kotlin support.
     alias(libs.plugins.kotlin.android)
+
+    // Apply Dokka plugin for documentation generation
+    id("org.jetbrains.dokka") version "2.0.0"
 }
 
 allprojects {
@@ -55,7 +60,7 @@ tasks.withType<Test> {
 
 android {
     namespace = "com.launchdarkly.observability"
-    compileSdk = 30
+    compileSdk = 35
 
     buildFeatures {
         buildConfig = true
@@ -95,6 +100,8 @@ publishing {
             groupId = "com.launchdarkly"
             artifactId = "launchdarkly-observability-android"
             version = releaseVersion
+
+            // artifact(dokkaJar)
 
             pom {
                 name.set("LaunchDarkly Observability Android SDK")
@@ -139,4 +146,17 @@ publishing {
 
 signing {
     sign(publishing.publications["release"])
+}
+
+// Dokka configuration for Android library documentation
+tasks.dokkaJavadoc.configure {
+    moduleName.set("launchdarkly-observability-android")
+    moduleVersion.set(project.version.toString())
+    outputDirectory.set(layout.projectDirectory.dir("docs"))
+
+    dokkaSourceSets {
+        configureEach {
+            includes.from("doc-module.md")
+        }
+    }
 }

--- a/sdk/@launchdarkly/observability-android/lib/doc-module.md
+++ b/sdk/@launchdarkly/observability-android/lib/doc-module.md
@@ -1,0 +1,3 @@
+# Module launchdarkly-observability-android
+
+This is the LaunchDarkly Observability package for Android. [Click here to view the README on our Github](https://github.com/launchdarkly/observability-sdk/tree/main/sdk/%40launchdarkly/observability-android/README.md)

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/client/InstrumentationManager.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/client/InstrumentationManager.kt
@@ -39,7 +39,11 @@ private const val INSTRUMENTATION_SCOPE_NAME = "com.launchdarkly.observability"
 /**
  * Manages instrumentation for LaunchDarkly Observability.
  *
+ * @param application The application instance.
+ * @param sdkKey The SDK key.
  * @param resources The OpenTelemetry resource describing this service.
+ * @param logger The logger.
+ * @param options Additional options.
  */
 class InstrumentationManager(
     private val application: Application,

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/client/ObservabilityClient.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/client/ObservabilityClient.kt
@@ -10,6 +10,19 @@ import io.opentelemetry.api.logs.Severity
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.sdk.resources.Resource
 
+/**
+ * The [ObservabilityClient] can be used for recording observability data such as
+ * metrics, logs, errors, and traces.
+ * 
+ * It is recommended to use the [Observability] plugin with the LaunchDarkly Android 
+ * Client SDK, as that will automatically initialize the [LDObserve] singleton instance.
+ * 
+ * @param application The application instance.
+ * @param sdkKey The SDK key.
+ * @param resource The resource.
+ * @param logger The logger.
+ * @param options Additional options for the client.
+ */
 class ObservabilityClient: Observe {
     private val instrumentationManager: InstrumentationManager
 

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/interfaces/Metric.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/interfaces/Metric.kt
@@ -2,6 +2,14 @@ package com.launchdarkly.observability.interfaces
 
 import io.opentelemetry.api.common.Attributes
 
+/**
+ * A metric is a value that can be recorded in the LaunchDarkly observability system.
+ * 
+ * @param name The name of the metric.
+ * @param value The value of the metric.
+ * @param attributes The attributes of the metric.
+ * @param timestamp The timestamp of the metric.
+ */
 data class Metric(
     val name: String,
     val value: Double,

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/interfaces/Observe.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/interfaces/Observe.kt
@@ -6,7 +6,7 @@ import io.opentelemetry.api.trace.Span
 
 /**
  * Interface for observability operations in the LaunchDarkly Android SDK.
- * Provides methods for recording various types of metrics.
+ * Provides methods for recording various types of information.
  */
 interface Observe {
     /**

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/plugin/EvalTracingHook.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/plugin/EvalTracingHook.kt
@@ -10,9 +10,13 @@ import io.opentelemetry.api.trace.Span
 import io.opentelemetry.api.trace.Tracer
 import io.opentelemetry.context.Context
 
+/**
+ * This class is a hook implementation for recording flag evaluation events
+ * on spans.
+ */
 class EvalTracingHook
 /**
- * Creates a [EvalTracingHook]
+ * Creates an [EvalTracingHook]
  *
  * @param withSpans will include child spans for the various hook series when they happen
  * @param withValue will include the value of the feature flag in the recorded evaluation events

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/plugin/Observability.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/plugin/Observability.kt
@@ -15,6 +15,35 @@ import com.launchdarkly.sdk.android.integrations.PluginMetadata
 import io.opentelemetry.sdk.resources.Resource
 import java.util.Collections
 
+/**
+ * This Observability class is a plugin implementation for recording observability data such as metrics, logs, errors, and traces.
+ * Provide the plugin to the LaunchDarkly Android Client SDK to enable observability.
+ *
+ * ```
+ * val ldConfig = LDConfig.Builder(LDConfig.Builder.AutoEnvAttributes.Enabled)
+ *     .mobileKey(LAUNCHDARKLY_MOBILE_KEY)
+ *     .plugins(
+ *         Components.plugins().setPlugins(
+ *             listOf(
+ *                 Observability(this@BaseApplication)
+ *             )
+ *         )
+ *     )
+ *     .build()
+ * ```
+ * 
+ * Later after initialization you can use [LDObserve] to record observability data.
+ * 
+ * ```
+ * LDObserve.recordMetric(metric)
+ * LDObserve.recordLog(message, severity, attributes)
+ * LDObserve.recordError(error, attributes)
+ * LDObserve.startSpan(name, attributes)
+ * ```
+ *
+ * @param application The application instance.
+ * @param options The options for the plugin.
+ */
 class Observability(
     private val application: Application,
     private val options: Options = Options() // new instance has reasonable defaults

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/sdk/LDObserve.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/sdk/LDObserve.kt
@@ -7,6 +7,15 @@ import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.logs.Severity
 import io.opentelemetry.api.trace.Span
 
+/**
+ * LDObserve is the singleton entry point for recording observability data such as 
+ * metrics, logs, errors, and traces. It is recommended to use the [Observability] plugin
+ * with the LaunchDarkly Android Client SDK, as that will automatically initialize the
+ * [LDObserve] singleton instance.
+ *
+ * @constructor Creates an LDObserve instance with the provided [ObservabilityClient].
+ * @param client The [ObservabilityClient] to which observability data will be forwarded.
+ */
 class LDObserve(private val client: ObservabilityClient) : Observe {
     override fun recordMetric(metric: Metric) {
         client.recordMetric(metric)


### PR DESCRIPTION
Leverages Dokka plugin and integrates into the existing docs publishing workflow via Makefile.  I expect some small tweaks to get the upload into the Github pages to play nicely.

<img width="1672" height="866" alt="image" src="https://github.com/user-attachments/assets/95f4b293-38b4-4923-b4b5-3dc14ad9582e" />
