### PR TITLE
feat: config options to customize privacy classes and selectors

### DIFF
--- a/e2e/react-router/src/ldclient.tsx
+++ b/e2e/react-router/src/ldclient.tsx
@@ -16,9 +16,7 @@ const observabilitySettings: ConstructorParameters<typeof Observability>[0] = {
 		otlpEndpoint: 'http://localhost:4318',
 	},
 }
-export const sessionReplaySettings: ConstructorParameters<
-	typeof SessionReplay
->[0] = {
+const sessionReplaySettings: ConstructorParameters<typeof SessionReplay>[0] = {
 	debug: { clientInteractions: true, domRecording: true },
 	privacySetting: 'none',
 	serviceName: 'ryan-test',

--- a/e2e/react-router/src/ldclient.tsx
+++ b/e2e/react-router/src/ldclient.tsx
@@ -16,7 +16,9 @@ const observabilitySettings: ConstructorParameters<typeof Observability>[0] = {
 		otlpEndpoint: 'http://localhost:4318',
 	},
 }
-const sessionReplaySettings: ConstructorParameters<typeof SessionReplay>[0] = {
+export const sessionReplaySettings: ConstructorParameters<
+	typeof SessionReplay
+>[0] = {
 	debug: { clientInteractions: true, domRecording: true },
 	privacySetting: 'none',
 	serviceName: 'ryan-test',

--- a/e2e/react-router/src/main.tsx
+++ b/e2e/react-router/src/main.tsx
@@ -10,6 +10,7 @@ import {
 } from 'react-router-dom'
 import Root from './routes/root'
 import Welcome from './routes/welcome'
+import PrivacyDemo from './routes/privacy-demo'
 
 function rootAction() {
 	const contact = { name: 'hello' }
@@ -55,6 +56,7 @@ const router = createBrowserRouter(
 				</Route>
 			</Route>
 			<Route path={'/welcome'} element={<Welcome />} />
+			<Route path={'/privacy'} element={<PrivacyDemo />} />
 		</>,
 	),
 )

--- a/e2e/react-router/src/routes/privacy-demo.tsx
+++ b/e2e/react-router/src/routes/privacy-demo.tsx
@@ -1,0 +1,109 @@
+import { useEffect } from 'react'
+import { initialize as init } from 'launchdarkly-js-client-sdk'
+import SessionReplay from '@launchdarkly/session-replay'
+import { sessionReplaySettings } from '../ldclient'
+
+export default function PrivacyDemo() {
+	useEffect(() => {
+		const client = init(
+			'548f6741c1efad40031b18ae',
+			{ key: 'unknown' },
+			{
+				plugins: [
+					new SessionReplay({
+						...sessionReplaySettings,
+						maskTextClass: 'ld-mask-text',
+						maskTextSelector: '[data-masking="true"]',
+						ignoreClass: 'ld-ignore',
+						ignoreSelector: '[data-ignore="true"]',
+						blockClass: 'ld-block',
+						blockSelector: '[data-block="true"]',
+					}),
+				],
+			},
+		)
+
+		client.on('ready', () => {
+			console.log('client ready')
+		})
+	}, [])
+
+	return (
+		<div style={{ display: 'grid', gap: 16 }}>
+			<h2>Session Replay Privacy Demo</h2>
+			<p>
+				This page showcases rrweb privacy options exposed via
+				@launchdarkly/session-replay.
+			</p>
+			<section>
+				<h3>Masked text by class</h3>
+				<p>
+					<span>Visible text</span>
+				</p>
+				<p className="ld-mask-text">
+					<span>Secret text</span>
+				</p>
+			</section>
+
+			<section>
+				<h3>Masked text by selector</h3>
+				<div data-masking="true">
+					This subtree should be masked by selector
+					<div>
+						<div>Deep child content</div>
+					</div>
+				</div>
+			</section>
+
+			<section>
+				<h3>Ignored inputs by class</h3>
+				<label>
+					Not ignored input:
+					<input type="text" placeholder="Type here (recorded)" />
+				</label>
+				<label>
+					Ignored input (class):
+					<input
+						className="ld-ignore"
+						type="text"
+						placeholder="Type here (ignored)"
+					/>
+				</label>
+			</section>
+
+			<section>
+				<h3>Ignored inputs by selector</h3>
+				<label>
+					Ignored input (selector):
+					<input
+						data-ignore="true"
+						type="text"
+						placeholder="Type here (ignored)"
+					/>
+				</label>
+			</section>
+
+			<section>
+				<h3>Blocked subtree</h3>
+				<div
+					className="ld-block"
+					style={{ border: '1px solid #ccc', padding: 8 }}
+				>
+					<p>Contents should be blocked (not serialized)</p>
+					<img src="/vite.svg" alt="example" width={48} height={48} />
+				</div>
+			</section>
+
+			<section>
+				<h3>Blocked subtree by selector</h3>
+				<div
+					data-block="true"
+					style={{ border: '1px solid #ccc', padding: 8 }}
+				>
+					<p>Contents should be blocked (not serialized)</p>
+				</div>
+				<img src="/vite.svg" alt="example" width={48} height={48} />
+			</section>
+		</div>
+	)
+}

--- a/e2e/react-router/src/routes/privacy-demo.tsx
+++ b/e2e/react-router/src/routes/privacy-demo.tsx
@@ -1,17 +1,20 @@
 import { useEffect } from 'react'
 import { initialize as init } from 'launchdarkly-js-client-sdk'
 import SessionReplay from '@launchdarkly/session-replay'
-import { sessionReplaySettings } from '../ldclient'
 
 export default function PrivacyDemo() {
 	useEffect(() => {
-		const client = init(
+		init(
 			'548f6741c1efad40031b18ae',
 			{ key: 'unknown' },
 			{
 				plugins: [
 					new SessionReplay({
-						...sessionReplaySettings,
+						privacySetting: 'none',
+						serviceName: 'privacy-test',
+						backendUrl: 'http://localhost:8082/public',
+						debug: { clientInteractions: true, domRecording: true },
+
 						maskTextClass: 'ld-mask-text',
 						maskTextSelector: '[data-masking="true"]',
 						ignoreClass: 'ld-ignore',
@@ -22,10 +25,6 @@ export default function PrivacyDemo() {
 				],
 			},
 		)
-
-		client.on('ready', () => {
-			console.log('client ready')
-		})
 	}, [])
 
 	return (
@@ -84,12 +83,12 @@ export default function PrivacyDemo() {
 			</section>
 
 			<section>
-				<h3>Blocked subtree</h3>
+				<h3>Blocked subtree by class</h3>
 				<div
 					className="ld-block"
 					style={{ border: '1px solid #ccc', padding: 8 }}
 				>
-					<p>Contents should be blocked (not serialized)</p>
+					<p>Contents should be blocked (not recorded)</p>
 					<img src="/vite.svg" alt="example" width={48} height={48} />
 				</div>
 			</section>
@@ -100,9 +99,9 @@ export default function PrivacyDemo() {
 					data-block="true"
 					style={{ border: '1px solid #ccc', padding: 8 }}
 				>
-					<p>Contents should be blocked (not serialized)</p>
+					<p>Contents should be blocked (not recorded)</p>
+					<img src="/vite.svg" alt="example" width={48} height={48} />
 				</div>
-				<img src="/vite.svg" alt="example" width={48} height={48} />
 			</section>
 		</div>
 	)

--- a/e2e/react-router/src/routes/root.tsx
+++ b/e2e/react-router/src/routes/root.tsx
@@ -39,6 +39,10 @@ export default function Root() {
 	return (
 		<div id="sidebar">
 			<h1>Hello, world</h1>
+			<nav style={{ display: 'flex', gap: 12 }}>
+				<a href="/welcome">Welcome</a>
+				<a href="/privacy">Privacy Demo</a>
+			</nav>
 			<p>{flags}</p>
 			<a href={session} target={'_blank'}>
 				{session}

--- a/sdk/highlight-run/src/__tests__/record-config.test.ts
+++ b/sdk/highlight-run/src/__tests__/record-config.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { RecordSDK } from '../sdk/record'
+
+const recordSpy = vi.fn((...args: any[]) => {
+	return vi.fn()
+})
+vi.mock('rrweb', () => ({
+	addCustomEvent: vi.fn(),
+	record: (...args: any[]) => recordSpy(...args),
+}))
+
+// Mock GraphQL generated SDK used inside RecordSDK.initializeSession
+vi.mock('../client/graph/generated/operations', () => ({
+	getSdk: () => ({
+		initializeSession: vi.fn().mockResolvedValue({
+			initializeSession: {
+				secure_id: 'test-session',
+				project_id: '1',
+			},
+		}),
+	}),
+}))
+
+// Provide a minimal worker mock used by RecordSDK
+vi.mock('../client/workers/highlight-client-worker?worker&inline', () => ({
+	default: class MockWorker {
+		onmessage: any
+		postMessage() {}
+	},
+}))
+
+describe('RecordSDK -> rrweb.record config wiring', () => {
+	const originalWindow = global.window
+
+	beforeEach(() => {
+		vi.useFakeTimers()
+		recordSpy.mockClear()
+	})
+
+	afterEach(() => {
+		vi.useRealTimers()
+		global.window = originalWindow
+	})
+
+	it('passes default ignore/block/mask options to rrweb.record', async () => {
+		const sdk = new RecordSDK({
+			organizationID: '1',
+			sessionSecureID: 'seed',
+		})
+
+		await sdk.start()
+
+		expect(recordSpy).toHaveBeenCalledTimes(1)
+		const arg = (recordSpy.mock.calls as any[])[0][0]
+		// Defaults
+		expect(arg.ignoreClass).toBe('highlight-ignore')
+		expect(arg.blockClass).toBe('highlight-block')
+		expect(arg.ignoreSelector).toBeUndefined()
+		expect(arg.blockSelector).toBeUndefined()
+		expect(arg.maskTextClass).toBeUndefined()
+		expect(arg.maskTextSelector).toBeUndefined()
+	})
+
+	it('respects overridden ignore/block/mask options', async () => {
+		const sdk = new RecordSDK({
+			organizationID: '1',
+			sessionSecureID: 'seed',
+			ignoreClass: 'custom-ignore',
+			ignoreSelector: '.ignore-me',
+			blockClass: 'custom-block',
+			blockSelector: '.block-me',
+			maskTextClass: 'mask-this',
+			maskTextSelector: '.mask-me',
+		})
+
+		await sdk.start()
+
+		expect(recordSpy).toHaveBeenCalledTimes(1)
+		const arg = (recordSpy.mock.calls as any[])[0][0]
+		expect(arg.ignoreClass).toBe('custom-ignore')
+		expect(arg.ignoreSelector).toBe('.ignore-me')
+		expect(arg.blockClass).toBe('custom-block')
+		expect(arg.blockSelector).toBe('.block-me')
+		expect(arg.maskTextClass).toBe('mask-this')
+		expect(arg.maskTextSelector).toBe('.mask-me')
+	})
+})

--- a/sdk/highlight-run/src/client/index.tsx
+++ b/sdk/highlight-run/src/client/index.tsx
@@ -143,6 +143,12 @@ export type HighlightClassOptions = {
 	reportConsoleErrors?: boolean
 	consoleMethodsToRecord?: ConsoleMethods[]
 	privacySetting?: PrivacySettingOption
+	maskTextClass?: string | RegExp
+	maskTextSelector?: string
+	blockClass?: string | RegExp
+	blockSelector?: string
+	ignoreClass?: string
+	ignoreSelector?: string
 	enableSegmentIntegration?: boolean
 	enableCanvasRecording?: boolean
 	enablePerformanceRecording?: boolean
@@ -823,13 +829,17 @@ SessionSecureID: ${this.sessionData.sessionSecureID}`,
 			)
 
 			this._recordStop = record({
-				ignoreClass: 'highlight-ignore',
-				blockClass: 'highlight-block',
+				ignoreClass: this.options.ignoreClass ?? 'highlight-ignore',
+				ignoreSelector: this.options.ignoreSelector,
+				blockClass: this.options.blockClass ?? 'highlight-block',
+				blockSelector: this.options.blockSelector,
 				emit,
 				recordCrossOriginIframes: this.options.recordCrossOriginIframe,
 				privacySetting: this.privacySetting,
 				maskAllInputs,
 				maskInputOptions: maskInputOptions,
+				maskTextClass: this.options.maskTextClass,
+				maskTextSelector: this.options.maskTextSelector,
 				recordCanvas: this.enableCanvasRecording,
 				sampling: {
 					canvas: {

--- a/sdk/highlight-run/src/client/types/record.ts
+++ b/sdk/highlight-run/src/client/types/record.ts
@@ -38,6 +38,40 @@ export type RecordOptions = CommonOptions & {
 	privacySetting?: PrivacySettingOption
 
 	/**
+	 * Customize which elements' text should be masked by specifying a CSS class name or RegExp.
+	 * Default class is 'highlight-mask'.
+	 */
+	maskTextClass?: string | RegExp
+
+	/**
+	 * Customize which elements' text should be masked via a CSS selector that will match the element
+	 * and its descendants.
+	 */
+	maskTextSelector?: string
+
+	/**
+	 * Customize which elements should be blocked (not serialized) by specifying a class name or RegExp.
+	 * Default is 'highlight-block'.
+	 */
+	blockClass?: string | RegExp
+
+	/**
+	 * Customize which elements should be blocked via a CSS selector.
+	 */
+	blockSelector?: string
+
+	/**
+	 * Customize which elements and their descendants should be ignored from DOM events by class.
+	 * Default is 'highlight-ignore'.
+	 */
+	ignoreClass?: string
+
+	/**
+	 * Customize which elements should be ignored from DOM events via a CSS selector.
+	 */
+	ignoreSelector?: string
+
+	/**
 	 * Specifies whether to record canvas elements or not.
 	 * @default false
 	 */

--- a/sdk/highlight-run/src/client/types/record.ts
+++ b/sdk/highlight-run/src/client/types/record.ts
@@ -64,7 +64,7 @@ export type RecordOptions = CommonOptions & {
 	 * Customize which elements and their descendants should be ignored from DOM events by class.
 	 * Default is 'highlight-ignore'.
 	 */
-	ignoreClass?: string | RegExp
+	ignoreClass?: string
 
 	/**
 	 * Customize which elements should be ignored from DOM events via a CSS selector.

--- a/sdk/highlight-run/src/client/types/record.ts
+++ b/sdk/highlight-run/src/client/types/record.ts
@@ -50,7 +50,7 @@ export type RecordOptions = CommonOptions & {
 	maskTextSelector?: string
 
 	/**
-	 * Customize which elements should be blocked (not serialized) by specifying a class name or RegExp.
+	 * Customize which elements should be blocked (not recorded) by specifying a class name or RegExp.
 	 * Default is 'highlight-block'.
 	 */
 	blockClass?: string | RegExp
@@ -64,7 +64,7 @@ export type RecordOptions = CommonOptions & {
 	 * Customize which elements and their descendants should be ignored from DOM events by class.
 	 * Default is 'highlight-ignore'.
 	 */
-	ignoreClass?: string
+	ignoreClass?: string | RegExp
 
 	/**
 	 * Customize which elements should be ignored from DOM events via a CSS selector.

--- a/sdk/highlight-run/src/sdk/record.ts
+++ b/sdk/highlight-run/src/sdk/record.ts
@@ -596,13 +596,17 @@ SessionSecureID: ${this.sessionData.sessionSecureID}`,
 			)
 
 			this._recordStop = record({
-				ignoreClass: 'highlight-ignore',
-				blockClass: 'highlight-block',
+				ignoreClass: this.options.ignoreClass ?? 'highlight-ignore',
+				ignoreSelector: this.options.ignoreSelector,
+				blockClass: this.options.blockClass ?? 'highlight-block',
+				blockSelector: this.options.blockSelector,
 				emit,
 				recordCrossOriginIframes: this.options.recordCrossOriginIframe,
 				privacySetting: this.privacySetting,
 				maskAllInputs,
 				maskInputOptions: maskInputOptions,
+				maskTextClass: this.options.maskTextClass,
+				maskTextSelector: this.options.maskTextSelector,
 				recordCanvas: this.enableCanvasRecording,
 				sampling: {
 					canvas: {


### PR DESCRIPTION
## Summary

Adds some new config options for specifying custom classes and selectors for masking, ignoring, and blocking elements. The new settings are:

* `maskTextClass`
* `maskTextSelector`
* `blockClass`
* `blockSelector`
* `ignoreClass`
* `ignoreSelector`

## How did you test this change?

I added a privacy demo page in the react router E2E app that shows each option being used.

https://www.loom.com/share/ad0a0fadc00a41ef9c687f431dabc576

## Are there any deployment considerations?

Some customers are waiting for this change and we will need to notify them.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce configurable classes/selectors for masking, ignoring, and blocking in session replay, with an E2E privacy demo and unit tests verifying rrweb.config wiring.
> 
> - **SDK (session replay)**:
>   - Add options to `RecordOptions`/client init: `maskTextClass`, `maskTextSelector`, `blockClass`, `blockSelector`, `ignoreClass`, `ignoreSelector`.
>   - Pass these options to `rrweb.record` (with defaults `highlight-ignore`/`highlight-block`), including `maskText*` selectors.
> - **Tests**:
>   - Add `record-config.test.ts` to assert default and overridden privacy options are forwarded to `rrweb.record`.
> - **E2E (react-router app)**:
>   - Add `routes/privacy-demo.tsx` showcasing masking/ignoring/blocking via class/selector.
>   - Wire route `'/privacy'` in `src/main.tsx` and add nav links in `routes/root.tsx`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 67159df9f78ad66ad98cfea70f958b797f93a074. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->