### PR TITLE
Fix error when initializing o11y plugin if global provider already set

### DIFF
--- a/e2e/react-router/package.json
+++ b/e2e/react-router/package.json
@@ -14,6 +14,7 @@
 		"@launchdarkly/js-client-sdk": "^0.6.0",
 		"@launchdarkly/observability": "workspace:*",
 		"@launchdarkly/session-replay": "workspace:*",
+		"@splunk/otel-web": "^0.24.0",
 		"launchdarkly-js-client-sdk": "3.8.1",
 		"launchdarkly-react-client-sdk": "3.8.1",
 		"localforage": "^1.10.0",

--- a/e2e/react-router/src/main.tsx
+++ b/e2e/react-router/src/main.tsx
@@ -10,6 +10,7 @@ import {
 } from 'react-router-dom'
 import Root from './routes/root'
 import Welcome from './routes/welcome'
+import OTelConflictTest from './routes/otel-conflict-test'
 
 function rootAction() {
 	const contact = { name: 'hello' }
@@ -55,6 +56,10 @@ const router = createBrowserRouter(
 				</Route>
 			</Route>
 			<Route path={'/welcome'} element={<Welcome />} />
+			<Route
+				path={'/otel-conflict-test'}
+				element={<OTelConflictTest />}
+			/>
 		</>,
 	),
 )

