### PR TITLE
fix: O11Y-725 - avoid creating multiple instances when secondaryMobileKeys are set

### DIFF
--- a/e2e/android/app/src/main/java/com/example/androidobservability/BaseApplication.kt
+++ b/e2e/android/app/src/main/java/com/example/androidobservability/BaseApplication.kt
@@ -48,6 +48,7 @@ open class BaseApplication : Application() {
     open fun realInit() {
         val observabilityPlugin = Observability(
             application = this@BaseApplication,
+            mobileKey = LAUNCHDARKLY_MOBILE_KEY,
             options = testUrl?.let { pluginOptions.copy(backendUrl = it, otlpEndpoint = it) } ?: pluginOptions
         )
 


### PR DESCRIPTION
## Summary
- This will probably be rewritten as part of [O11Y-726](https://launchdarkly.atlassian.net/browse/O11Y-726)

[O11Y-726]: https://launchdarkly.atlassian.net/browse/O11Y-726?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Gate Observability initialization to the primary mobile key and update the app to pass it, avoiding multiple OTel instances with secondary keys.
> 
> - **SDK Plugin (`Observability.kt`)**:
>   - Add `mobileKey` constructor parameter and use it to gate `register(...)` so the observability client/resources initialize only when `metadata.credential` matches the primary `mobileKey`.
>   - Initialization of `Resource` attributes and `ObservabilityClient` now occurs only under this condition.
> - **E2E App (`BaseApplication.kt`)**:
>   - Update `Observability` instantiation to pass `mobileKey = LAUNCHDARKLY_MOBILE_KEY`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 79743210cc083ef2356a10e49aff71b539fc7baa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->