### PR TITLE
fix: Fix an issue where logging configuration could over-match for log records without a message or severity.

### DIFF
--- a/go/internal/otel/custom_sampler.go
+++ b/go/internal/otel/custom_sampler.go
@@ -625,10 +625,12 @@ func (cs *CustomSampler) matchesLogConfig(
 
 	// Check message if defined
 	if messageConfig := config.GetMessage(); !isMatchConfigEmpty(&messageConfig) {
-		if record.Body().Kind() == log.KindString {
-			if !matchesValue(cs, &messageConfig, record.Body().AsString()) {
-				return false
-			}
+		// We only support string message bodies for now.
+		if record.Body().Kind() != log.KindString {
+			return false
+		}
+		if !matchesValue(cs, &messageConfig, record.Body().AsString()) {
+			return false
 		}
 	}
 

--- a/go/internal/otel/log-test-scenarios.json
+++ b/go/internal/otel/log-test-scenarios.json
@@ -420,5 +420,102 @@
 				}
 			}
 		]
+	},
+	{
+		"description": "Should not match an empty log when message and severity are defined",
+		"samplingConfig": {
+			"logs": [
+				{
+					"message": {
+						"regexValue": "Database connection .*"
+					},
+					"severityText": {
+						"matchValue": "error"
+					},
+					"samplingRatio": 90
+				}
+			]
+		},
+		"inputLog": {},
+		"samplerFunctionCases": [
+			{
+				"type": "always",
+				"expected_result": {
+					"sample": true
+				}
+			},
+			{
+				"type": "never",
+				"expected_result": {
+					"sample": true
+				}
+			}
+		]
+	},
+	{
+		"description": "Should not match a log with a message when message and severity are defined",
+		"samplingConfig": {
+			"logs": [
+				{
+					"message": {
+						"regexValue": "Database connection .*"
+					},
+					"severityText": {
+						"matchValue": "error"
+					},
+					"samplingRatio": 90
+				}
+			]
+		},
+		"inputLog": {
+			"message": "Database connection failed: timeout"
+		},
+		"samplerFunctionCases": [
+			{
+				"type": "always",
+				"expected_result": {
+					"sample": true
+				}
+			},
+			{
+				"type": "never",
+				"expected_result": {
+					"sample": true
+				}
+			}
+		]
+	},
+	{
+		"description": "Should not match a log with only severity when message and severity are defined",
+		"samplingConfig": {
+			"logs": [
+				{
+					"message": {
+						"regexValue": "Database connection .*"
+					},
+					"severityText": {
+						"matchValue": "error"
+					},
+					"samplingRatio": 90
+				}
+			]
+		},
+		"inputLog": {
+			"severityText": "error"
+		},
+		"samplerFunctionCases": [
+			{
+				"type": "always",
+				"expected_result": {
+					"sample": true
+				}
+			},
+			{
+				"type": "never",
+				"expected_result": {
+					"sample": true
+				}
+			}
+		]
 	}
 ]

--- a/sdk/@launchdarkly/observability-node/src/otel/sampling/CustomSampler.test.ts
+++ b/sdk/@launchdarkly/observability-node/src/otel/sampling/CustomSampler.test.ts
@@ -150,6 +150,14 @@ const runTestSpanScenarios = (scenarios: SpanTestScenario[]) => {
 	})
 }
 
