### PR TITLE
chore: release 1.x SDKs for O11y GA

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,11 +1,11 @@
 {
-	"go": "0.4.0",
-	"sdk/@launchdarkly/observability": "0.5.2",
+	"go": "1.0.0",
+	"sdk/@launchdarkly/observability": "1.0.0",
 	"sdk/@launchdarkly/observability-android": "0.24.0",
-	"sdk/@launchdarkly/observability-dotnet": "0.3.0",
-	"sdk/@launchdarkly/observability-node": "0.3.1",
-	"sdk/@launchdarkly/observability-python": "0.1.1",
+	"sdk/@launchdarkly/observability-dotnet": "1.0.0",
+	"sdk/@launchdarkly/observability-node": "1.0.0",
+	"sdk/@launchdarkly/observability-python": "1.0.0",
 	"sdk/@launchdarkly/observability-react-native": "0.7.0",
-	"sdk/@launchdarkly/session-replay": "0.5.2",
+	"sdk/@launchdarkly/session-replay": "1.0.0",
 	"sdk/highlight-run": "9.26.0"
 }


### PR DESCRIPTION
## Summary

Prepare for Observability General Availability.

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Manifest-only version bumps with no runtime code changes; risk is limited to release automation producing 1.0.0 tags/packages for the listed SDKs.
> 
> **Overview**
> Bumps release-please manifest versions to `1.0.0` for the Go and core observability SDK packages (`sdk/@launchdarkly/observability`, `-dotnet`, `-node`, `-python`) and `sdk/@launchdarkly/session-replay`, aligning them for a 1.x/GA release.
> 
> Leaves `observability-android`, `observability-react-native`, and `highlight-run` unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c25bd925bc93107a62f1e98d0556d2a54a539fb4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->