### PR TITLE
ci: allow manual trigger of release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,6 +3,7 @@ name: Run Release Please
 on:
     push:
         branches: [main]
+    workflow_dispatch:
 
 jobs:
     release-package:


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch` trigger to the release-please workflow so it can be run manually from the GitHub Actions UI.

## Test plan
- [ ] Verify the "Run workflow" button appears on the Actions page for this workflow after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Minimal change to CI triggering only; no application logic or release steps were modified.
> 
> **Overview**
> Adds a manual `workflow_dispatch` trigger to `.github/workflows/release-please.yml`, allowing Release Please to be run on-demand from the GitHub Actions UI in addition to running on `push` to `main`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e4d5a69c18db0d9502179e2efc0792027f160c1e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->