### PR TITLE
feat: add addSessionProperties to RecordSDK

### DIFF
--- a/e2e/react-router/src/routes/root.tsx
+++ b/e2e/react-router/src/routes/root.tsx
@@ -301,6 +301,42 @@ export default function Root() {
 			>
 				LDObserve.stop()
 			</button>
+			<div
+				style={{
+					marginTop: 8,
+					padding: 12,
+					border: '1px solid #ddd',
+					borderRadius: 6,
+					maxWidth: 720,
+				}}
+			>
+				<h3>Session Properties</h3>
+				<p>
+					Add custom session-level attributes via{' '}
+					<code>LDRecord.addSessionProperties</code>.
+				</p>
+				<textarea
+					style={{
+						width: '100%',
+						minHeight: 120,
+						fontFamily: 'monospace',
+					}}
+					defaultValue='{"plan":"pro","favoriteColor":"seafoam"}'
+					placeholder='{"key":"value"}'
+				/>
+				<div style={{ display: 'flex', gap: 8, marginTop: 8 }}>
+					<button
+						onClick={() => {
+							const value =
+								document.querySelector('textarea')?.value ?? ''
+
+							LDRecord.addSessionProperties(JSON.parse(value))
+						}}
+					>
+						Apply session properties
+					</button>
+				</div>
+			</div>
 		</div>
 	)
 }

--- a/sdk/highlight-run/src/__tests__/record-add-session-properties.test.ts
+++ b/sdk/highlight-run/src/__tests__/record-add-session-properties.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../client/workers/highlight-client-worker?worker&inline', () => {
+	class FakeWorker {
+		onmessage = (_e: any) => {}
+		postMessage = vi.fn((_message: any) => null)
+	}
+	return { default: FakeWorker }
+})
+
+import { RecordSDK } from '../sdk/record'
+import { LDRecord } from '../sdk/LDRecord'
+import { MessageType } from '../client/workers/types'
+
+describe('Record addSessionProperties', () => {
+	let recordImpl: RecordSDK
+
+	beforeEach(() => {
+		recordImpl = new RecordSDK({
+			organizationID: '1',
+			environment: 'test',
+			sessionSecureID: 'test-session',
+		})
+	})
+
+	it('posts Properties message with session type to the worker', () => {
+		const postSpy = vi.spyOn((recordImpl as any)._worker, 'postMessage')
+
+		const props = { plan: 'pro', count: 1, active: true }
+		recordImpl.addSessionProperties(props)
+
+		expect(postSpy).toHaveBeenCalled()
+		const call = postSpy.mock.calls[0]?.[0] as any
+		expect(call?.message?.type).toBe(MessageType.Properties)
+		expect(call?.message?.propertyType).toEqual({ type: 'session' })
+		expect(call?.message?.propertiesObject).toMatchObject(props)
+	})
+
+	it('LDRecord proxies addSessionProperties to implementation', () => {
+		// Load the implementation into the LDRecord buffered proxy
+		LDRecord.load(recordImpl)
+
+		const spy = vi.spyOn(recordImpl, 'addSessionProperties')
+		const props = { foo: 'bar' }
+		LDRecord.addSessionProperties(props)
+
+		expect(spy).toHaveBeenCalledWith(props)
+	})
+})

--- a/sdk/highlight-run/src/api/record.ts
+++ b/sdk/highlight-run/src/api/record.ts
@@ -15,6 +15,11 @@ export interface Record {
 	 */
 	stop: () => void
 	/**
+	 * Add custom session-level properties. These are attached to the current session
+	 * and are searchable, but do not create timeline Track events.
+	 */
+	addSessionProperties: (properties: { [key: string]: any }) => void
+	/**
 	 * Snapshot an HTML <canvas> element in WebGL manual snapshotting mode.
 	 * See {@link https://www.highlight.io/docs/getting-started/browser/replay-configuration/canvas#manual-snapshotting}
 	 * for more information.

--- a/sdk/highlight-run/src/sdk/LDRecord.ts
+++ b/sdk/highlight-run/src/sdk/LDRecord.ts
@@ -20,6 +20,10 @@ class _LDRecord extends BufferedClass<Record> implements Record {
 		return this._sdk.stop()
 	}
 
+	addSessionProperties(properties: { [key: string]: any }) {
+		return this._bufferCall('addSessionProperties', [properties])
+	}
+
 	getRecordingState() {
 		return this._isLoaded
 			? this._bufferCall('getRecordingState', [])

--- a/sdk/highlight-run/src/sdk/record.ts
+++ b/sdk/highlight-run/src/sdk/record.ts
@@ -403,6 +403,14 @@ export class RecordSDK implements Record {
 		})
 	}
 
+	/**
+	 * Add custom session-level properties. These are attached to the current session
+	 * and are searchable, but do not create timeline Track events.
+	 */
+	addSessionProperties(properties: { [key: string]: any }) {
+		this.addProperties(properties, { type: 'session' })
+	}
+
 	async start(options?: StartOptions) {
 		if (
 			navigator?.userAgent?.includes('Googlebot') ||


### PR DESCRIPTION
## Summary

Adds the `addSessionProperties` method to the Record SDK allowing users to call `RecordSDK.addSessionProperties` to attach metadata to sessions.

## How did you test this change?

Added a new E2E test page in the react router app and sent [a session to staging](https://ld-stg.launchdarkly.com/projects/default/sessions/5sSphshqZVXLgNOJWR69Tm3GdKXN?query=service_name%3Dryan-test&page=1&relativeTime=last_30_days&env=alexis-perf&selected-env=alexis-perf). Note the `plan` and `favoriteColor` properties.

<img width="1122" height="825" alt="image" src="https://github.com/user-attachments/assets/2bb3dab2-5d35-42a2-8353-1bfc27c697b9" />

## Are there any deployment considerations?

Need to notify customers waiting on this functionality and open a docs PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce `addSessionProperties` to Record SDK and `LDRecord`, wiring it to send session-scoped Properties messages; add unit tests and an E2E UI panel to apply properties.
> 
> - **SDK**:
>   - Add `Record.addSessionProperties(properties)` in `sdk/highlight-run/src/api/record.ts`.
>   - Implement in `RecordSDK.addSessionProperties` to call `addProperties(..., { type: 'session' })` and post a `MessageType.Properties` message.
>   - Add `LDRecord.addSessionProperties` proxy in `sdk/highlight-run/src/sdk/LDRecord.ts`.
> - **Tests**:
>   - New `record-add-session-properties.test.ts` verifies worker posts `Properties` with `{ type: 'session' }` and that `LDRecord` proxies correctly.
> - **E2E/Demo**:
>   - Add "Session Properties" panel in `e2e/react-router/src/routes/root.tsx` to input JSON and call `LDRecord.addSessionProperties`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8d30961183856deda3f6d8067b6d3c361a9b4035. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->