### PR TITLE
fix: Show correct import in documentation

### DIFF
--- a/sdk/@launchdarkly/observability-node/README.md
+++ b/sdk/@launchdarkly/observability-node/README.md
@@ -22,17 +22,40 @@ yarn add @launchdarkly/observability-node
 Update your application to instantiate the observability plugin when you initialize the LaunchDarkly SDK.
 ```TypeScript
 import { init } from '@launchdarkly/node-server-sdk'
-import Observability, { LDObserve } from '@launchdarkly/observability'
+import { Observability } from '@launchdarkly/observability-node'
 
 const client = init(
-        'sdk-key',
-        {
-          plugins: [
-            new Observability(),
-          ],
-        },
+  'sdk-key',
+  {
+    plugins: [
+      new Observability(),
+    ],
+  },
 )
+```
 
+## Manual instrumentation with LDObserve
+
+The `Observability` plugin automatically captures flag evaluations, logs, and traces. Use the `LDObserve` singleton when you want to record custom metrics, logs, errors, or spans so they are correlated with your LaunchDarkly data.
+
+```TypeScript
+import { LDObserve } from '@launchdarkly/observability-node'
+
+// Record custom metrics (counters, gauges, histograms, etc.)
+LDObserve.recordCount({ name: 'api_calls', value: 1 })
+LDObserve.recordHistogram({ name: 'response_time_ms', value: 150 })
+
+// Record logs and errors
+LDObserve.recordLog('User performed action', 'info', undefined, undefined, { user_id: '12345' })
+LDObserve.recordError(new Error('Payment failed'), undefined, undefined, { component: 'checkout' })
+
+// Create spans tied to request context (e.g. in Express)
+app.get('/order', (req, res) => {
+  LDObserve.runWithHeaders('handle-order', req.headers, (span) => {
+    // Your handler logic; span is linked to the request trace
+    res.json({ orderId: '123' })
+  })
+})
 ```
 
 ## Getting started

--- a/sdk/@launchdarkly/observability-node/package.json
+++ b/sdk/@launchdarkly/observability-node/package.json
@@ -6,6 +6,7 @@
 		"type": "git",
 		"url": "https://github.com/launchdarkly/observability-sdk.git"
 	},
+	"homepage": "https://github.com/launchdarkly/observability-sdk/tree/main/sdk/@launchdarkly/observability-node#readme",
 	"scripts": {
 		"typegen": "tsc -d --emitDeclarationOnly",
 		"dev": "yarn build --watch",

--- a/sdk/@launchdarkly/observability-node/src/index.ts
+++ b/sdk/@launchdarkly/observability-node/src/index.ts
@@ -11,7 +11,7 @@
  * # Quick Start
  * ```typescript
  * import { init } from '@launchdarkly/node-server-sdk'
- * import Observability, { LDObserve } from '@launchdarkly/observability'
+ * import { Observability } from '@launchdarkly/observability-node'
  *
  * const client = init(
  *   'sdk-key',


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only changes plus a `package.json` metadata update; no runtime logic is modified.
> 
> **Overview**
> Updates `@launchdarkly/observability-node` docs to show the correct named import (`{ Observability }` from `@launchdarkly/observability-node`) in both the README and the package-level `src/index.ts` quick start.
> 
> Expands the README with a new *Manual instrumentation with `LDObserve`* section including examples for custom metrics/logs/errors and request-context spans, and adds a `homepage` field to `package.json` pointing to the README on GitHub.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9146d36dd1dfb17e72f3436fe57be481df4c2804. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->