+const toReadableLogRecord = (log: LogTestScenario['inputLog']) => {
+	return {
+		severityText: log.severityText,
+		body: log.message,
+		attributes: log.attributes,
+	} as ReadableLogRecord
+}
+
 const runTestLogScenarios = (scenarios: LogTestScenario[]) => {
 	scenarios.forEach((scenario) => {
 		scenario.samplerFunctionCases.forEach((samplerCase) => {
@@ -162,7 +170,7 @@ const runTestLogScenarios = (scenarios: LogTestScenario[]) => {
 				expect(sampler.isSamplingEnabled()).toBe(true)
 
 				const result = sampler.sampleLog(
-					scenario.inputLog as ReadableLogRecord,
+					toReadableLogRecord(scenario.inputLog),
 				)
 
 				expect(result.sample).toBe(samplerCase.expected_result.sample)

--- a/sdk/@launchdarkly/observability-node/src/otel/sampling/CustomSampler.ts
+++ b/sdk/@launchdarkly/observability-node/src/otel/sampling/CustomSampler.ts
@@ -232,20 +232,14 @@ export class CustomSampler implements ExportSampler {
 	): boolean {
 		if (config.severityText) {
 			const severityText = record.severityText
-			if (
-				typeof severityText === 'string' &&
-				!this.matchesValue(config.severityText, severityText)
-			) {
+			if (!this.matchesValue(config.severityText, severityText)) {
 				return false
 			}
 		}
 
 		if (config.message) {
 			const message = record.body
-			if (
-				typeof message === 'string' &&
-				!this.matchesValue(config.message, message)
-			) {
+			if (!this.matchesValue(config.message, message)) {
 				return false
 			}
 		}

--- a/sdk/@launchdarkly/observability-node/src/otel/sampling/log-test-scenarios.json
+++ b/sdk/@launchdarkly/observability-node/src/otel/sampling/log-test-scenarios.json
@@ -388,5 +388,102 @@
 				}
 			}
 		]
+	},
+	{
+		"description": "Should not match an empty log when message and severity are defined",
+		"samplingConfig": {
+			"logs": [
+				{
+					"message": {
+						"regexValue": "Database connection .*"
+					},
+					"severityText": {
+						"matchValue": "error"
+					},
+					"samplingRatio": 90
+				}
+			]
+		},
+		"inputLog": {},
+		"samplerFunctionCases": [
+			{
+				"type": "always",
+				"expected_result": {
+					"sample": true
+				}
+			},
+			{
+				"type": "never",
+				"expected_result": {
+					"sample": true
+				}
+			}
+		]
+	},
+	{
+		"description": "Should not match a log with a message when message and severity are defined",
+		"samplingConfig": {
+			"logs": [
+				{
+					"message": {
+						"regexValue": "Database connection .*"
+					},
+					"severityText": {
+						"matchValue": "error"
+					},
+					"samplingRatio": 90
+				}
+			]
+		},
+		"inputLog": {
+			"message": "Database connection failed: timeout"
+		},
+		"samplerFunctionCases": [
+			{
+				"type": "always",
+				"expected_result": {
+					"sample": true
+				}
+			},
+			{
+				"type": "never",
+				"expected_result": {
+					"sample": true
+				}
+			}
+		]
+	},
+	{
+		"description": "Should not match a log with only severity when message and severity are defined",
+		"samplingConfig": {
+			"logs": [
+				{
+					"message": {
+						"regexValue": "Database connection .*"
+					},
+					"severityText": {
+						"matchValue": "error"
+					},
+					"samplingRatio": 90
+				}
+			]
+		},
+		"inputLog": {
+			"severityText": "error"
+		},
+		"samplerFunctionCases": [
+			{
+				"type": "always",
+				"expected_result": {
+					"sample": true
+				}
+			},
+			{
+				"type": "never",
+				"expected_result": {
+					"sample": true
+				}
+			}
+		]
 	}
 ]

--- a/sdk/@launchdarkly/observability-shared/src/sampling/CustomSampler.test.ts
+++ b/sdk/@launchdarkly/observability-shared/src/sampling/CustomSampler.test.ts
@@ -150,6 +150,14 @@ const runTestSpanScenarios = (scenarios: SpanTestScenario[]) => {
 	})
 }
 
+const toReadableLogRecord = (log: LogTestScenario['inputLog']) => {
+	return {
+		severityText: log.severityText,
+		body: log.message,
+		attributes: log.attributes,
+	} as ReadableLogRecord
+}
+
 const runTestLogScenarios = (scenarios: LogTestScenario[]) => {
 	scenarios.forEach((scenario) => {
 		scenario.samplerFunctionCases.forEach((samplerCase) => {
@@ -162,7 +170,7 @@ const runTestLogScenarios = (scenarios: LogTestScenario[]) => {
 				expect(sampler.isSamplingEnabled()).toBe(true)
 
 				const result = sampler.sampleLog(
-					scenario.inputLog as ReadableLogRecord,
+					toReadableLogRecord(scenario.inputLog),
 				)
 
 				expect(result.sample).toBe(samplerCase.expected_result.sample)

--- a/sdk/@launchdarkly/observability-shared/src/sampling/CustomSampler.ts
+++ b/sdk/@launchdarkly/observability-shared/src/sampling/CustomSampler.ts
@@ -232,20 +232,14 @@ export class CustomSampler implements ExportSampler {
 	): boolean {
 		if (config.severityText) {
 			const severityText = record.severityText
-			if (
-				typeof severityText === 'string' &&
-				!this.matchesValue(config.severityText, severityText)
-			) {
+			if (!this.matchesValue(config.severityText, severityText)) {
 				return false
 			}
 		}
 
 		if (config.message) {
 			const message = record.body
-			if (
-				typeof message === 'string' &&
-				!this.matchesValue(config.message, message)
-			) {
+			if (!this.matchesValue(config.message, message)) {
 				return false
 			}
 		}

--- a/sdk/@launchdarkly/observability-shared/src/sampling/CustomSampler.ts
+++ b/sdk/@launchdarkly/observability-shared/src/sampling/CustomSampler.ts
@@ -231,15 +231,17 @@ export class CustomSampler implements ExportSampler {
 		record: ReadableLogRecord,
 	): boolean {
 		if (config.severityText) {
-			const severityText = record.severityText
-			if (!this.matchesValue(config.severityText, severityText)) {
+			if (!this.matchesValue(config.severityText, record.severityText)) {
 				return false
 			}
 		}
 
 		if (config.message) {
-			const message = record.body
-			if (!this.matchesValue(config.message, message)) {
+			if(typeof record.body !== 'string') {
+				// We only support string message bodies for now.
+				return false
+			}
+			if (!this.matchesValue(config.message, record.body)) {
 				return false
 			}
 		}

--- a/sdk/@launchdarkly/observability-shared/src/sampling/CustomSampler.ts
+++ b/sdk/@launchdarkly/observability-shared/src/sampling/CustomSampler.ts
@@ -237,7 +237,7 @@ export class CustomSampler implements ExportSampler {
 		}
 
 		if (config.message) {
-			if(typeof record.body !== 'string') {
+			if (typeof record.body !== 'string') {
 				// We only support string message bodies for now.
 				return false
 			}

--- a/sdk/@launchdarkly/observability-shared/src/sampling/log-test-scenarios.json
+++ b/sdk/@launchdarkly/observability-shared/src/sampling/log-test-scenarios.json
@@ -388,5 +388,102 @@
 				}
 			}
 		]
+	},
+	{
+		"description": "Should not match an empty log when message and severity are defined",
+		"samplingConfig": {
+			"logs": [
+				{
+					"message": {
+						"regexValue": "Database connection .*"
+					},
+					"severityText": {
+						"matchValue": "error"
+					},
+					"samplingRatio": 90
+				}
+			]
+		},
+		"inputLog": {},
+		"samplerFunctionCases": [
+			{
+				"type": "always",
+				"expected_result": {
+					"sample": true
+				}
+			},
+			{
+				"type": "never",
+				"expected_result": {
+					"sample": true
+				}
+			}
+		]
+	},
+	{
+		"description": "Should not match a log with a message when message and severity are defined",
+		"samplingConfig": {
+			"logs": [
+				{
+					"message": {
+						"regexValue": "Database connection .*"
+					},
+					"severityText": {
+						"matchValue": "error"
+					},
+					"samplingRatio": 90
+				}
+			]
+		},
+		"inputLog": {
+			"message": "Database connection failed: timeout"
+		},
+		"samplerFunctionCases": [
+			{
+				"type": "always",
+				"expected_result": {
+					"sample": true
+				}
+			},
+			{
+				"type": "never",
+				"expected_result": {
+					"sample": true
+				}
+			}
+		]
+	},
+	{
+		"description": "Should not match a log with only severity when message and severity are defined",
+		"samplingConfig": {
+			"logs": [
+				{
+					"message": {
+						"regexValue": "Database connection .*"
+					},
+					"severityText": {
+						"matchValue": "error"
+					},
+					"samplingRatio": 90
+				}
+			]
+		},
+		"inputLog": {
+			"severityText": "error"
+		},
+		"samplerFunctionCases": [
+			{
+				"type": "always",
+				"expected_result": {
+					"sample": true
+				}
+			},
+			{
+				"type": "never",
+				"expected_result": {
+					"sample": true
+				}
+			}
+		]
 	}
 ]

--- a/sdk/highlight-run/src/client/otel/sampling/CustomSampler.ts
+++ b/sdk/highlight-run/src/client/otel/sampling/CustomSampler.ts
@@ -240,20 +240,14 @@ export class CustomSampler implements ExportSampler {
 	): boolean {
 		if (config.severityText) {
 			const severityText = attributes[ATTR_LOG_SEVERITY]
-			if (
-				typeof severityText === 'string' &&
-				!this.matchesValue(config.severityText, severityText)
-			) {
+			if (!this.matchesValue(config.severityText, severityText)) {
 				return false
 			}
 		}
 
 		if (config.message) {
 			const message = attributes[ATTR_LOG_MESSAGE]
-			if (
-				typeof message === 'string' &&
-				!this.matchesValue(config.message, message)
-			) {
+			if (!this.matchesValue(config.message, message)) {
 				return false
 			}
 		}

--- a/sdk/highlight-run/src/client/otel/sampling/log-test-scenarios.json
+++ b/sdk/highlight-run/src/client/otel/sampling/log-test-scenarios.json
@@ -388,5 +388,102 @@
 				}
 			}
 		]
+	},
+	{
+		"description": "Should not match an empty log when message and severity are defined",
+		"samplingConfig": {
+			"logs": [
+				{
+					"message": {
+						"regexValue": "Database connection .*"
+					},
+					"severityText": {
+						"matchValue": "error"
+					},
+					"samplingRatio": 90
+				}
+			]
+		},
+		"inputLog": {},
+		"samplerFunctionCases": [
+			{
+				"type": "always",
+				"expected_result": {
+					"sample": true
+				}
+			},
+			{
+				"type": "never",
+				"expected_result": {
+					"sample": true
+				}
+			}
+		]
+	},
+	{
+		"description": "Should not match a log with a message when message and severity are defined",
+		"samplingConfig": {
+			"logs": [
+				{
+					"message": {
+						"regexValue": "Database connection .*"
+					},
+					"severityText": {
+						"matchValue": "error"
+					},
+					"samplingRatio": 90
+				}
+			]
+		},
+		"inputLog": {
+			"message": "Database connection failed: timeout"
+		},
+		"samplerFunctionCases": [
+			{
+				"type": "always",
+				"expected_result": {
+					"sample": true
+				}
+			},
+			{
+				"type": "never",
+				"expected_result": {
+					"sample": true
+				}
+			}
+		]
+	},
+	{
+		"description": "Should not match a log with only severity when message and severity are defined",
+		"samplingConfig": {
+			"logs": [
+				{
+					"message": {
+						"regexValue": "Database connection .*"
+					},
+					"severityText": {
+						"matchValue": "error"
+					},
+					"samplingRatio": 90
+				}
+			]
+		},
+		"inputLog": {
+			"severityText": "error"
+		},
+		"samplerFunctionCases": [
+			{
+				"type": "always",
+				"expected_result": {
+					"sample": true
+				}
+			},
+			{
+				"type": "never",
+				"expected_result": {
+					"sample": true
+				}
+			}
+		]
 	}
 ]

--- a/sdk/highlight-run/src/client/otel/user-interaction.ts
+++ b/sdk/highlight-run/src/client/otel/user-interaction.ts
@@ -27,7 +27,7 @@ function defaultShouldPreventSpanCreation() {
  * the Highlight SDK.
  */
 export class UserInteractionInstrumentation extends InstrumentationBase {
-	static readonly version = '0.1.0'
+	static readonly version = '0.1.1'
 	static readonly moduleName: string = 'user-interaction'
 	private _spansData = new WeakMap<api.Span, SpanData>()
 	private _zonePatched?: boolean
@@ -124,6 +124,7 @@ export class UserInteractionInstrumentation extends InstrumentationBase {
 						['event.tag']: element.tagName,
 						['event.xpath']: xpath,
 						['event.id']: element.id,
+						['event.classname']: element.className,
 						['event.text']: element.textContent ?? '',
 						['event.url']: window.location.href,
 						['viewport.width']: window.innerWidth,


### PR DESCRIPTION
## Summary

The CustomSampler errantly checked if message and severity were of the correct type before attempting to match them. If they were not, then they matched. The simplest solutions is to not do the check. Alternatively it could do the check, and when the type is not string they do not match.

## How did you test this change?

Unit tests.

## Other

After this PR is non-js SDKs should have their JSON files updated. I did not update in this PR because I didn't want to trigger a release of those SDKs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure log rules requiring message/severity only match when the record has a string message/severity; add scenarios and test helpers across SDKs.
> 
> - **Sampling logic**:
>   - Go (`go/internal/otel/custom_sampler.go`): In `matchesLogConfig`, require `record.Body()` to be `KindString` for message matching; return false otherwise.
>   - JS/TS (Node, Shared, Highlight Run): Simplify `matchesLogConfig` by removing permissive typeof gates; Shared explicitly rejects non-string `record.body` for message matching.
> - **Tests**:
>   - Add log scenarios that verify configs with both `message` and `severityText` do not match when logs are empty, only have message, or only have severity (in Go/Node/Shared/Highlight Run JSONs).
>   - Introduce helper to construct `ReadableLogRecord` from scenario input in Node/Shared tests and update usages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 67c936714f20c6221245c3524bc4b32771a5880f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->