### PR TITLE
feat: O11Y-576 / O11Y-544 - Added disk buffering to cache signals

### DIFF
--- a/e2e/android/app/build.gradle.kts
+++ b/e2e/android/app/build.gradle.kts
@@ -65,6 +65,9 @@ dependencies {
     implementation("io.opentelemetry.android.instrumentation:httpurlconnection-library:0.11.0-alpha")
     byteBuddy("io.opentelemetry.android.instrumentation:httpurlconnection-agent:0.11.0-alpha")
 
+    // Used for accessing the SignalFromDiskExporter class in TestApplication
+    implementation("io.opentelemetry.android:core:0.11.0-alpha")
+
     // OkHTTP instrumentation
     implementation("io.opentelemetry.android.instrumentation:okhttp3-library:0.11.0-alpha")
     byteBuddy("io.opentelemetry.android.instrumentation:okhttp3-agent:0.11.0-alpha")

--- a/e2e/android/app/src/test/java/com/example/androidobservability/TestApplication.kt
+++ b/e2e/android/app/src/test/java/com/example/androidobservability/TestApplication.kt
@@ -1,6 +1,7 @@
 package com.example.androidobservability
 
 import com.launchdarkly.sdk.android.LDClient
+import io.opentelemetry.android.features.diskbuffering.SignalFromDiskExporter
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import java.net.InetAddress
@@ -48,6 +49,7 @@ class TestApplication : BaseApplication() {
             mockWebServer = null
         }
         LDClient.get().close()
+        SignalFromDiskExporter.resetForTesting()
         super.onTerminate()
     }
 }

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/client/InstrumentationManager.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/client/InstrumentationManager.kt
@@ -133,7 +133,7 @@ class InstrumentationManager(
 
     private fun createOtelRumConfig(): OtelRumConfig {
         val config = OtelRumConfig()
-            .setDiskBufferingConfig(DiskBufferingConfig.create(enabled = true))
+            .setDiskBufferingConfig(DiskBufferingConfig.create(enabled = isAnySignalEnabled(options), debugEnabled = options.debug))
             .setSessionConfig(SessionConfig(backgroundInactivityTimeout = options.sessionBackgroundTimeout))
 
         if (options.disableErrorTracking) {
@@ -143,6 +143,10 @@ class InstrumentationManager(
         }
 
         return config
+    }
+
+    private fun isAnySignalEnabled(options: Options): Boolean {
+        return !options.disableLogs || !options.disableTraces || !options.disableMetrics || !options.disableErrorTracking
     }
 
     private fun configureLoggerProvider(sdkLoggerProviderBuilder: SdkLoggerProviderBuilder): SdkLoggerProviderBuilder {

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/client/InstrumentationManager.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/client/InstrumentationManager.kt
@@ -14,6 +14,7 @@ import com.launchdarkly.observability.sampling.SamplingLogExporter
 import com.launchdarkly.observability.sampling.SamplingTraceExporter
 import io.opentelemetry.android.OpenTelemetryRum
 import io.opentelemetry.android.config.OtelRumConfig
+import io.opentelemetry.android.features.diskbuffering.DiskBufferingConfig
 import io.opentelemetry.android.session.SessionConfig
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.logs.Logger
@@ -132,6 +133,7 @@ class InstrumentationManager(
 
     private fun createOtelRumConfig(): OtelRumConfig {
         val config = OtelRumConfig()
+            .setDiskBufferingConfig(DiskBufferingConfig.create(enabled = true))
             .setSessionConfig(SessionConfig(backgroundInactivityTimeout = options.sessionBackgroundTimeout))
 
         if (options.disableErrorTracking) {
@@ -311,7 +313,7 @@ class InstrumentationManager(
     }
 
     fun recordError(error: Error, attributes: Attributes) {
-        if(!options.disableErrorTracking){
+        if (!options.disableErrorTracking) {
             val span = otelTracer
                 .spanBuilder("highlight.error")
                 .setParent(Context.current().with(Span.current()))

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/sampling/CustomSampler.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/sampling/CustomSampler.kt
@@ -151,14 +151,14 @@ class CustomSampler(
     ): Boolean {
         if (config.severityText != null) {
             val severityText = record.severity?.name
-            if (severityText != null && !matchesValue(config.severityText, severityText)) {
+            if (!matchesValue(config.severityText, severityText)) {
                 return false
             }
         }
 
         if (config.message != null) {
             val message = record.bodyValue?.asString()
-            if (message != null && !matchesValue(config.message, message)) {
+            if (!matchesValue(config.message, message)) {
                 return false
             }
         }


### PR DESCRIPTION
## Summary
A DiskBufferingCache was set on OtelRumConfig to cache signals (metrics, traces, logs) and avoid data loss when the Android client has no connection.

CustomSampler: The log sampling logic was fixed to avoid continuing to evaluate a log in search of a match when the config severityText or message are not null but the log severityText or message values are null.

## How did you test this change?
Unit tests

## Are there any deployment considerations?
No

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables disk buffering in Otel RUM config and updates log sampling to not match when message/severity are absent, with tests and e2e test harness support.
> 
> - **Observability SDK (Android)**
>   - Enable disk buffering via `OtelRumConfig.setDiskBufferingConfig(DiskBufferingConfig.create(...))`, toggled by `isAnySignalEnabled(options)` and `options.debug`.
>   - Add helper `isAnySignalEnabled` and minor formatting cleanup.
> - **Sampling**
>   - Tighten `CustomSampler.matchesLogConfig` to treat missing `severityText`/`message` as non-matches.
>   - Update tests to cover non-match cases for null or mismatched `message`/`severity` and rename one test for clarity.
> - **E2E Test App**
>   - Add dependency `io.opentelemetry.android:core` and call `SignalFromDiskExporter.resetForTesting()` in `TestApplication.onTerminate()` to support disk buffering tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ad1b187b556f2cb3d646956883e5de2302813d7e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->