### PR TITLE
feat: Support Go observability initialization independent of plugins.

### DIFF
--- a/e2e/go-plugin/README.md
+++ b/e2e/go-plugin/README.md
@@ -29,6 +29,7 @@ This project contains several examples, each demonstrating the LaunchDarkly Obse
 - [Gorilla Mux Example](#3-gorilla-mux-example-cmdgorillamux)
 - [Standard HTTP Example](#4-standard-http-example-cmdhttp)
 - [Logrus Example](#5-logrus-example-cmdlogrus)
+- [Pre-Initialize Example](#6-pre-initialize-example-cmdpreinit)
 
 ### 1. Fiber Example (`cmd/fiber/`)
 
@@ -117,4 +118,29 @@ go run cmd/logrus/logrus.go
 
 **Endpoints:**
 - `GET /log` - Logs structured data with various field types and demonstrates Logrus + OpenTelemetry integration
+
+### 6. Pre-Initialize Example (`cmd/preinit/`)
+
+A web server demonstrating advanced observability initialization patterns, including pre-initializing the observability plugin before the LaunchDarkly client.
+
+**Features:**
+- Uses `ldobserve.PreInitialize()` to initialize observability before the LaunchDarkly client
+- Demonstrates using observability without the LaunchDarkly client (with limited features)
+- Shows the `NewObservabilityPluginWithoutInit()` pattern for pre-initialized observability
+- Uses standard `net/http` package with OpenTelemetry instrumentation
+- Includes graceful shutdown handling
+- Demonstrates manual span creation and attribute setting
+
+**To run:**
+```bash
+go run cmd/preinit/preinit.go
+```
+
+**Endpoints:**
+- `GET /rolldice` - Rolls a dice and returns the result, with verbose output controlled by the `verbose-response` feature flag
+
+**Use Cases:**
+- Advanced initialization scenarios where you need observability before the LaunchDarkly client
+- Using observability features without a LaunchDarkly client (some features will be unavailable)
+- Custom initialization timing requirements
  

--- a/e2e/go-plugin/cmd/preinit/preinit.go
+++ b/e2e/go-plugin/cmd/preinit/preinit.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"context"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"time"
+
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	ld "github.com/launchdarkly/go-server-sdk/v7"
+	"github.com/launchdarkly/go-server-sdk/v7/ldplugins"
+	ldobserve "github.com/launchdarkly/observability-sdk/go"
+
+	appcontext "dice/internal/context"
+	"dice/internal/dice"
+	"dice/internal/version"
+)
+
+func main() {
+	if err := run(); err != nil {
+		log.Fatalln(err)
+	}
+}
+
+func run() (err error) {
+	// Handle SIGINT (CTRL+C) gracefully.
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer stop()
+
+	// Initialize the observability plugin ahead of the LaunchDarkly client.
+	// This is generally only required for advanced use cases and is not the
+	// recommended way to initialize observability.
+	// Observability can also be used without the LaunchDarkly client at all
+	// by using this method. Some features will not be available when using
+	// observability without the LaunchDarkly client.
+	ldobserve.PreInitialize(os.Getenv("LAUNCHDARKLY_SDK_KEY"),
+		ldobserve.WithEnvironment("test"),
+		ldobserve.WithServiceName("go-plugin-example"),
+		ldobserve.WithServiceVersion(version.Commit),
+	)
+
+	client, _ := ld.MakeCustomClient(os.Getenv("LAUNCHDARKLY_SDK_KEY"),
+		ld.Config{
+			Plugins: []ldplugins.Plugin{
+				// This special form of constructing the observability plugin
+				// is used when observability has been pre-initialized.
+				ldobserve.NewObservabilityPluginWithoutInit(),
+			},
+		}, 5*time.Second)
+
+	ctx = appcontext.WithLaunchDarklyClient(ctx, client)
+
+	// Start HTTP server.
+	srv := &http.Server{
+		Addr:         ":8080",
+		BaseContext:  func(_ net.Listener) context.Context { return ctx },
+		ReadTimeout:  time.Second,
+		WriteTimeout: 10 * time.Second,
+		Handler:      newHTTPHandler(),
+	}
+	srvErr := make(chan error, 1)
+	go func() {
+		srvErr <- srv.ListenAndServe()
+	}()
+
+	// Wait for interruption.
+	select {
+	case err = <-srvErr:
+		// Error when starting HTTP server.
+		return err
+	case <-ctx.Done():
+		stop()
+	}
+
+	ldobserve.Shutdown()
+
+	// When Shutdown is called, ListenAndServe immediately returns ErrServerClosed.
+	err = srv.Shutdown(context.Background())
+	return err
+}
+
+func newHTTPHandler() http.Handler {
+	mux := http.NewServeMux()
+
+	_, span := ldobserve.StartSpan(context.Background(), "test-span", []trace.SpanStartOption{})
+	span.SetAttributes(attribute.String("test-attribute", "test-value"))
+	span.End()
+
+	// handleFunc is a replacement for mux.HandleFunc
+	// which enriches the handler's HTTP instrumentation with the pattern as the http.route.
+	handleFunc := func(pattern string, handlerFunc func(http.ResponseWriter, *http.Request)) {
+		// Configure the "http.route" for the HTTP instrumentation.
+		handler := otelhttp.WithRouteTag(pattern, http.HandlerFunc(handlerFunc))
+		mux.Handle(pattern, handler)
+	}
+
+	// Register handlers.Als
+	handleFunc("/rolldice", dice.Rolldice)
+
+	// Add HTTP instrumentation for the whole server.
+	handler := otelhttp.NewHandler(
+		mux,
+		"/",
+		otelhttp.WithSpanNameFormatter(func(operation string, r *http.Request) string {
+			// Return the route as the span name
+			return r.URL.Path
+		}))
+	return handler
+}

--- a/go/initialize.go
+++ b/go/initialize.go
@@ -1,0 +1,100 @@
+package ldobserve
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Khan/genqlient/graphql"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.34.0"
+
+	"github.com/launchdarkly/observability-sdk/go/attributes"
+	"github.com/launchdarkly/observability-sdk/go/internal/gql"
+	"github.com/launchdarkly/observability-sdk/go/internal/logging"
+	"github.com/launchdarkly/observability-sdk/go/internal/metadata"
+	"github.com/launchdarkly/observability-sdk/go/internal/otel"
+)
+
+func getSamplingConfig(projectId string, config observabilityConfig) (*gql.GetSamplingConfigResponse, error) {
+	var ctx context.Context
+	if config.context != nil {
+		ctx = config.context
+	} else {
+		ctx = context.Background()
+	}
+	client := graphql.NewClient(config.backendURL, http.DefaultClient)
+	return gql.GetSamplingConfig(ctx, client, projectId)
+}
+
+func setupOtel(sdkKey string, config observabilityConfig) {
+	attributes := []attribute.KeyValue{
+		semconv.TelemetryDistroNameKey.String(metadata.InstrumentationName),
+		semconv.TelemetryDistroVersionKey.String(metadata.InstrumentationVersion),
+		attribute.String(attributes.ProjectIDAttribute, sdkKey),
+	}
+	if config.environment != "" {
+		attributes = append(attributes, semconv.DeploymentEnvironmentName(config.environment))
+	}
+	if config.serviceName != "" {
+		attributes = append(attributes, semconv.ServiceNameKey.String(config.serviceName))
+	}
+	if config.serviceVersion != "" {
+		attributes = append(attributes, semconv.ServiceVersionKey.String(config.serviceVersion))
+	}
+	if config.debug {
+		logging.SetLogger(logging.ConsoleLogger{})
+	}
+
+	var s trace.Sampler
+	if len(config.samplingRateMap) > 0 {
+		s = getSampler(config.samplingRateMap)
+	} else {
+		s = nil
+	}
+	otel.SetConfig(otel.Config{
+		OtlpEndpoint:       config.otlpEndpoint,
+		ResourceAttributes: attributes,
+		Sampler:            s,
+	})
+	if !config.manualStart {
+		err := otel.StartOTLP()
+		if err != nil {
+			logging.GetLogger().Errorf("failed to start otel: %v", err)
+		}
+	}
+	go func() {
+		cfg, err := getSamplingConfig(sdkKey, config)
+		if err != nil {
+			logging.GetLogger().Errorf("failed to get sampling config: %v", err)
+			return
+		}
+		logging.GetLogger().Infof("got sampling config: %v", cfg)
+		otel.SetSamplingConfig(cfg)
+	}()
+	if config.context != nil {
+		go func() {
+			<-config.context.Done()
+			otel.Shutdown()
+		}()
+	}
+}
+
+// PreInitialize initializes the observability plugin independently of the
+// LaunchDarkly client.
+//
+// In most situations the plugin should be used instead of this function.
+// In cases where the usage of observability needs to be flagged, the plugin
+// can be used with the WithManualStart option.
+//
+// This function is provided for situations where the LaunchDarkly client is not
+// readily available, or when observability needs to be initialized earlier than
+// the LaunchDarkly client.
+func PreInitialize(sdkKey string, opts ...Option) {
+	config := defaultConfig()
+	for _, opt := range opts {
+		opt(&config)
+	}
+
+	setupOtel(sdkKey, config)
+}

--- a/go/plugin.go
+++ b/go/plugin.go
@@ -5,30 +5,15 @@
 package ldobserve
 
 import (
-	"context"
-	"net/http"
-
-	"github.com/Khan/genqlient/graphql"
-
-	"github.com/launchdarkly/observability-sdk/go/attributes"
-	"github.com/launchdarkly/observability-sdk/go/internal/gql"
-	"github.com/launchdarkly/observability-sdk/go/internal/logging"
-	"github.com/launchdarkly/observability-sdk/go/internal/metadata"
-
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.34.0"
-
 	"github.com/launchdarkly/go-server-sdk/ldotel"
 	"github.com/launchdarkly/go-server-sdk/v7/interfaces"
 	"github.com/launchdarkly/go-server-sdk/v7/ldhooks"
 	"github.com/launchdarkly/go-server-sdk/v7/ldplugins"
-	"github.com/launchdarkly/observability-sdk/go/internal/otel"
 )
 
 // ObservabilityPlugin represents the LaunchDarkly observability plugin.
 type ObservabilityPlugin struct {
-	config observabilityConfig
+	config *observabilityConfig
 	ldplugins.Unimplemented
 }
 
@@ -40,8 +25,16 @@ func NewObservabilityPlugin(opts ...Option) *ObservabilityPlugin {
 	}
 
 	return &ObservabilityPlugin{
-		config: config,
+		config: &config,
 	}
+}
+
+// NewObservabilityPluginWithoutInit creates a new observability plugin without
+// for performing initialization.
+// This method generally does not need to be used, and should only be used in
+// conjunction with InitializeWithoutPlugin.
+func NewObservabilityPluginWithoutInit() *ObservabilityPlugin {
+	return &ObservabilityPlugin{}
 }
 
 // GetHooks returns the hooks for the observability plugin.
@@ -56,67 +49,10 @@ func (p ObservabilityPlugin) Metadata() ldplugins.Metadata {
 	return ldplugins.NewMetadata("launchdarkly-observability")
 }
 
-func (p ObservabilityPlugin) getSamplingConfig(projectId string) (*gql.GetSamplingConfigResponse, error) {
-	var ctx context.Context
-	if p.config.context != nil {
-		ctx = p.config.context
-	} else {
-		ctx = context.Background()
-	}
-	client := graphql.NewClient(p.config.backendURL, http.DefaultClient)
-	return gql.GetSamplingConfig(ctx, client, projectId)
-}
-
 // Register registers the observability plugin with the LaunchDarkly client.
 func (p ObservabilityPlugin) Register(client interfaces.LDClientInterface, ldmd ldplugins.EnvironmentMetadata) {
-	attributes := []attribute.KeyValue{
-		semconv.TelemetryDistroNameKey.String(metadata.InstrumentationName),
-		semconv.TelemetryDistroVersionKey.String(metadata.InstrumentationVersion),
-		attribute.String(attributes.ProjectIDAttribute, ldmd.SdkKey),
+	if p.config == nil {
+		return
 	}
-	if p.config.environment != "" {
-		attributes = append(attributes, semconv.DeploymentEnvironmentName(p.config.environment))
-	}
-	if p.config.serviceName != "" {
-		attributes = append(attributes, semconv.ServiceNameKey.String(p.config.serviceName))
-	}
-	if p.config.serviceVersion != "" {
-		attributes = append(attributes, semconv.ServiceVersionKey.String(p.config.serviceVersion))
-	}
-	if p.config.debug {
-		logging.SetLogger(logging.ConsoleLogger{})
-	}
-
-	var s trace.Sampler
-	if len(p.config.samplingRateMap) > 0 {
-		s = getSampler(p.config.samplingRateMap)
-	} else {
-		s = nil
-	}
-	otel.SetConfig(otel.Config{
-		OtlpEndpoint:       p.config.otlpEndpoint,
-		ResourceAttributes: attributes,
-		Sampler:            s,
-	})
-	if !p.config.manualStart {
-		err := otel.StartOTLP()
-		if err != nil {
-			logging.GetLogger().Errorf("failed to start otel: %v", err)
-		}
-	}
-	go func() {
-		cfg, err := p.getSamplingConfig(ldmd.SdkKey)
-		if err != nil {
-			logging.GetLogger().Errorf("failed to get sampling config: %v", err)
-			return
-		}
-		logging.GetLogger().Infof("got sampling config: %v", cfg)
-		otel.SetSamplingConfig(cfg)
-	}()
-	if p.config.context != nil {
-		go func() {
-			<-p.config.context.Done()
-			otel.Shutdown()
-		}()
-	}
+	setupOtel(ldmd.SdkKey, *p.config)
 }


### PR DESCRIPTION
## Summary

Allow for initialization of Go observability independent of the LaunchDarkly SDK.

This allows for advanced use-cases where the LD SDK may not be in use, or may not be readily accessible.

I called it `PreInitialize`, but I am not attached to that name. 

You do this:
```go
	// Initialize the observability plugin ahead of the LaunchDarkly client.
	// This is generally only required for advanced use cases and is not the
	// recommended way to initialize observability.
	// Observability can also be used without the LaunchDarkly client at all
	// by using this method. Some features will not be available when using
	// observability without the LaunchDarkly client.
	ldobserve.PreInitialize(os.Getenv("LAUNCHDARKLY_SDK_KEY"),
		ldobserve.WithEnvironment("test"),
		ldobserve.WithServiceName("go-plugin-example"),
		ldobserve.WithServiceVersion(version.Commit),
	)
```

And now observability it setup. 

You can then later optionally use the plugin to facilitate registering hooks.

```
	client, _ := ld.MakeCustomClient(os.Getenv("LAUNCHDARKLY_SDK_KEY"),
		ld.Config{
			Plugins: []ldplugins.Plugin{
				// This special form of constructing the observability plugin
				// is used when observability has been pre-initialized.
				ldobserve.NewObservabilityPluginWithoutInit(),
			},
		}, 5*time.Second)
```

Or you can directly use the ldotel hook instead. Using the plugin will be more resilient in case we add more hooks.


## How did you test this change?

Manual testing.

