### PR TITLE
fix: note react sdk deprecation

### DIFF
--- a/sdk/highlight-react/README.md
+++ b/sdk/highlight-react/README.md
@@ -1,5 +1,11 @@
 ## @highlight-run/react
 
+> **Deprecated: This package has been superseded by the LaunchDarkly Observability SDK.**
+>
+> `@highlight-run/react` is no longer actively maintained. For error monitoring, logging, tracing, and session replay in React applications, use the [`@launchdarkly/observability`](https://www.npmjs.com/package/@launchdarkly/observability) plugin for the LaunchDarkly React Web SDK (v3.7.0+).
+>
+> See the [Observability SDK documentation](https://launchdarkly.com/docs/sdk/observability/react-web) for setup instructions.
+
 The `@highlight-run/react` package hosts the react SDK for highlight.
 This includes the `<ErrorBoundary/>` component which allows capturing and rendering an
 error dialog for React rendering exceptions in your app.


### PR DESCRIPTION
## Summary

Add a deprecation note for `@highlight-run/react`

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime, API, or data-handling impact.
> 
> **Overview**
> Updates `sdk/highlight-react/README.md` to clearly mark `@highlight-run/react` as **deprecated**, noting it is no longer actively maintained.
> 
> Directs users to migrate to the LaunchDarkly Observability SDK via `@launchdarkly/observability` (with links to npm and setup docs).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6ecb4bdb0262ce276ebe213d6f84f0571a2dcb8f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->