### PR TITLE
fix: support recordError with falsy Error

### DIFF
--- a/sdk/highlight-run/src/sdk/observe.ts
+++ b/sdk/highlight-run/src/sdk/observe.ts
@@ -254,9 +254,7 @@ export class ObserveSDK implements Observe {
 		source?: string,
 		type?: ErrorMessageType,
 	) {
-		if (!error) {
-			error = new Error(message ?? 'Unknown error')
-		}
+		error = error || new Error('Unknown error')
 		if (error instanceof Error && error.cause) {
 			payload = {
 				...payload,


### PR DESCRIPTION
## Summary

Support calling `LDObserve.recordError` with falsy value without causing an error.

## How did you test this change?

CI

## Are there any deployment considerations?

no

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure `recordError` handles nullish values by defaulting to `new Error('Unknown error')`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d63bee4e6523a4b6117ac36263e8e8016e5b9e31. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->