### PR TITLE
fix: Fix telemetry version for Go plugin.

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -30,7 +30,7 @@
 			"versioning": "default",
 			"include-v-in-tag": true,
 			"include-component-in-tag": true,
-			"extra-files": ["version.go"]
+			"extra-files": ["internal/metadata/metadata.go"]
 		},
 		"sdk/@launchdarkly/observability-dotnet": {
 			"bump-minor-pre-major": true,


### PR DESCRIPTION
## Summary

There was some refactoring in the go SDK which moved where the version is stored. The release-please config was not updated for the change