### PR TITLE
fix: correctly forward error payload to launchdarkly

### DIFF
--- a/sdk/highlight-run/src/integrations/launchdarkly/index.ts
+++ b/sdk/highlight-run/src/integrations/launchdarkly/index.ts
@@ -252,8 +252,9 @@ export class LaunchDarklyIntegrationSDK implements IntegrationClient {
 				payload = JSON.parse(error.payload)
 			}
 		} catch (e) {}
+		const { payload: _, ...errorWithoutPayload } = error
 		this.client.track(LD_ERROR_EVENT, {
-			...error,
+			...errorWithoutPayload,
 			sessionID: sessionSecureID,
 			...payload,
 		})

--- a/sdk/highlight-run/src/sdk/observe.ts
+++ b/sdk/highlight-run/src/sdk/observe.ts
@@ -245,9 +245,10 @@ export class ObserveSDK implements Observe {
 				...payload,
 			})
 		})
+		const { payload: _, ...errorWithoutPayload } = errorMsg
 		for (const integration of this._integrations) {
 			integration.error(getPersistentSessionSecureID(), {
-				...errorMsg,
+				...errorWithoutPayload,
 				payload: JSON.stringify(payload),
 			})
 		}


### PR DESCRIPTION
## Summary

Ensure that the SDK correctly reports the error payload to LaunchDarkly.

## How did you test this change?

<img width="2209" height="1922" alt="image" src="https://github.com/user-attachments/assets/cb6977b3-b891-4f9a-a505-ed865d0338ec" />

## Are there any deployment considerations?

no

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Correctly forwards parsed error payload to LaunchDarkly and spans, and defaults error source to "frontend".
> 
> - **Errors**:
>   - **Payload propagation**:
>     - In `sdk/observe.ts`, merges `errorMsg.payload` JSON into `payload` and forwards integrations an `errorMsg` with `payload` stringified.
>     - In `integrations/launchdarkly/index.ts`, parses `error.payload` and spreads it into the `LD_ERROR_EVENT` tracking payload.
>   - **Defaults**:
>     - Sets `recordError` default `source` to `"frontend"` in `sdk/observe.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5a0a9d50f99420c624cfc9d51cda7b2b5727f33c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->