### PR TITLE
chore(deps): update `@launchdarkly/js-client-sdk` to stable version

### DIFF
--- a/e2e/nextjs/package.json
+++ b/e2e/nextjs/package.json
@@ -15,7 +15,7 @@
 	"dependencies": {
 		"@highlight-run/next": "workspace:*",
 		"@highlight-run/pino": "workspace:*",
-		"@launchdarkly/js-client-sdk": "^0.11.0",
+		"@launchdarkly/js-client-sdk": "^4.0.0",
 		"@next/env": "^15.1.7",
 		"@prisma/client": "^6.4.1",
 		"@prisma/instrumentation": "^6.4.1",

--- a/e2e/react-router/package.json
+++ b/e2e/react-router/package.json
@@ -11,7 +11,7 @@
 	},
 	"dependencies": {
 		"@highlight-run/react": "workspace:*",
-		"@launchdarkly/js-client-sdk": "^0.11.0",
+		"@launchdarkly/js-client-sdk": "^4.0.0",
 		"@launchdarkly/observability": "workspace:*",
 		"@launchdarkly/session-replay": "workspace:*",
 		"launchdarkly-js-client-sdk": "3.8.1",

--- a/sdk/highlight-run/package.json
+++ b/sdk/highlight-run/package.json
@@ -81,7 +81,7 @@
 		"dist"
 	],
 	"dependencies": {
-		"@launchdarkly/js-client-sdk": "^0.11.0",
+		"@launchdarkly/js-client-sdk": "^4.0.0",
 		"imurmurhash": "^0.1.4"
 	},
 	"devDependencies": {

--- a/sdk/highlight-run/src/client/types/types.ts
+++ b/sdk/highlight-run/src/client/types/types.ts
@@ -11,7 +11,7 @@ import type {
 import type { ErrorMessageType, Source } from './shared-types'
 import type { LDClient } from '../../integrations/launchdarkly'
 import type { LDPluginEnvironmentMetadata } from '../../plugins/plugin'
-import type { LDContext } from '@launchdarkly/js-sdk-common'
+import type { LDContext } from '@launchdarkly/js-client-sdk'
 
 export interface Metadata {
 	[key: string]: any

--- a/sdk/highlight-run/src/integrations/launchdarkly/getContextKeys.test.ts
+++ b/sdk/highlight-run/src/integrations/launchdarkly/getContextKeys.test.ts
@@ -1,6 +1,9 @@
 import { expect, it } from 'vitest'
 import { getContextKeys } from './index'
-import type { LDContext, LDMultiKindContext } from '@launchdarkly/js-client-sdk'
+import type {
+	LDContextStrict,
+	LDMultiKindContext,
+} from '@launchdarkly/js-client-sdk'
 
 it.each([
 	// Legacy user (no kind property)
@@ -49,7 +52,7 @@ it.each([
 	],
 ])(
 	'should produce the correct context keys for a given context',
-	(context: LDContext, expectedKeys: Record<string, string>) => {
+	(context: LDContextStrict, expectedKeys: Record<string, string>) => {
 		const result = getContextKeys(context)
 		expect(result).toEqual(expectedKeys)
 	},

--- a/sdk/highlight-run/src/integrations/launchdarkly/index.ts
+++ b/sdk/highlight-run/src/integrations/launchdarkly/index.ts
@@ -11,7 +11,7 @@ import type {
 	IdentifySeriesContext,
 	IdentifySeriesData,
 	IdentifySeriesResult,
-	LDContext,
+	LDContextStrict,
 	LDContextCommon,
 	LDMultiKindContext,
 } from '@launchdarkly/js-client-sdk'
@@ -72,7 +72,7 @@ function isMultiContext(context: any): context is LDMultiKindContext {
  * @param context The context to get a canonical key for.
  * @returns The canonical context key.
  */
-export function getCanonicalKey(context: LDContext) {
+export function getCanonicalKey(context: LDContextStrict) {
 	if (isMultiContext(context)) {
 		return Object.keys(context)
 			.sort()
@@ -92,7 +92,7 @@ export function getCanonicalKey(context: LDContext) {
 	return `${context.kind}:${encodeKey(context.key)}`
 }
 
-export function getContextKeys(context: LDContext) {
+export function getContextKeys(context: LDContextStrict) {
 	if (isMultiContext(context)) {
 		return Object.keys(context)
 			.sort()
@@ -125,7 +125,7 @@ export function setupLaunchDarklyIntegration(
 	hClient: HighlightPublicInterface,
 	ldClient: LDClient,
 	options?: {
-		contextFriendlyName?: (context: LDContext) => string | undefined
+		contextFriendlyName?: (context: LDContextStrict) => string | undefined
 	},
 ) {
 	ldClient.addHook({

--- a/yarn.lock
+++ b/yarn.lock
@@ -8420,21 +8420,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@launchdarkly/js-client-sdk-common@npm:1.16.0":
-  version: 1.16.0
-  resolution: "@launchdarkly/js-client-sdk-common@npm:1.16.0"
+"@launchdarkly/js-client-sdk-common@npm:1.17.2":
+  version: 1.17.2
+  resolution: "@launchdarkly/js-client-sdk-common@npm:1.17.2"
   dependencies:
     "@launchdarkly/js-sdk-common": "npm:2.20.0"
-  checksum: 10/afc9e39403fdeefc5de650fa7dae3fd2faa35e7015c2d58acd6e9f0ea0f79c13410c9cd4911ce559dca6b84cee02b782aa1a09901a0b7d191b3684d1e68339ca
+  checksum: 10/871c0cb16ee498d5f734bb1ba23cf7959ec6a34f1f483fd0fcd30492cd0083ba6ff3370c7af03615b661219bd2a7dc561f3f6ff84634a5c3a04cd6196fdfd637
   languageName: node
   linkType: hard
 
-"@launchdarkly/js-client-sdk@npm:^0.11.0":
-  version: 0.11.0
-  resolution: "@launchdarkly/js-client-sdk@npm:0.11.0"
+"@launchdarkly/js-client-sdk@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "@launchdarkly/js-client-sdk@npm:4.0.0"
   dependencies:
-    "@launchdarkly/js-client-sdk-common": "npm:1.16.0"
-  checksum: 10/56b6565c58663f50225964f393baba40794d57d99f7e0475985c8c1ec404286c406282a9a1f59ce5249a05e2845d8a459f708ab5fc594b81726c32ac59eea13e
+    "@launchdarkly/js-client-sdk-common": "npm:1.17.2"
+  checksum: 10/daf2b64932ca05782e3b024367bb305ab7bd88e4b4a2ee959562cc5e43534ebd355e0929e9d8d3ddd345ec201fce79130806cdd66f97450442858010abd65327
   languageName: node
   linkType: hard
 
@@ -28131,7 +28131,7 @@ __metadata:
     "@graphql-codegen/typescript": "npm:^4.0.1"
     "@graphql-codegen/typescript-graphql-request": "npm:^6.0.1"
     "@graphql-codegen/typescript-operations": "npm:^4.0.1"
-    "@launchdarkly/js-client-sdk": "npm:^0.11.0"
+    "@launchdarkly/js-client-sdk": "npm:^4.0.0"
     "@opentelemetry/api": "npm:^1.9.0"
     "@opentelemetry/exporter-metrics-otlp-http": "npm:>=0.57.1 < 0.200.0"
     "@opentelemetry/exporter-trace-otlp-http": "npm:>=0.57.1 < 0.200.0"
@@ -35286,7 +35286,7 @@ __metadata:
   dependencies:
     "@highlight-run/next": "workspace:*"
     "@highlight-run/pino": "workspace:*"
-    "@launchdarkly/js-client-sdk": "npm:^0.11.0"
+    "@launchdarkly/js-client-sdk": "npm:^4.0.0"
     "@next/env": "npm:^15.1.7"
     "@prisma/client": "npm:^6.4.1"
     "@prisma/instrumentation": "npm:^6.4.1"
@@ -39242,7 +39242,7 @@ __metadata:
   resolution: "react-router@workspace:e2e/react-router"
   dependencies:
     "@highlight-run/react": "workspace:*"
-    "@launchdarkly/js-client-sdk": "npm:^0.11.0"
+    "@launchdarkly/js-client-sdk": "npm:^4.0.0"
     "@launchdarkly/observability": "workspace:*"
     "@launchdarkly/session-replay": "workspace:*"
     "@types/react": "npm:^19.0.4"


### PR DESCRIPTION
## Summary

Updating `@launchdarkly/js-client-sdk` to the latest stable release version.

A notable change is to the `LDContext` type. `LDContext` given to a client side SDK could be missing a key. In those cases, the SDK will federate a key to the context which turns it to a `LDContextStrict`.

## How did you test this change?

No test changes

## Are there any deployment considerations?

No changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily a dependency major-version bump; risk comes from potential runtime/typing behavior changes in the LaunchDarkly client SDK and its context semantics affecting feature flag instrumentation.
> 
> **Overview**
> Upgrades `@launchdarkly/js-client-sdk` from `^0.11.0` to `^4.0.0` across the SDK package and the `e2e` Next.js/React Router apps, updating `yarn.lock` accordingly.
> 
> Adjusts LaunchDarkly integration typings to match the new SDK: switches context handling to `LDContextStrict` (and updates imports/tests) so helpers like `getCanonicalKey`, `getContextKeys`, and `contextFriendlyName` callbacks use the stricter context type expected after key federation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 04901cc2285074b45e948222a116d7857a5340d7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->