--- a/e2e/react-router/src/routes/otel-conflict-test.tsx
+++ b/e2e/react-router/src/routes/otel-conflict-test.tsx
@@ -1,0 +1,258 @@
+import { useState } from 'react'
+import SplunkRum from '@splunk/otel-web'
+import { initialize as initLD } from 'launchdarkly-js-client-sdk'
+import Observability, { LDObserve } from '@launchdarkly/observability'
+
+function OTelConflictTest() {
+	const [initStatus, setInitStatus] = useState<string>('Not started')
+	const [ldClient, setLdClient] = useState<ReturnType<typeof initLD> | null>(
+		null,
+	)
+	const [logs, setLogs] = useState<string[]>([])
+
+	const addLog = (message: string) => {
+		console.log(message)
+		setLogs((prev) => [
+			...prev,
+			`${new Date().toLocaleTimeString()}: ${message}`,
+		])
+	}
+
+	const initializeStandaloneOTel = () => {
+		try {
+			addLog('🔧 Initializing Splunk RUM (OpenTelemetry)...')
+
+			// Initialize Splunk RUM which sets up OpenTelemetry under the hood
+			SplunkRum.init({
+				beaconUrl: 'https://rum-ingest.us0.signalfx.com/v1/rum',
+				rumAuth: 'test-token-for-conflict-demo',
+				app: 'otel-conflict-test-app',
+				version: '1.0.0',
+				environment: 'test',
+				// Enable debug mode to see what's happening
+				debug: true,
+			})
+
+			addLog('✅ Splunk RUM (OpenTelemetry) initialized successfully!')
+
+			// Test that it works by creating a custom span
+			SplunkRum.provider
+				.getTracer('test-tracer')
+				.startSpan('test-span', {
+					attributes: { 'test.attribute': 'splunk-rum' },
+				})
+				.end()
+
+			addLog('✅ Created test span with Splunk RUM')
+			return true
+		} catch (error) {
+			addLog(`❌ Error initializing Splunk RUM: ${error}`)
+			return false
+		}
+	}
+
+	const initializeLaunchDarklyWithOTel = async () => {
+		try {
+			addLog('🚀 Initializing LaunchDarkly with Observability plugin...')
+
+			const observabilitySettings = {
+				networkRecording: {
+					enabled: true,
+					recordHeadersAndBody: true,
+				},
+				serviceName: 'ld-conflict-test',
+				backendUrl: 'http://localhost:8082/public',
+			}
+
+			const client = initLD(
+				'548f6741c1efad40031b18ae',
+				{ key: 'otel-conflict-test-user' },
+				{
+					plugins: [new Observability(observabilitySettings)],
+					baseUrl: 'https://ld-stg.launchdarkly.com',
+					eventsUrl: 'https://events-stg.launchdarkly.com',
+				},
+			)
+
+			await client.waitForInitialization()
+			setLdClient(client)
+
+			addLog(
+				'✅ LaunchDarkly client with Observability plugin initialized!',
+			)
+
+			// Test that both OTel setups work
+			LDObserve.recordLog(
+				'Testing LaunchDarkly observability after OTel conflict',
+				'info',
+			)
+			addLog('✅ Successfully recorded log via LDObserve')
+
+			// Test the original Splunk RUM still works
+			SplunkRum.provider
+				.getTracer('test-tracer')
+				.startSpan('post-ld-init-span', {
+					attributes: { 'test.attribute': 'after-ld-init' },
+				})
+				.end()
+
+			addLog('✅ Splunk RUM tracer still works after LD init')
+
+			return true
+		} catch (error) {
+			addLog(`❌ Error initializing LaunchDarkly: ${error}`)
+			return false
+		}
+	}
+
+	const runFullTest = async () => {
+		setInitStatus('Running...')
+		setLogs([])
+
+		// Step 1: Initialize standalone OTel first
+		const otelSuccess = initializeStandaloneOTel()
+		if (!otelSuccess) {
+			setInitStatus('❌ Failed at standalone OTel step')
+			return
+		}
+
+		// // Wait a bit to see the separation
+		await new Promise((resolve) => setTimeout(resolve, 1000))
+
+		// Step 2: Initialize LaunchDarkly with Observability plugin
+		const ldSuccess = await initializeLaunchDarklyWithOTel()
+		if (!ldSuccess) {
+			setInitStatus('❌ Failed at LaunchDarkly step')
+			return
+		}
+
+		setInitStatus('✅ All tests passed! No conflicts detected.')
+	}
+
+	return (
+		<div style={{ padding: '20px', maxWidth: '800px' }}>
+			<h1>OpenTelemetry Conflict Test (Splunk RUM)</h1>
+			<p>
+				This page tests that LaunchDarkly's Observability plugin can be
+				initialized alongside Splunk RUM (which uses OpenTelemetry under
+				the hood) without conflicts.
+			</p>
+
+			<div style={{ marginBottom: '20px' }}>
+				<button
+					onClick={runFullTest}
+					style={{
+						padding: '10px 20px',
+						fontSize: '16px',
+						backgroundColor: '#007bff',
+						color: 'white',
+						border: 'none',
+						borderRadius: '4px',
+						cursor: 'pointer',
+					}}
+				>
+					Run Splunk RUM Conflict Test
+				</button>
+			</div>
+
+			<div style={{ marginBottom: '20px' }}>
+				<strong>Status:</strong> <span>{initStatus}</span>
+			</div>
+
+			{ldClient && (
+				<div style={{ marginBottom: '20px' }}>
+					<h3>Test Actions (available after successful init):</h3>
+					<button
+						onClick={() => {
+							LDObserve.recordLog('Manual test log', 'info', {
+								timestamp: Date.now(),
+							})
+							addLog('📝 Recorded manual test log')
+						}}
+						style={{ marginRight: '10px', padding: '5px 10px' }}
+					>
+						Record Test Log
+					</button>
+					<button
+						onClick={() => {
+							LDObserve.recordError(
+								new Error('Test error for conflict testing'),
+							)
+							addLog('🚨 Recorded test error')
+						}}
+						style={{ marginRight: '10px', padding: '5px 10px' }}
+					>
+						Record Test Error
+					</button>
+					<button
+						onClick={() => {
+							SplunkRum.provider
+								.getTracer('manual-test-tracer')
+								.startSpan('manual-test-span', {
+									attributes: {
+										'manual.test': true,
+										timestamp: Date.now(),
+									},
+								})
+								.end()
+							addLog(
+								'🔍 Created manual test span with Splunk RUM',
+							)
+						}}
+						style={{ padding: '5px 10px' }}
+					>
+						Create Splunk RUM Span
+					</button>
+				</div>
+			)}
+
+			<div>
+				<h3>Logs:</h3>
+				<div
+					style={{
+						backgroundColor: '#f8f9fa',
+						border: '1px solid #dee2e6',
+						borderRadius: '4px',
+						padding: '10px',
+						height: '400px',
+						overflowY: 'auto',
+						fontFamily: 'monospace',
+						fontSize: '12px',
+					}}
+				>
+					{logs.map((log, index) => (
+						<div key={index} style={{ marginBottom: '2px' }}>
+							{log}
+						</div>
+					))}
+				</div>
+			</div>
+
+			<div style={{ marginTop: '20px', fontSize: '14px', color: '#666' }}>
+				<p>
+					<strong>What this test does:</strong>
+				</p>
+				<ol>
+					<li>
+						Initializes Splunk RUM (which sets up OpenTelemetry
+						under the hood)
+					</li>
+					<li>
+						Initializes LaunchDarkly client with Observability
+						plugin
+					</li>
+					<li>Verifies both systems work without conflicts</li>
+					<li>Tests that no "duplicate registration" errors occur</li>
+				</ol>
+				<p>
+					<strong>Expected result:</strong> Both OTel systems should
+					coexist peacefully, with the LaunchDarkly plugin detecting
+					the existing OTel setup from Splunk RUM and working with it
+					instead of causing conflicts.
+				</p>
+			</div>
+		</div>
+	)
+}
+
+export default OTelConflictTest

