### PR TITLE
fix: add @launchdarkly/session-replay-react-native to release-please

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -6,7 +6,7 @@
 	"sdk/@launchdarkly/observability-node": "1.0.1",
 	"sdk/@launchdarkly/observability-python": "1.1.0",
 	"sdk/@launchdarkly/observability-react-native": "0.7.0",
-	"sdk/@launchdarkly/session-replay": "1.0.2",
 	"sdk/@launchdarkly/react-native-ld-session-replay": "0.1.0",
+	"sdk/@launchdarkly/session-replay": "1.0.2",
 	"sdk/highlight-run": "9.27.0"
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -70,6 +70,13 @@
 			"include-v-in-tag": false,
 			"include-component-in-tag": true
 		},
+		"sdk/@launchdarkly/react-native-ld-session-replay": {
+			"package-name": "@launchdarkly/session-replay-react-native",
+			"release-type": "node",
+			"versioning": "default",
+			"include-v-in-tag": false,
+			"include-component-in-tag": true
+		},
 		"sdk/highlight-run": {
 			"package-name": "highlight.run",
 			"release-type": "node",


### PR DESCRIPTION
## Summary

Setup automated publishing.

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change to release automation; main risk is misnaming/misconfiguring the package leading to incorrect or missing releases.
> 
> **Overview**
> Configures Release Please to manage `@launchdarkly/session-replay-react-native` by adding a new package entry in `release-please-config.json` and tracking its initial version (`0.1.0`) in `.release-please-manifest.json`. This enables automated tagging/release generation for the React Native session replay SDK alongside the existing workspace packages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ac148a1772c1ab3d772ba0ddd7ac0feb18a57c6c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->