### PR TITLE
docs: Update readme with options refactor

### DIFF
--- a/sdk/@launchdarkly/observability-android/README.md
+++ b/sdk/@launchdarkly/observability-android/README.md
@@ -26,7 +26,7 @@ Add the dependency to your app's Gradle file:
 ```kotlin
 dependencies {
     implementation("com.launchdarkly:launchdarkly-android-client-sdk:5.+")
-    implementation("com.launchdarkly:launchdarkly-observability-android:0.5.0")
+    implementation("com.launchdarkly:launchdarkly-observability-android:0.19.1")
 }
 ```
 
@@ -45,13 +45,15 @@ import com.launchdarkly.sdk.android.LDClient
 class MyApplication : Application() {
     override fun onCreate() {
         super.onCreate()
+
+        val mobileKey = "your-mobile-key"
         
         val ldConfig = LDConfig.Builder(LDConfig.Builder.AutoEnvAttributes.Enabled)
-            .mobileKey("your-mobile-key")
+            .mobileKey(mobileKey)
             .plugins(
                 Components.plugins().setPlugins(
                     listOf(
-                        Observability(this@MyApplication)
+                        Observability(this@MyApplication, mobileKey)
                     )
                 )
             )
@@ -93,14 +95,17 @@ dependencies {
 You can customize the observability plugin with various options:
 
 ```kotlin
-import com.launchdarkly.observability.api.Options
+import com.launchdarkly.observability.api.ObservabilityOptions
 import com.launchdarkly.sdk.android.LDAndroidLogging
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.common.Attributes
 
+val mobileKey = "your-mobile-key"
+
 val observabilityPlugin = Observability(
     application = this@MyApplication,
-    options = Options(
+    mobileKey = mobileKey,
+    options = ObservabilityOptions(
         serviceName = "my-android-app",
         serviceVersion = "1.0.0",
         debug = true,
@@ -112,6 +117,28 @@ val observabilityPlugin = Observability(
         customHeaders = mapOf(
             "X-Custom-Header" to "custom-value"
         )
+    )
+)
+```
+
+Additional `ObservabilityOptions` settings:
+
+- `logsApiLevel`: Minimum log severity to export (defaults to `INFO`). Set to `ObservabilityOptions.LogLevel.NONE` to disable log exporting.
+- `tracesApi`: Controls trace recording (defaults to enabled). Use `ObservabilityOptions.TracesApi.disabled()` to disable all tracing, or set `includeErrors`/`includeSpans`.
+- `metricsApi`: Controls metric export (defaults to enabled). Use `ObservabilityOptions.MetricsApi.disabled()` to disable metrics.
+- `instrumentations`: Enables/disables specific automatic instrumentations like `crashReporting`, `activityLifecycle`, and `launchTime`.
+
+Example:
+
+```kotlin
+val options = ObservabilityOptions(
+    logsApiLevel = ObservabilityOptions.LogLevel.WARN,
+    tracesApi = ObservabilityOptions.TracesApi(includeErrors = true, includeSpans = false),
+    metricsApi = ObservabilityOptions.MetricsApi.disabled(),
+    instrumentations = ObservabilityOptions.Instrumentations(
+        crashReporting = false,
+        activityLifecycle = true,
+        launchTime = true
     )
 )
 ```

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/api/ObservabilityOptions.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/api/ObservabilityOptions.kt
@@ -77,6 +77,7 @@ data class ObservabilityOptions(
      * This class allows enabling or disabling specific automatic instrumentations.
      *
      * @property crashReporting If `true`, the plugin will automatically report any uncaught exceptions as errors.
+     * @property activityLifecycle If `true`, the plugin will automatically start spans for Android Activity lifecycle events.
      * @property launchTime If `true`, the plugin will automatically measure and report the application's startup time as metrics.
      */
     data class Instrumentations(


### PR DESCRIPTION
## Summary
- Readme updated
- `activityLifecycle` property added to `ObservabilityOptions.Instrumentation` KDocs

## How did you test this change?
- No tests needed

## Are there any deployment considerations?
No

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates Android Observability README to use ObservabilityOptions and mobileKey with version 0.19.1, and adds KDoc for the activityLifecycle instrumentation option.
> 
> - **Docs (Android Observability)**:
>   - Bump dependency to `launchdarkly-observability-android:0.19.1`.
>   - Update setup to pass `mobileKey` and construct `Observability(this, mobileKey)`.
>   - Replace `Options` with `ObservabilityOptions`; add example and outline for `logsApiLevel`, `tracesApi`, `metricsApi`, and `instrumentations` (including `crashReporting`, `activityLifecycle`, `launchTime`).
> - **API KDoc**:
>   - Document `activityLifecycle` in `ObservabilityOptions.Instrumentations`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a6e82c45c87d9b127559388f344bad03f5114a95. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->