### PR TITLE
fix: [SEC-7656] Add Set-Cookie to default redacted headers

### DIFF
--- a/sdk/highlight-run/src/client/listeners/network-listener/utils/network-sanitizer.ts
+++ b/sdk/highlight-run/src/client/listeners/network-listener/utils/network-sanitizer.ts
@@ -50,7 +50,7 @@ export const sanitizeHeaders = (
 	return newHeaders
 }
 
-/** These are known headers that are secrets. */
+/** Known headers that contain secrets. Applies to both request and response headers. */
 const SENSITIVE_HEADERS = [
 	'authorization',
 	'cookie',


### PR DESCRIPTION
## Summary
Adds Set-Cookie to the default list of redacted headers.

## Changes
- Added `'set-cookie'` to `SENSITIVE_HEADERS` array in `network-sanitizer.ts`

## Security Impact
The Set-Cookie response header can contain session cookies. Without this change, these cookies could be captured in observability telemetry when network recording is enabled, potentially enabling session hijacking.

Fixes SEC-7656 (HackerOne report 3506797)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted change limited to header redaction defaults; low risk aside from potentially hiding `Set-Cookie` in recorded network data for debugging.
> 
> **Overview**
> **Redacts `Set-Cookie` by default** in the network recording sanitizer by adding `'set-cookie'` to the `SENSITIVE_HEADERS` list (and updating the comment to clarify it applies to both request and response headers). This prevents session cookies in response headers from being captured in telemetry unless explicitly allowed via `headersToRecord`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 99e8474520cca6e00b21c7f21676bf1bfefdc3c0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
<!-- ld-jira-link -->
---
Related Jira issue: [SEC-7656: Observability network recording does not redact `Set-Cookie` response headers by default (session cookie leak)](https://launchdarkly.atlassian.net/browse/SEC-7656)
<!-- end-ld-jira-link -->