### PR TITLE
fix: Trigger release / Code comments change

### DIFF
--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/ReplayOptions.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/ReplayOptions.kt
@@ -6,7 +6,7 @@ package com.launchdarkly.observability.replay
  * @property debug enables verbose logging if true as well as other debug functionality. Defaults to false.
  * @property privacyProfile privacy profile that controls masking behavior
  * @property capturePeriodMillis period between captures
- * @property enabled controls whether session replay starts capturing immediately
+ * @property enabled controls whether session replay starts capturing immediately on initialization
  */
 data class ReplayOptions(
     val enabled: Boolean = true,

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/sdk/LDReplay.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/sdk/LDReplay.kt
@@ -21,14 +21,14 @@ object LDReplay {
     }
 
     /**
-     * Starts session replay capture and event buffering if configured.
+     * Starts session replay capture
      */
     fun start() {
         delegate.start()
     }
 
     /**
-     * Stops session replay capture and event buffering until started again.
+     * Stops session replay capture
      */
     fun stop() {
         delegate.stop()


### PR DESCRIPTION
## Summary

The goal to bump version to trigger release 



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only changes that clarify Session Replay behavior; no functional or API behavior changes.
> 
> **Overview**
> Updates KDoc wording to clarify Session Replay semantics: `ReplayOptions.enabled` now explicitly states capture begins immediately *on initialization*, and `LDReplay.start()`/`stop()` docs are simplified to “starts/stops capture” (removing mention of event buffering).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b0d18991418c906d859b170cb736fdb7c5067b95. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->