### PR TITLE
feat: Cache OpenTelemetry metric instruments

### DIFF
--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/client/InstrumentationManager.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/client/InstrumentationManager.kt
@@ -47,6 +47,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeUnit
 
 /**
@@ -94,10 +95,10 @@ class InstrumentationManager(
     private var spanProcessor: BatchSpanProcessor? = null
     private var logProcessor: BatchLogRecordProcessor? = null
     private var metricsReader: PeriodicMetricReader? = null
-    private val gaugeCache = mutableMapOf<String, DoubleGauge>()
-    private val counterCache = mutableMapOf<String, LongCounter>()
-    private val histogramCache = mutableMapOf<String, DoubleHistogram>()
-    private val upDownCounterCache = mutableMapOf<String, LongUpDownCounter>()
+    private val gaugeCache = ConcurrentHashMap<String, DoubleGauge>()
+    private val counterCache = ConcurrentHashMap<String, LongCounter>()
+    private val histogramCache = ConcurrentHashMap<String, DoubleHistogram>()
+    private val upDownCounterCache = ConcurrentHashMap<String, LongUpDownCounter>()
 
     //TODO: Evaluate if this class should have a close/shutdown method to close this scope
     private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())


### PR DESCRIPTION
## Summary
This change introduces caching for OpenTelemetry metric instruments (Gauge, Counter, Histogram, UpDownCounter) within the `InstrumentationManager`.

Previously, a new instrument was built for every metric recording call (`recordMetric`, `recordCount`, etc.), which is inefficient. Now, instruments are created once per metric name and reused for subsequent calls, improving performance.

## How did you test this change?
--

## Are there any deployment considerations?
No

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Caches OTEL metric instruments in `InstrumentationManager` and reuses them per metric name instead of rebuilding on each call.
> 
> - **Metrics caching in `sdk/@launchdarkly/observability-android/.../InstrumentationManager.kt`**:
>   - Add caches for instruments: `gaugeCache`, `counterCache`, `histogramCache`, `upDownCounterCache` using `ConcurrentHashMap`.
>   - Import instrument types (`DoubleGauge`, `LongCounter`, `DoubleHistogram`, `LongUpDownCounter`) and `ConcurrentHashMap`.
>   - Update `recordMetric`, `recordCount`, `recordIncr`, `recordHistogram`, `recordUpDownCounter` to `getOrPut` and reuse instruments by name.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6888028dd39ecd39f897391e10b81a0a5cf69ca3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->