### PR TITLE
feat: enhance Web Vitals telemetry with semantic attributes

### DIFF
--- a/sdk/highlight-run/src/sdk/observe.ts
+++ b/sdk/highlight-run/src/sdk/observe.ts
@@ -80,6 +80,7 @@ import { ObserveOptions } from '../client/types/observe'
 import { WebTracerProvider } from '@opentelemetry/sdk-trace-web'
 import { MeterProvider } from '@opentelemetry/sdk-metrics'
 import { isMetricSafeNumber } from '../client/utils/utils'
+import * as SemanticAttributes from '@opentelemetry/semantic-conventions'
 
 export class ObserveSDK implements Observe {
 	/** Verbose project ID that is exposed to users. Legacy users may still be using ints. */
@@ -576,12 +577,16 @@ export class ObserveSDK implements Observe {
 		)
 		WebVitalsListener((data) => {
 			const { name, value } = data
+			const { hostname, pathname, href } = window.location
 			this.recordGauge({
 				name,
 				value,
 				attributes: {
-					group: window.location.href,
+					group: window.location.pathname,
 					category: MetricCategory.WebVital,
+					[SemanticAttributes.ATTR_URL_FULL]: href,
+					[SemanticAttributes.ATTR_URL_PATH]: pathname,
+					[SemanticAttributes.ATTR_SERVER_ADDRESS]: hostname,
 				},
 			})
 		})


### PR DESCRIPTION
## Summary

Adds some SemConv attributes for different parts o the URL. This will be used to build UI for breaking down web vitals performance across different pages in an app. Also migrates the `group` attribute to pathname rather than the full href, lowering its cardinality.

## How did you test this change?

Click tested the E2E react router example and checked things were landing in Clickhouse correctly.

<img width="1272" height="526" alt="image" src="https://github.com/user-attachments/assets/add9f1d0-a3d6-4fb1-8aa3-c6c71f17d36e" />

## Are there any deployment considerations?

N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds OTel semantic URL attributes to Web Vitals gauges and groups them by pathname instead of full URL.
> 
> - **Web Vitals telemetry (`sdk/highlight-run/src/sdk/observe.ts`)**:
>   - Add OpenTelemetry semantic URL attributes to gauge attributes: `ATTR_URL_FULL`, `ATTR_URL_PATH`, `ATTR_SERVER_ADDRESS`.
>   - Change grouping from `window.location.href` to `window.location.pathname` for Web Vitals metrics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a6ff35aa0d478890c1227bc08d071e2d70497e7c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->