### PR TITLE
fix: avoid noisy error log on starting new sessions

### DIFF
--- a/sdk/highlight-run/src/client/utils/sessionStorage/highlightSession.ts
+++ b/sdk/highlight-run/src/client/utils/sessionStorage/highlightSession.ts
@@ -115,7 +115,7 @@ function pruneSessionData(keepKey: string): void {
 				if (
 					sessionData.lastPushTime !== undefined &&
 					Date.now() - sessionData.lastPushTime >=
-					SESSION_PUSH_THRESHOLD
+						SESSION_PUSH_THRESHOLD
 				) {
 					internalLogOnce(
 						'highlightSession',


### PR DESCRIPTION
## Summary

First-time visitors with no session replay metadata in local storage would
get an error log related to the session data not being valid (it would be an empty object).

## How did you test this change?

CI

## Are there any deployment considerations?

no

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts `pruneSessionData` to only act on entries with `lastPushTime` and removes error logging for non-session data, preventing noisy logs for new sessions.
> 
> - **Session storage (`sdk/highlight-run/src/client/utils/sessionStorage/highlightSession.ts`)**:
>   - Update `pruneSessionData` to only consider items with `lastPushTime` before pruning.
>   - Remove error log for entries lacking `lastPushTime`; keep debug log when removing stale data.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3cecc11755b5780c470cb7eac04fec1c27bd98b7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->