### PR TITLE
fix: tweaks Android InteractionDetector to delegate additional defaul…

### DIFF
--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/InteractionSource.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/InteractionSource.kt
@@ -57,6 +57,7 @@ class InteractionSource(
             originalCallback.onProvideKeyboardShortcuts(data, menu, deviceId)
         }
 
+        @RequiresApi(Build.VERSION_CODES.O)
         override fun onPointerCaptureChanged(hasCapture: Boolean) {
             originalCallback.onPointerCaptureChanged(hasCapture)
         }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> `InteractionDetector` now forwards `onProvideKeyboardShortcuts` and `onPointerCaptureChanged` to the original `Window.Callback` while still intercepting touch events.
> 
> - **Android — `InteractionSource`**:
>   - **`InteractionDetector`**:
>     - Delegates `onProvideKeyboardShortcuts(...)` to the original `Window.Callback`.
>     - Delegates `onPointerCaptureChanged(...)` (API 26+) to the original `Window.Callback`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ecd7671b6239a1491dadb4e754cf2f99671777e9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->