### PR TITLE
chore: readme update with real examples

### DIFF
--- a/sdk/@launchdarkly/observability-android/README.md
+++ b/sdk/@launchdarkly/observability-android/README.md
@@ -178,12 +178,9 @@ Use `ldMask()` to mark views that should be masked in session replay. There are 
 Import the masking API and call `ldMask()` on any `View` (for example, after inflating the layout in an `Activity` or `Fragment`).
 
 ```kotlin
-import android.os.Bundle
-import android.widget.EditText
-import androidx.appcompat.app.AppCompatActivity
 import com.launchdarkly.observability.api.ldMask
 
-class LoginActivity : AppCompatActivity() {
+class LoginActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_login)
@@ -197,18 +194,18 @@ class LoginActivity : AppCompatActivity() {
 With View Binding or Data Binding:
 
 ```kotlin
-import android.os.Bundle
-import android.view.View
-import androidx.fragment.app.Fragment
 import com.launchdarkly.observability.api.ldMask
 
-class CheckoutFragment : Fragment(R.layout.fragment_checkout) {
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-        val binding = FragmentCheckoutBinding.bind(view)
-        binding.creditCardNumber.ldMask()
-        binding.cvv.ldMask()
-    }
+override fun onCreateView(
+    inflater: LayoutInflater,
+    container: ViewGroup?,
+    savedInstanceState: Bundle?,
+): View {
+    _binding = SettingsPageBinding.inflate(inflater, container, false)
+    binding.nestedScrollView.systemBarsPadding()
+    viewModel.toggleBackgroundAccess(requireContext().isIgnoreBatteryEnabled())
+    val toolbar = binding.toolbar
+    toolbar.ldMask()
 }
 ```
 
@@ -219,21 +216,21 @@ Optional: use `ldUnmask()` to explicitly clear masking on a view you previously 
 Add the masking `Modifier` to any composable you want masked in session replay.
 
 ```kotlin
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.material3.TextField
-import androidx.compose.runtime.*
-import androidx.compose.ui.Modifier
 import com.launchdarkly.observability.api.ldMask
 
 @Composable
 fun CreditCardField() {
-    var number by remember { mutableStateOf("") }
-    TextField(
-        value = number,
-        onValueChange = { number = it },
+    ...
+   	var zipCode by remember { mutableStateOf("") }
+
+    OutlinedTextField(
+        value = zipCode,
+        onValueChange = { zipCode = it },
+        label = { Text("ZIP Code") },
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
         modifier = Modifier
             .fillMaxWidth()
-            .ldMask() // mask this composable in session replay
+            .ldMask()
     )
 }
 ```


### PR DESCRIPTION
## Summary

Update readme with examples from the test app.

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refreshes README session replay masking examples (XML, View Binding/Data Binding, Compose) with realistic code and switches LoginActivity to ComponentActivity.
> 
> - **Docs (sdk/@launchdarkly/observability-android/README.md)**:
>   - **Session Replay / Masking examples**:
>     - XML Views: update `LoginActivity` sample to use `ComponentActivity`; simplify imports.
>     - View Binding/Data Binding: replace `Fragment` example with `onCreateView` using `SettingsPageBinding` and mask `toolbar` via `ldMask()`.
>     - Jetpack Compose: replace generic `TextField` with `OutlinedTextField` ZIP code example, add `KeyboardOptions`, and apply `Modifier.ldMask()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit afe4bffbc0fd0ac5a0aa0e44f8102ec5c6f91216. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->