### PR TITLE
fix: Android - Remove Disk Buffering

### DIFF
--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/client/InstrumentationManager.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/client/InstrumentationManager.kt
@@ -148,12 +148,6 @@ class InstrumentationManager(
 
     private fun createOtelRumConfig(): OtelRumConfig {
         val config = OtelRumConfig()
-            .setDiskBufferingConfig(
-                DiskBufferingConfig.create(
-                    enabled = isAnySignalEnabled(options),
-                    debugEnabled = options.debug
-                )
-            )
             .setSessionConfig(SessionConfig(backgroundInactivityTimeout = options.sessionBackgroundTimeout))
 
         if (options.disableErrorTracking) {
@@ -163,10 +157,6 @@ class InstrumentationManager(
         }
 
         return config
-    }
-
-    private fun isAnySignalEnabled(options: Options): Boolean {
-        return !options.disableLogs || !options.disableTraces || !options.disableMetrics || !options.disableErrorTracking
     }
 
     private fun configureTracerProvider(sdkTracerProviderBuilder: SdkTracerProviderBuilder): SdkTracerProviderBuilder {


### PR DESCRIPTION
## Summary

Remove Disk buffering seems failing. Let's just delete it.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes OpenTelemetry disk buffering setup and its helper from `InstrumentationManager`.
> 
> - **Observability Android SDK**:
>   - Remove disk buffering configuration from `createOtelRumConfig()` in `InstrumentationManager.kt` (drop `DiskBufferingConfig` setup).
>   - Delete unused helper `isAnySignalEnabled(options)`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 10aa48766852544fbd976d739b0444c9ae517c29. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->