### PR TITLE
fix: Android SR, remove visible scrollbars

### DIFF
--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/exporter/SessionReplayEventGenerator.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/exporter/SessionReplayEventGenerator.kt
@@ -22,6 +22,10 @@ import kotlinx.serialization.json.put
 class SessionReplayEventGenerator(
     private val canvasDrawEntourage: Int
 ) {
+    companion object {
+        private const val RRWEB_DOCUMENT_PADDING = 11
+    }
+
     /**
      * Sequence ID for the events being generated.
      * Each event in a session needs a unique, monotonically increasing "sid".
@@ -86,9 +90,9 @@ class SessionReplayEventGenerator(
             sid = nextSid(),
             data = EventDataUnion.StandardEventData(
                 EventData(
-                    width = captureEvent.origWidth,
-                    height = captureEvent.origHeight,
-                )
+                    width = captureEvent.origWidth + RRWEB_DOCUMENT_PADDING * 2,
+                    height = captureEvent.origHeight + RRWEB_DOCUMENT_PADDING * 2,
+                    )
             ),
         )
         eventBatch.add(metaEvent)
@@ -182,7 +186,7 @@ class SessionReplayEventGenerator(
                         timestamp = firstPosition.timestamp,
                         sid = nextSid(),
                         data = EventDataUnion.CustomEventDataWrapper(
-                            Json.parseToJsonElement("""{"source":2,"texts": [],"type":7,"id":6,"x":${firstPosition.x}, "y":${firstPosition.y}}""")
+                            Json.parseToJsonElement("""{"source":2,"texts": [],"type":7,"id":6,"x":${firstPosition.x + RRWEB_DOCUMENT_PADDING}, "y":${firstPosition.y + RRWEB_DOCUMENT_PADDING}}""")
                         )
                     )
                 )
@@ -206,7 +210,7 @@ class SessionReplayEventGenerator(
                         timestamp = lastPosition.timestamp,
                         sid = nextSid(),
                         data = EventDataUnion.CustomEventDataWrapper(
-                            Json.parseToJsonElement("""{"source":2,"texts": [],"type":9,"id":6,"x":${lastPosition.x}, "y":${lastPosition.y}}""")
+                            Json.parseToJsonElement("""{"source":2,"texts": [],"type":9,"id":6,"x":${lastPosition.x + RRWEB_DOCUMENT_PADDING}, "y":${lastPosition.y + RRWEB_DOCUMENT_PADDING}}""")
                         )
                     )
                 )
@@ -221,7 +225,7 @@ class SessionReplayEventGenerator(
                             timestamp = position.timestamp,
                             sid = nextSid(),
                             data = EventDataUnion.CustomEventDataWrapper(
-                                Json.parseToJsonElement("""{"positions": [{"id":6,"timeOffset":0,"x":${position.x},"y":${position.y}}], "source": 6}""")
+                                Json.parseToJsonElement("""{"positions": [{"id":6,"timeOffset":0,"x":${position.x + RRWEB_DOCUMENT_PADDING},"y":${position.y + RRWEB_DOCUMENT_PADDING}}], "source": 6}""")
                             )
                         )
                     )


### PR DESCRIPTION
## Summary

Match current iOS padding approach to remove scrollbars

## How did you test this change?
<img width="341" height="451" alt="image" src="https://github.com/user-attachments/assets/ea004914-3398-488e-866b-fcd1b50b4e08" />

## Are there any deployment considerations?
Probably there is more stable way, but this one works

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to session replay event generation; main risk is slight coordinate/layout mismatch if consumers assume unpadded dimensions.
> 
> **Overview**
> Adds a fixed `RRWEB_DOCUMENT_PADDING` in `SessionReplayEventGenerator` and applies it to RRWeb meta sizing and touch coordinates.
> 
> `META` events now report `width`/`height` with extra padding, and interaction events (`ACTION_DOWN`/`MOVE`/`UP`) offset `x`/`y` by the same amount so replays align with the padded document and avoid visible scrollbars.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 366da92c778670d12909e1ef28fc92f634ca09ae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->