### PR TITLE
fix: O11Y-725 - Return no-op span when not initialized

### DIFF
--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/sdk/LDObserve.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/sdk/LDObserve.kt
@@ -10,13 +10,13 @@ import io.opentelemetry.api.trace.Span
 /**
  * LDObserve is the singleton entry point for recording observability data such as
  * metrics, logs, errors, and traces. It is recommended to use the [com.launchdarkly.observability.plugin.Observability] plugin
- * with the LaunchDarkly Android Client SDK, as that will automatically initialize the
- * [LDObserve] singleton instance.
+ * with the LaunchDarkly Android Client SDK, as that will automatically initialize the [LDObserve] singleton instance.
  *
  * @constructor Creates an LDObserve instance with the provided [Observe].
  * @param client The [Observe] to which observability data will be forwarded.
  */
 class LDObserve(private val client: Observe) : Observe {
+
     override fun recordMetric(metric: Metric) {
         client.recordMetric(metric)
     }


### PR DESCRIPTION
## Summary
Instead of throwing an `IllegalStateException` when the observability plugin is not initialized, `startSpan` now returns an invalid span.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Return an invalid no-op span from `startSpan` when not initialized, plus minor KDoc and formatting updates.
> 
> - **Core behavior**:
>   - `companion object` no-op `startSpan` now returns `Span.getInvalid()` when Observability isn’t initialized.
> - **Docs**:
>   - KDoc updated to reference `com.launchdarkly.observability.plugin.Observability` and streamlined wording.
> - **Cleanup**:
>   - Minor formatting/style adjustments in `LDObserve.kt`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9548adfdbd2e6351cbdee5e9ad2c459e2c61625e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->