--- a/e2e/react-router/src/routes/otel-conflict-test.tsx
+++ b/e2e/react-router/src/routes/otel-conflict-test.tsx
@@ -61,7 +61,6 @@ function OTelConflictTest() {
 					recordHeadersAndBody: true,
 				},
 				serviceName: 'ld-conflict-test',
-				backendUrl: 'http://localhost:8082/public',
 			}
 
 			const client = initLD(

--- a/e2e/react-router/src/routes/root.tsx
+++ b/e2e/react-router/src/routes/root.tsx
@@ -39,6 +39,12 @@ export default function Root() {
 	return (
 		<div id="sidebar">
 			<h1>Hello, world</h1>
+			<nav style={{ marginBottom: '20px' }}>
+				<a href="/welcome" style={{ marginRight: '10px' }}>
+					Welcome Page
+				</a>
+				<a href="/otel-conflict-test">OTel Conflict Test</a>
+			</nav>
 			<p>{flags}</p>
 			<a href={session} target={'_blank'}>
 				{session}

--- a/sdk/highlight-run/package.json
+++ b/sdk/highlight-run/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "highlight.run",
-	"version": "9.21.1",
+	"version": "9.21.0",
 	"description": "Open source, fullstack monitoring. Capture frontend errors, record server side logs, and visualize what broke with session replay.",
 	"keywords": [
 		"highlight",

--- a/sdk/highlight-run/package.json
+++ b/sdk/highlight-run/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "highlight.run",
-	"version": "9.21.0",
+	"version": "9.21.1",
 	"description": "Open source, fullstack monitoring. Capture frontend errors, record server side logs, and visualize what broke with session replay.",
 	"keywords": [
 		"highlight",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9865,6 +9865,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@opentelemetry/api-logs@npm:0.52.1":
+  version: 0.52.1
+  resolution: "@opentelemetry/api-logs@npm:0.52.1"
+  dependencies:
+    "@opentelemetry/api": "npm:^1.0.0"
+  checksum: 10/7515667a41a38014ffda70674c0b77c9c68417cde9f8ce8840e675308b4431f99d879e8d347f1b08486561617f914c07ee704ad6ed8a6522dabc3a81ac39dc88
+  languageName: node
+  linkType: hard
+
 "@opentelemetry/api-logs@npm:0.57.1":
   version: 0.57.1
   resolution: "@opentelemetry/api-logs@npm:0.57.1"
@@ -9883,7 +9892,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/api@npm:^1.3.0, @opentelemetry/api@npm:^1.9.0":
+"@opentelemetry/api@npm:^1.0.0, @opentelemetry/api@npm:^1.3.0, @opentelemetry/api@npm:^1.9.0":
   version: 1.9.0
   resolution: "@opentelemetry/api@npm:1.9.0"
   checksum: 10/a607f0eef971893c4f2ee2a4c2069aade6ec3e84e2a1f5c2aac19f65c5d9eeea41aa72db917c1029faafdd71789a1a040bdc18f40d63690e22ccae5d7070f194
@@ -10021,6 +10030,17 @@ __metadata:
   peerDependencies:
     "@opentelemetry/api": ">=1.0.0 <1.10.0"
   checksum: 10/198dacdce36377f6ded7062eb9fc77f86c9fcc8c86dd395e9cb276e14a01c7906ea2f0271999cae21bf251dbec44641286b8bd34a39c67c88c08ed925a986f4b
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/core@npm:1.25.1":
+  version: 1.25.1
+  resolution: "@opentelemetry/core@npm:1.25.1"
+  dependencies:
+    "@opentelemetry/semantic-conventions": "npm:1.25.1"
+  peerDependencies:
+    "@opentelemetry/api": ">=1.0.0 <1.10.0"
+  checksum: 10/3f669798760e70587cb1f329def5c02b586d3ceeb3200728387e6fb6dcd5ac9a04e4eafe3dc98a6c0cf5204e4ca238d4f0809a37425a1f1e7e9aea673ea28f59
   languageName: node
   linkType: hard
 
@@ -10358,6 +10378,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@opentelemetry/exporter-trace-otlp-http@npm:^0.52.1":
+  version: 0.52.1
+  resolution: "@opentelemetry/exporter-trace-otlp-http@npm:0.52.1"
+  dependencies:
+    "@opentelemetry/core": "npm:1.25.1"
+    "@opentelemetry/otlp-exporter-base": "npm:0.52.1"
+    "@opentelemetry/otlp-transformer": "npm:0.52.1"
+    "@opentelemetry/resources": "npm:1.25.1"
+    "@opentelemetry/sdk-trace-base": "npm:1.25.1"
+  peerDependencies:
+    "@opentelemetry/api": ^1.0.0
+  checksum: 10/12580244204ac156c0a5d059e275a8d9f1fd5b705d425b6e1c6b3045740d157f5d55190e88c430a528cdc5fa92ad8f3ae4fb157e253f9026462728b189d6b6c3
+  languageName: node
+  linkType: hard
+
 "@opentelemetry/exporter-trace-otlp-proto@npm:0.203.0":
   version: 0.203.0
   resolution: "@opentelemetry/exporter-trace-otlp-proto@npm:0.203.0"
@@ -10388,7 +10423,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/exporter-zipkin@npm:1.30.1":
+"@opentelemetry/exporter-zipkin@npm:1.30.1, @opentelemetry/exporter-zipkin@npm:^1.25.1":
   version: 1.30.1
   resolution: "@opentelemetry/exporter-zipkin@npm:1.30.1"
   dependencies:
@@ -10656,6 +10691,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@opentelemetry/instrumentation-document-load@npm:^0.39.0":
+  version: 0.39.0
+  resolution: "@opentelemetry/instrumentation-document-load@npm:0.39.0"
+  dependencies:
+    "@opentelemetry/core": "npm:^1.8.0"
+    "@opentelemetry/instrumentation": "npm:^0.52.0"
+    "@opentelemetry/sdk-trace-base": "npm:^1.0.0"
+    "@opentelemetry/sdk-trace-web": "npm:^1.15.0"
+    "@opentelemetry/semantic-conventions": "npm:^1.22.0"
+  peerDependencies:
+    "@opentelemetry/api": ^1.3.0
+  checksum: 10/5867182a6146a7ac957fe90bfef3bec6ef98b12bf06962f48391bbc1e5017fb04af6d71c350f7bd8735da123ae5be5fbbc5b3a86b527520db2a4328ae99f2c38
+  languageName: node
+  linkType: hard
+
 "@opentelemetry/instrumentation-express@npm:^0.47.0":
   version: 0.47.0
   resolution: "@opentelemetry/instrumentation-express@npm:0.47.0"
@@ -10733,6 +10783,20 @@ __metadata:
   peerDependencies:
     "@opentelemetry/api": ^1.3.0
   checksum: 10/561bdb119d36499fbec8b636b6192714a82d3e41d1cd720a3c732436fe1908e68b1480457fa4604c50a37de9c1914fa82d037a5a4e1e536b5c16165b4044a5e2
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/instrumentation-fetch@npm:^0.52.1":
+  version: 0.52.1
+  resolution: "@opentelemetry/instrumentation-fetch@npm:0.52.1"
+  dependencies:
+    "@opentelemetry/core": "npm:1.25.1"
+    "@opentelemetry/instrumentation": "npm:0.52.1"
+    "@opentelemetry/sdk-trace-web": "npm:1.25.1"
+    "@opentelemetry/semantic-conventions": "npm:1.25.1"
+  peerDependencies:
+    "@opentelemetry/api": ^1.0.0
+  checksum: 10/0d21aa1c3170d77fe6e09f540304ba22d728a9ce0160e81934ab26c47545289aaca81c2f2dd435d5564c11d9a835e86641ff4bcdf6fd6185b6bd5a3edc0e04fa
   languageName: node
   linkType: hard
 
@@ -11492,6 +11556,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@opentelemetry/instrumentation-xml-http-request@npm:^0.52.1":
+  version: 0.52.1
+  resolution: "@opentelemetry/instrumentation-xml-http-request@npm:0.52.1"
+  dependencies:
+    "@opentelemetry/core": "npm:1.25.1"
+    "@opentelemetry/instrumentation": "npm:0.52.1"
+    "@opentelemetry/sdk-trace-web": "npm:1.25.1"
+    "@opentelemetry/semantic-conventions": "npm:1.25.1"
+  peerDependencies:
+    "@opentelemetry/api": ^1.0.0
+  checksum: 10/02833d5d940a455979df7e02f425e4eae12f8f45e00ab59c85830be58e4e0a28294391f2cb1bc0b0fe29dc68df2f0945794e6d20b4ecf6409f6a24569b6080d7
+  languageName: node
+  linkType: hard
+
 "@opentelemetry/instrumentation@npm:0.203.0, @opentelemetry/instrumentation@npm:>=0.53.0, @opentelemetry/instrumentation@npm:^0.203.0":
   version: 0.203.0
   resolution: "@opentelemetry/instrumentation@npm:0.203.0"
@@ -11502,6 +11580,22 @@ __metadata:
   peerDependencies:
     "@opentelemetry/api": ^1.3.0
   checksum: 10/0e85cd7df97e4a7a9cdd23d187be45dae93806bf04783c531fe847cc4b24abd96934ad1196320661190648444d726bed1f702fa96e0af3fc7edb3c04c44fde34
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/instrumentation@npm:0.52.1, @opentelemetry/instrumentation@npm:^0.52.0, @opentelemetry/instrumentation@npm:^0.52.1":
+  version: 0.52.1
+  resolution: "@opentelemetry/instrumentation@npm:0.52.1"
+  dependencies:
+    "@opentelemetry/api-logs": "npm:0.52.1"
+    "@types/shimmer": "npm:^1.0.2"
+    import-in-the-middle: "npm:^1.8.1"
+    require-in-the-middle: "npm:^7.1.1"
+    semver: "npm:^7.5.2"
+    shimmer: "npm:^1.2.1"
+  peerDependencies:
+    "@opentelemetry/api": ^1.3.0
+  checksum: 10/87761bd593f2b905d88d0531a3a2a7f4b0186334ae413b4c172a86bd4de0fd6d2f906a1bfd9dd7bd172a228a44fa7a680f5802a1570dfe2fadad0768e80bd7a8
   languageName: node
   linkType: hard
 
@@ -11546,6 +11640,18 @@ __metadata:
   peerDependencies:
     "@opentelemetry/api": ^1.3.0
   checksum: 10/dd55cc74125e9e5736485e0b6df3105cdde783ab3b814d7ecef91b48ca11dbff720cae46020460b7053f05172a40257215b09f520044fba7855803cf3d75ad53
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/otlp-exporter-base@npm:0.52.1":
+  version: 0.52.1
+  resolution: "@opentelemetry/otlp-exporter-base@npm:0.52.1"
+  dependencies:
+    "@opentelemetry/core": "npm:1.25.1"
+    "@opentelemetry/otlp-transformer": "npm:0.52.1"
+  peerDependencies:
+    "@opentelemetry/api": ^1.0.0
+  checksum: 10/0fbe164e04b05a7ba230f5532ecfbf1bb2156e2a7330090e1880c5b1db05f89ed4e7a89a67b8297415389975045377efbfb82410685b666581eaa6782c353450
   languageName: node
   linkType: hard
 
@@ -11603,6 +11709,23 @@ __metadata:
   peerDependencies:
     "@opentelemetry/api": ^1.3.0
   checksum: 10/a7ce86976ca556e1827c64cc8dba0695718eece364644523fc835fdc8bd1e200728aa2d9b2c44dbc2948a551c2acff0ec632ebe6671d112885e8887ac8d8064b
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/otlp-transformer@npm:0.52.1":
+  version: 0.52.1
+  resolution: "@opentelemetry/otlp-transformer@npm:0.52.1"
+  dependencies:
+    "@opentelemetry/api-logs": "npm:0.52.1"
+    "@opentelemetry/core": "npm:1.25.1"
+    "@opentelemetry/resources": "npm:1.25.1"
+    "@opentelemetry/sdk-logs": "npm:0.52.1"
+    "@opentelemetry/sdk-metrics": "npm:1.25.1"
+    "@opentelemetry/sdk-trace-base": "npm:1.25.1"
+    protobufjs: "npm:^7.3.0"
+  peerDependencies:
+    "@opentelemetry/api": ">=1.3.0 <1.10.0"
+  checksum: 10/954bef8f732bb0f4791755de73627cd6d83bde2e42337d5961d6694d90e404f20a48e941f17229ce87ef39b3bb9ddc11cc1293ac77a3e0bb2b2cca4ea660a778
   languageName: node
   linkType: hard
 
@@ -11831,7 +11954,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/resources@npm:1.30.1, @opentelemetry/resources@npm:^1.10.0, @opentelemetry/resources@npm:^1.10.1, @opentelemetry/resources@npm:^1.24.0, @opentelemetry/resources@npm:^1.30.1":
+"@opentelemetry/resources@npm:1.25.1":
+  version: 1.25.1
+  resolution: "@opentelemetry/resources@npm:1.25.1"
+  dependencies:
+    "@opentelemetry/core": "npm:1.25.1"
+    "@opentelemetry/semantic-conventions": "npm:1.25.1"
+  peerDependencies:
+    "@opentelemetry/api": ">=1.0.0 <1.10.0"
+  checksum: 10/971f9616deeff76e584ba7d2957db402332701d9e1f679532e105ff2b929cd93e8ee40ccac029585e70ab917ff47696a0f37a4ddfcb9f96b4ae0eeca860deaf5
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/resources@npm:1.30.1, @opentelemetry/resources@npm:^1.10.0, @opentelemetry/resources@npm:^1.10.1, @opentelemetry/resources@npm:^1.24.0, @opentelemetry/resources@npm:^1.25.1, @opentelemetry/resources@npm:^1.30.1":
   version: 1.30.1
   resolution: "@opentelemetry/resources@npm:1.30.1"
   dependencies:
@@ -11868,6 +12003,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@opentelemetry/sdk-logs@npm:0.52.1":
+  version: 0.52.1
+  resolution: "@opentelemetry/sdk-logs@npm:0.52.1"
+  dependencies:
+    "@opentelemetry/api-logs": "npm:0.52.1"
+    "@opentelemetry/core": "npm:1.25.1"
+    "@opentelemetry/resources": "npm:1.25.1"
+  peerDependencies:
+    "@opentelemetry/api": ">=1.4.0 <1.10.0"
+  checksum: 10/17057d6105fb2bfba7cc7860a0d01c22e2a488d90d6d065ba6938a4c5315b025fb2ed98b7d82e2e828af8ec0c046934646c651f5bf0d587d64dc23643507c4fd
+  languageName: node
+  linkType: hard
+
 "@opentelemetry/sdk-logs@npm:0.57.2, @opentelemetry/sdk-logs@npm:^0.57.2":
   version: 0.57.2
   resolution: "@opentelemetry/sdk-logs@npm:0.57.2"
@@ -11878,6 +12026,19 @@ __metadata:
   peerDependencies:
     "@opentelemetry/api": ">=1.4.0 <1.10.0"
   checksum: 10/4c60faf32cb177e64a44aa139372e01a69b6d9805c4296a2cb555ea3f824f1a4ebb52909742ef62f1fcc0701348168d2c318e6e74902996c04de7a8ebdb013ed
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/sdk-metrics@npm:1.25.1":
+  version: 1.25.1
+  resolution: "@opentelemetry/sdk-metrics@npm:1.25.1"
+  dependencies:
+    "@opentelemetry/core": "npm:1.25.1"
+    "@opentelemetry/resources": "npm:1.25.1"
+    lodash.merge: "npm:^4.6.2"
+  peerDependencies:
+    "@opentelemetry/api": ">=1.3.0 <1.10.0"
+  checksum: 10/751015cef39cb13502fd03d32d46280697b24b6ceee27bf3b1336bef16259baf3fb629734cec6bf4998a14d785da467ae93cafc7b519c83cec52312269a773b3
   languageName: node
   linkType: hard
 
@@ -11967,7 +12128,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/sdk-trace-base@npm:1.30.1, @opentelemetry/sdk-trace-base@npm:^1.30.1":
+"@opentelemetry/sdk-trace-base@npm:1.25.1":
+  version: 1.25.1
+  resolution: "@opentelemetry/sdk-trace-base@npm:1.25.1"
+  dependencies:
+    "@opentelemetry/core": "npm:1.25.1"
+    "@opentelemetry/resources": "npm:1.25.1"
+    "@opentelemetry/semantic-conventions": "npm:1.25.1"
+  peerDependencies:
+    "@opentelemetry/api": ">=1.0.0 <1.10.0"
+  checksum: 10/65d289a144bba052d1b4a0f8f528d2598cfb6bfbf60d9372543a317665e9e1dc63069a66601537fe1e6e94563f53d1be9cc3474dfc3361a8d33f31e1ea2d6262
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/sdk-trace-base@npm:1.30.1, @opentelemetry/sdk-trace-base@npm:^1.0.0, @opentelemetry/sdk-trace-base@npm:^1.25.1, @opentelemetry/sdk-trace-base@npm:^1.30.1":
   version: 1.30.1
   resolution: "@opentelemetry/sdk-trace-base@npm:1.30.1"
   dependencies:
@@ -12022,7 +12196,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/sdk-trace-web@npm:1.30.1, @opentelemetry/sdk-trace-web@npm:^1.15.0, @opentelemetry/sdk-trace-web@npm:^1.30.1, @opentelemetry/sdk-trace-web@npm:^1.8.0":
+"@opentelemetry/sdk-trace-web@npm:1.25.1":
+  version: 1.25.1
+  resolution: "@opentelemetry/sdk-trace-web@npm:1.25.1"
+  dependencies:
+    "@opentelemetry/core": "npm:1.25.1"
+    "@opentelemetry/sdk-trace-base": "npm:1.25.1"
+    "@opentelemetry/semantic-conventions": "npm:1.25.1"
+  peerDependencies:
+    "@opentelemetry/api": ">=1.0.0 <1.10.0"
+  checksum: 10/0c12cac81b612b361704d20264c663fafb1ccfb43f3ab08c1c8ddccbdc009c02de4dd8f89129799344a6095767a3949e86bf38e4c4222992a432c2c352f77ba0
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/sdk-trace-web@npm:1.30.1, @opentelemetry/sdk-trace-web@npm:^1.15.0, @opentelemetry/sdk-trace-web@npm:^1.25.1, @opentelemetry/sdk-trace-web@npm:^1.30.1, @opentelemetry/sdk-trace-web@npm:^1.8.0":
   version: 1.30.1
   resolution: "@opentelemetry/sdk-trace-web@npm:1.30.1"
   dependencies:
@@ -12047,10 +12234,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@opentelemetry/semantic-conventions@npm:1.25.1":
+  version: 1.25.1
+  resolution: "@opentelemetry/semantic-conventions@npm:1.25.1"
+  checksum: 10/d84745a9e21a451560a293b4e6f996ee7c67bb983a7ec05408c23d207c6fc8b73a0af9c1ebea26e3acb4f0e3405ea7eb0d6bdf9adad9f954d60829bbb48ea307
+  languageName: node
+  linkType: hard
+
 "@opentelemetry/semantic-conventions@npm:1.28.0":
   version: 1.28.0
   resolution: "@opentelemetry/semantic-conventions@npm:1.28.0"
   checksum: 10/c182a3206769b5d5a8ab89a5c674d046fd789421cef27ea55af179990e314732433c98e5017aa23e99f15fd2b0e13cb129bb6c2282da6860ce9419adf32b2e87
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/semantic-conventions@npm:^1.22.0, @opentelemetry/semantic-conventions@npm:^1.25.1":
+  version: 1.37.0
+  resolution: "@opentelemetry/semantic-conventions@npm:1.37.0"
+  checksum: 10/919951c2ddbe5509dad26afc7b09d9a5e3c169de187013d1836d2771a7e840e85ea500725128b798d7659d89aff480c07fd039cf77858df3f3573a15063db7c3
   languageName: node
   linkType: hard
 
@@ -14685,6 +14886,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@splunk/otel-web@npm:^0.24.0":
+  version: 0.24.0
+  resolution: "@splunk/otel-web@npm:0.24.0"
+  dependencies:
+    "@opentelemetry/api": "npm:^1.9.0"
+    "@opentelemetry/core": "npm:^1.25.1"
+    "@opentelemetry/exporter-trace-otlp-http": "npm:^0.52.1"
+    "@opentelemetry/exporter-zipkin": "npm:^1.25.1"
+    "@opentelemetry/instrumentation": "npm:^0.52.1"
+    "@opentelemetry/instrumentation-document-load": "npm:^0.39.0"
+    "@opentelemetry/instrumentation-fetch": "npm:^0.52.1"
+    "@opentelemetry/instrumentation-xml-http-request": "npm:^0.52.1"
+    "@opentelemetry/resources": "npm:^1.25.1"
+    "@opentelemetry/sdk-trace-base": "npm:^1.25.1"
+    "@opentelemetry/sdk-trace-web": "npm:^1.25.1"
+    "@opentelemetry/semantic-conventions": "npm:^1.25.1"
+    core-js: "npm:3.45.1"
+    regenerator-runtime: "npm:^0.14.1"
+    shimmer: "npm:^1.2.1"
+    source-map-loader: "npm:^5.0.0"
+    web-vitals: "npm:^3.5.2"
+  checksum: 10/b33fa4ac2cce69e6a2d0c97d8b09734c169ca92162bab03a197d8f6c83d96ee9b8a0b78ffe716c7fa1a4e903a929df0deb94a4071ba6046d1f5de4750b93c54a
+  languageName: node
+  linkType: hard
+
 "@sveltejs/adapter-auto@npm:^3.0.0":
   version: 3.2.2
   resolution: "@sveltejs/adapter-auto@npm:3.2.2"
@@ -16318,7 +16544,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/shimmer@npm:^1.2.0":
+"@types/shimmer@npm:^1.0.2, @types/shimmer@npm:^1.2.0":
   version: 1.2.0
   resolution: "@types/shimmer@npm:1.2.0"
   checksum: 10/f081a31d826ce7bfe8cc7ba8129d2b1dffae44fd580eba4fcf741237646c4c2494ae6de2cada4b7713d138f35f4bc512dbf01311d813dee82020f97d7d8c491c
@@ -21811,6 +22037,13 @@ __metadata:
   dependencies:
     browserslist: "npm:^4.24.3"
   checksum: 10/3dd3d717b3d4ae0d9c2930d39c0f2a21ca6f195fcdd5711bda833557996c4d9f90277eab576423478e95689257e2de8d1a2623d6618084416bd224d10d5df9a4
+  languageName: node
+  linkType: hard
+
+"core-js@npm:3.45.1":
+  version: 3.45.1
+  resolution: "core-js@npm:3.45.1"
+  checksum: 10/b9dca79b1af8bb4f0d4af0752ea98d694fe157abaf55513fd4084df32dfd4398f0fc57898b32cdb643c1cecb87b9231c2a2ce535797c80ae328eac6d6078ee61
   languageName: node
   linkType: hard
 
@@ -39267,6 +39500,7 @@ __metadata:
     "@launchdarkly/js-client-sdk": "npm:^0.6.0"
     "@launchdarkly/observability": "workspace:*"
     "@launchdarkly/session-replay": "workspace:*"
+    "@splunk/otel-web": "npm:^0.24.0"
     "@types/react": "npm:^19.0.4"
     "@types/react-dom": "npm:^19.0.2"
     "@typescript-eslint/eslint-plugin": "npm:^5.61.0"
@@ -39618,7 +39852,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"regenerator-runtime@npm:^0.14.0":
+"regenerator-runtime@npm:^0.14.0, regenerator-runtime@npm:^0.14.1":
   version: 0.14.1
   resolution: "regenerator-runtime@npm:0.14.1"
   checksum: 10/5db3161abb311eef8c45bcf6565f4f378f785900ed3945acf740a9888c792f75b98ecb77f0775f3bf95502ff423529d23e94f41d80c8256e8fa05ed4b07cf471
@@ -41747,7 +41981,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"source-map-loader@npm:5.0.0":
+"source-map-loader@npm:5.0.0, source-map-loader@npm:^5.0.0":
   version: 5.0.0
   resolution: "source-map-loader@npm:5.0.0"
   dependencies:
@@ -46156,6 +46390,13 @@ __metadata:
   version: 3.5.0
   resolution: "web-vitals@npm:3.5.0"
   checksum: 10/8ec26186d277548b0426c5ed0dbd88a193cff7dedde52978e61a474659557f8534e48eba776b2fbe79591f5aab6ef84aa3f1722a8ff880fe38e74bcd66fa2f44
+  languageName: node
+  linkType: hard
+
+"web-vitals@npm:^3.5.2":
+  version: 3.5.2
+  resolution: "web-vitals@npm:3.5.2"
+  checksum: 10/59c5d7775c32977eb9156d186113f4de66c235cfea7a113d2f430ef25db25a5efe1980d2ba466f7ceefc7b1a3847764933dc1567b6d9b8f340d12e75209e3f79
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

We had reports that initializing our SDK alongside others using the core OTel packages could cause errors about duplicate registration of global providers.

<img width="720" height="486" alt="image" src="https://github.com/user-attachments/assets/c0ec5496-3430-4c5e-b345-3cb754fb55a6" />

This was a result of calling `setGlobalTracerProvider` and `setGlobalMeterProvider` after another SDK had already done so. It turns out, there's no clean way to override a global provider, and I realized it's best practice to avoid calling the `setGlobal*Provider` methods entirely in an SDK since you want to allow the end user to be able to set that.

This PR removes our calls to `setGlobalTracingProvider` and `setGlobalMeterProvider`, eliminating the error. It also sets the trace and meter provider explicitly on all of our instrumentations since those will use the global providers as a fallback if they are not set.

## How did you test this change?

I added a new page in the react router E2E app to replicate the original issue that was reported, then I worked on my fix and rebuilt locally to confirm the error went away.

- [ ] Ensure traces and metrics from instrumentations are still flowing correctly

## Are there any deployment considerations?

Need to notify the customer who reported the issue when this is fixed.