### PR TITLE
test: O11Y-741 - Replace direct dispatcher usage with a provider for testing

### DIFF
--- a/e2e/android/app/build.gradle.kts
+++ b/e2e/android/app/build.gradle.kts
@@ -89,6 +89,7 @@ dependencies {
     testImplementation(libs.robolectric)
     testImplementation("com.squareup.okhttp3:mockwebserver:4.12.0")
     testImplementation("io.opentelemetry:opentelemetry-sdk-testing:1.51.0")
+    testImplementation(testFixtures(project(":observability-android")))
 
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/e2e/android/app/src/test/java/com/example/androidobservability/DisablingConfigOptionsE2ETest.kt
+++ b/e2e/android/app/src/test/java/com/example/androidobservability/DisablingConfigOptionsE2ETest.kt
@@ -184,8 +184,7 @@ class DisablingConfigOptionsE2ETest {
 
     private fun requestsContainsUrl(url: String): Boolean {
         while (true) {
-            val request = application.mockWebServer?.takeRequest(100, TimeUnit.MILLISECONDS)
-            if (request == null) return false
+            val request = application.mockWebServer?.takeRequest(100, TimeUnit.MILLISECONDS) ?: return false
             if (request.requestUrl.toString() == url) return true
         }
     }

--- a/e2e/android/app/src/test/java/com/example/androidobservability/SamplingE2ETest.kt
+++ b/e2e/android/app/src/test/java/com/example/androidobservability/SamplingE2ETest.kt
@@ -10,7 +10,9 @@ import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.logs.Severity
 import junit.framework.TestCase.assertEquals
+import kotlinx.coroutines.test.runTest
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -39,6 +41,9 @@ import org.robolectric.annotation.Config
 @Config(application = TestApplication::class)
 class SamplingE2ETest {
 
+    @get:Rule
+    val testCoroutineRule = TestCoroutineRule()
+
     private val application = ApplicationProvider.getApplicationContext<Application>() as TestApplication
     private var telemetryInspector: TelemetryInspector? = null
 
@@ -49,7 +54,7 @@ class SamplingE2ETest {
     }
 
     @Test
-    fun `should avoid exporting logs matching sampling configuration for logs`() {
+    fun `should avoid exporting logs matching sampling configuration for logs`() = runTest {
         triggerLogs()
         telemetryInspector?.logExporter?.flush()
         waitForTelemetryData(telemetryInspector = application.telemetryInspector, telemetryType = TelemetryType.LOGS)
@@ -65,7 +70,7 @@ class SamplingE2ETest {
     }
 
     @Test
-    fun `should avoid exporting spans matching sampling configuration for spans`() {
+    fun `should avoid exporting spans matching sampling configuration for spans`() = runTest {
         triggerSpans()
         telemetryInspector?.spanExporter?.flush()
         waitForTelemetryData(telemetryInspector = application.telemetryInspector, telemetryType = TelemetryType.SPANS)

--- a/e2e/android/app/src/test/java/com/example/androidobservability/TestCoroutineRule.kt
+++ b/e2e/android/app/src/test/java/com/example/androidobservability/TestCoroutineRule.kt
@@ -1,0 +1,24 @@
+package com.example.androidobservability
+
+import com.launchdarkly.observability.testing.ObservabilityDispatcherTestHooks
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class TestCoroutineRule : TestWatcher() {
+    private val testDispatcher: TestDispatcher = UnconfinedTestDispatcher()
+
+    val dispatcher: TestDispatcher
+        get() = testDispatcher
+
+    override fun starting(description: Description) {
+        ObservabilityDispatcherTestHooks.overrideWith(testDispatcher)
+    }
+
+    override fun finished(description: Description) {
+        ObservabilityDispatcherTestHooks.reset()
+    }
+}

--- a/e2e/android/gradle.properties
+++ b/e2e/android/gradle.properties
@@ -21,3 +21,4 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+android.experimental.enableTestFixturesKotlinSupport=true

--- a/sdk/@launchdarkly/observability-android/lib/build.gradle.kts
+++ b/sdk/@launchdarkly/observability-android/lib/build.gradle.kts
@@ -67,6 +67,8 @@ dependencies {
 
     testImplementation("io.mockk:mockk:1.14.5")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2")
+
+    testFixturesImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2")
 }
 
 val releaseVersion = version.toString()
@@ -108,6 +110,10 @@ android {
             withJavadocJar()
             withSourcesJar()
         }
+    }
+
+    testFixtures {
+        enable = true
     }
 }
 

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/client/InstrumentationManager.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/client/InstrumentationManager.kt
@@ -11,6 +11,7 @@ import com.launchdarkly.observability.sampling.ExportSampler
 import com.launchdarkly.observability.sampling.SamplingConfig
 import com.launchdarkly.observability.sampling.SamplingLogExporter
 import com.launchdarkly.observability.sampling.SamplingTraceExporter
+import com.launchdarkly.observability.coroutines.DispatcherProviderHolder
 import io.opentelemetry.android.OpenTelemetryRum
 import io.opentelemetry.android.config.OtelRumConfig
 import io.opentelemetry.android.features.diskbuffering.DiskBufferingConfig
@@ -43,7 +44,6 @@ import io.opentelemetry.sdk.trace.SdkTracerProviderBuilder
 import io.opentelemetry.sdk.trace.export.BatchSpanProcessor
 import io.opentelemetry.sdk.trace.export.SpanExporter
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import java.util.concurrent.ConcurrentHashMap
@@ -83,7 +83,7 @@ class InstrumentationManager(
     private val upDownCounterCache = ConcurrentHashMap<String, LongUpDownCounter>()
 
     //TODO: Evaluate if this class should have a close/shutdown method to close this scope
-    private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+    private val scope = CoroutineScope(DispatcherProviderHolder.current.io + SupervisorJob())
 
     init {
         initializeTelemetryInspector()

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/coroutines/DispatcherProvider.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/coroutines/DispatcherProvider.kt
@@ -1,0 +1,34 @@
+package com.launchdarkly.observability.coroutines
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+
+internal interface DispatcherProvider {
+    val main: CoroutineDispatcher
+    val io: CoroutineDispatcher
+    val default: CoroutineDispatcher
+    val unconfined: CoroutineDispatcher
+}
+
+internal object DefaultDispatcherProvider : DispatcherProvider {
+    override val main: CoroutineDispatcher = Dispatchers.Main
+    override val io: CoroutineDispatcher = Dispatchers.IO
+    override val default: CoroutineDispatcher = Dispatchers.Default
+    override val unconfined: CoroutineDispatcher = Dispatchers.Unconfined
+}
+
+internal object DispatcherProviderHolder {
+    @Volatile
+    private var provider: DispatcherProvider = DefaultDispatcherProvider
+
+    val current: DispatcherProvider
+        get() = provider
+
+    internal fun set(provider: DispatcherProvider) {
+        this.provider = provider
+    }
+
+    internal fun reset() {
+        provider = DefaultDispatcherProvider
+    }
+}

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/network/GraphQLClient.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/network/GraphQLClient.kt
@@ -1,5 +1,6 @@
 package com.launchdarkly.observability.network
 
+import com.launchdarkly.observability.coroutines.DispatcherProviderHolder
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.KSerializer
@@ -72,7 +73,7 @@ class GraphQLClient(
         queryFileName: String,
         variables: Map<String, JsonElement> = emptyMap(),
         dataSerializer: KSerializer<T>
-    ): GraphQLResponse<T> = withContext(Dispatchers.IO) {
+    ): GraphQLResponse<T> = withContext(DispatcherProviderHolder.current.io) {
         try {
             val query = loadQuery(queryFileName)
             val request = GraphQLRequest(

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/RRwebGraphQLReplayLogExporter.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/RRwebGraphQLReplayLogExporter.kt
@@ -1,5 +1,6 @@
 package com.launchdarkly.observability.replay
 
+import com.launchdarkly.observability.coroutines.DispatcherProviderHolder
 import com.launchdarkly.observability.network.GraphQLClient
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.sdk.common.CompletableResultCode
@@ -31,7 +32,7 @@ class RRwebGraphQLReplayLogExporter(
     val serviceVersion: String,
     private val injectedReplayApiService: SessionReplayApiService? = null
 ) : LogRecordExporter {
-    private val coroutineScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+    private val coroutineScope = CoroutineScope(DispatcherProviderHolder.current.io + SupervisorJob())
 
     private var graphqlClient: GraphQLClient = GraphQLClient(backendUrl)
     private val replayApiService: SessionReplayApiService = injectedReplayApiService ?: SessionReplayApiService(
@@ -136,7 +137,7 @@ class RRwebGraphQLReplayLogExporter(
      *
      * @param capture the capture to be sent
      */
-    suspend fun sendCaptureIncremental(capture: Capture): Boolean = withContext(Dispatchers.IO) {
+    suspend fun sendCaptureIncremental(capture: Capture): Boolean = withContext(DispatcherProviderHolder.current.io) {
         try {
             val eventsBatch = mutableListOf<Event>()
             val timestamp = System.currentTimeMillis()
@@ -188,7 +189,7 @@ class RRwebGraphQLReplayLogExporter(
      *
      * @param capture the capture to be sent
      */
-    suspend fun sendCaptureFull(capture: Capture): Boolean = withContext(Dispatchers.IO) {
+    suspend fun sendCaptureFull(capture: Capture): Boolean = withContext(DispatcherProviderHolder.current.io) {
         try {
             replayApiService.initializeReplaySession(organizationVerboseId, capture.session)
             replayApiService.identifyReplaySession(capture.session)

--- a/sdk/@launchdarkly/observability-android/lib/src/testFixtures/kotlin/com/launchdarkly/observability/testing/ObservabilityDispatcherTestHooks.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/testFixtures/kotlin/com/launchdarkly/observability/testing/ObservabilityDispatcherTestHooks.kt
@@ -1,0 +1,55 @@
+package com.launchdarkly.observability.testing
+
+import com.launchdarkly.observability.coroutines.DefaultDispatcherProvider
+import com.launchdarkly.observability.coroutines.DispatcherProvider
+import com.launchdarkly.observability.coroutines.DispatcherProviderHolder
+import kotlinx.coroutines.CoroutineDispatcher
+
+/**
+ * Allows test modules to override the coroutine dispatchers used by the SDK.
+ *
+ * This hooks directly into [DispatcherProviderHolder] but remains inaccessible to SDK consumers
+ * because it is published only via the test fixtures artifact.
+ */
+object ObservabilityDispatcherTestHooks {
+
+    /**
+     * Overrides dispatchers used by the SDK. Any argument left null continues to use the default
+     * value provided by the SDK.
+     */
+    fun overrideDispatchers(
+        main: CoroutineDispatcher? = null,
+        io: CoroutineDispatcher? = null,
+        default: CoroutineDispatcher? = null,
+        unconfined: CoroutineDispatcher? = null,
+    ) {
+        val fallback = DefaultDispatcherProvider
+        DispatcherProviderHolder.set(
+            object : DispatcherProvider {
+                override val main = main ?: fallback.main
+                override val io = io ?: fallback.io
+                override val default = default ?: fallback.default
+                override val unconfined = unconfined ?: fallback.unconfined
+            }
+        )
+    }
+
+    /**
+     * Convenience override that routes every dispatcher to the same [CoroutineDispatcher].
+     */
+    fun overrideWith(dispatcher: CoroutineDispatcher) {
+        overrideDispatchers(
+            main = dispatcher,
+            io = dispatcher,
+            default = dispatcher,
+            unconfined = dispatcher
+        )
+    }
+
+    /**
+     * Restores the SDK dispatchers to their defaults.
+     */
+    fun reset() {
+        DispatcherProviderHolder.reset()
+    }
+}


### PR DESCRIPTION
## Summary
This commit replaces direct calls to `kotlinx.coroutines.Dispatchers` with a `DispatcherProvider` abstraction. This change facilitates testing by allowing coroutine dispatchers to be overridden.

## How did you test this change?
These changes are part of the test suite

## Are there any deployment considerations?
No

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace direct coroutine dispatcher usage with an injectable provider, and add test hooks and e2e rule to override dispatchers in tests.
> 
> - **SDK**:
>   - Replace direct `Dispatchers` usage with `DispatcherProviderHolder.current.io` in `InstrumentationManager`, `GraphQLClient`, and `RRwebGraphQLReplayLogExporter`.
>   - Add `coroutines/DispatcherProvider` abstraction and `DispatcherProviderHolder`.
> - **Testing**:
>   - Add test fixture `ObservabilityDispatcherTestHooks` to override SDK dispatchers.
>   - Introduce `TestCoroutineRule` in e2e tests; update `SamplingE2ETest` to use `@Rule` and `runTest`.
>   - Minor test cleanup in `DisablingConfigOptionsE2ETest` (null-check compactness).
> - **Build/Config**:
>   - Enable `testFixtures` in `lib/build.gradle.kts`; add `testFixturesImplementation` for coroutines-test.
>   - In e2e app, depend on `testFixtures(project(":observability-android"))`.
>   - Set `android.experimental.enableTestFixturesKotlinSupport=true` in `gradle.properties`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a2e32b5d3d9874af32f052265264e63b92f66000. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->