### PR TITLE
feat: disable client-side LD metric forwarding

### DIFF
--- a/sdk/highlight-run/src/integrations/launchdarkly/index.ts
+++ b/sdk/highlight-run/src/integrations/launchdarkly/index.ts
@@ -1,4 +1,4 @@
-import { type HighlightPublicInterface, MetricCategory } from '../../client'
+import { type HighlightPublicInterface } from '../../client'
 import type { ErrorMessage, Source } from '../../client/types/shared-types'
 import type { IntegrationClient } from '../index'
 import type { LDClientMin as LDClient } from './types/LDClient'
@@ -46,9 +46,7 @@ export const FEATURE_FLAG_APP_ID_ATTR = `${LD_SCOPE}.application.id`
 export const FEATURE_FLAG_APP_VERSION_ATTR = `${LD_SCOPE}.application.version`
 
 export const LD_INITIALIZE_EVENT = '$ld:telemetry:session:init'
-export const LD_ERROR_EVENT = '$ld:telemetry:error'
 export const LD_TRACK_EVENT = '$ld:telemetry:track'
-export const LD_METRIC_EVENT = '$ld:telemetry:metric'
 
 export const LD_METRIC_NAME_DOCUMENT_LOAD = 'document_load'
 
@@ -211,29 +209,7 @@ export class LaunchDarklyIntegrationSDK implements IntegrationClient {
 	}
 
 	recordGauge(sessionSecureID: string, metric: RecordMetric) {
-		// only record web vitals
-		if (
-			metric.category !== MetricCategory.WebVital &&
-			metric.name !== LD_METRIC_NAME_DOCUMENT_LOAD
-		) {
-			return
-		}
-		// ignore Jank metric, sent on interaction
-		if (metric.name === 'Jank') {
-			return
-		}
-		this.client.track(
-			`${LD_METRIC_EVENT}:${metric.name.toLowerCase()}`,
-			{
-				...metric.tags
-					?.map((t) => ({ [t.name]: t.value }))
-					.reduce((a, b) => ({ ...a, ...b }), {}),
-				category: metric.category,
-				group: metric.group,
-				sessionID: sessionSecureID,
-			},
-			metric.value,
-		)
+		// noop - metric forwarding is handled upon data ingest
 	}
 
 	identify(
@@ -246,18 +222,7 @@ export class LaunchDarklyIntegrationSDK implements IntegrationClient {
 	}
 
 	error(sessionSecureID: string, error: ErrorMessage) {
-		let payload: { [key: string]: string } = {}
-		try {
-			if (error.payload) {
-				payload = JSON.parse(error.payload)
-			}
-		} catch (e) {}
-		const { payload: _, ...errorWithoutPayload } = error
-		this.client.track(LD_ERROR_EVENT, {
-			...errorWithoutPayload,
-			sessionID: sessionSecureID,
-			...payload,
-		})
+		// noop - metric forwarding is handled upon data ingest
 	}
 
 	track(sessionSecureID: string, metadata: object) {


### PR DESCRIPTION
## Summary

After https://github.com/launchdarkly/observability/pull/320 is shipped, we can 
switch to server-emitted metrics for the Web SDK.

## How did you test this change?

CI

## Are there any deployment considerations?

need to make sure server metrics are flowing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Stops forwarding metrics and errors from the LaunchDarkly client; metrics now handled on ingest while init and track events remain.
> 
> - **Integrations – `sdk/highlight-run/src/integrations/launchdarkly/index.ts`**
>   - Disable client-side forwarding:
>     - `recordGauge` and `error` now no-ops (metrics handled on ingest).
>     - Remove metric/error events and filtering logic (`LD_METRIC_EVENT`, `LD_ERROR_EVENT`, `MetricCategory`).
>   - Retain session init and custom tracking:
>     - Still emits `LD_INITIALIZE_EVENT` and `LD_TRACK_EVENT` via `track()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2febce07977d4105b2c015cb2c0645351dc2ba66. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->