### PR TITLE
feat: Android SR use Jpeg 0.3 quality

### DIFF
--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/capture/ExportDiffManager.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/capture/ExportDiffManager.kt
@@ -13,7 +13,7 @@ class ExportDiffManager(
     private val currentImages = mutableListOf<ExportFrame.RemoveImage>()
     private val currentImagesIndex = mutableMapOf<ImageSignature, Int>()
     private val lock = Any()
-    private val format = ExportFrame.ExportFormat.Jpeg(quality = 0.3f)
+    private val format = ExportFrame.DEFAULT_EXPORT_FORMAT
 
     private var keyFrameId = 0
 
@@ -98,7 +98,6 @@ class ExportDiffManager(
                 removeImages = removes,
                 originalSize = tiledFrame.originalSize,
                 scale = tiledFrame.scale,
-                format = format,
                 timestamp = tiledFrame.timestamp,
                 orientation = tiledFrame.orientation,
                 isKeyframe = tiledFrame.isKeyframe,

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/capture/ExportFrame.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/capture/ExportFrame.kt
@@ -9,13 +9,16 @@ data class ExportFrame(
     val removeImages: List<RemoveImage>?,
     val originalSize: IntSize,
     val scale: Float,
-    val format: ExportFormat,
     val timestamp: Long,
     val orientation: Int,
     val isKeyframe: Boolean,
     val imageSignature: ImageSignature?,
     val session: String
 ){
+    companion object {
+        val DEFAULT_EXPORT_FORMAT: ExportFormat = ExportFormat.Jpeg(quality = 0.3f)
+    }
+
     constructor(
         imageBase64: String,
         origHeight: Int,
@@ -34,7 +37,6 @@ data class ExportFrame(
         removeImages = null,
         originalSize = IntSize(width = origWidth, height = origHeight),
         scale = 1f,
-        format = ExportFormat.Webp(quality = 30),
         timestamp = timestamp,
         orientation = 0,
         isKeyframe = true,

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/exporter/RRWebEventGenerator.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/exporter/RRWebEventGenerator.kt
@@ -79,17 +79,17 @@ class RRWebEventGenerator(
         return lastNodeId
     }
 
-    private fun imageMimeType(format: ExportFrame.ExportFormat): String =
-        when (format) {
+    private fun imageMimeType(): String =
+        when (ExportFrame.DEFAULT_EXPORT_FORMAT) {
             ExportFrame.ExportFormat.Png -> "image/png"
             is ExportFrame.ExportFormat.Jpeg -> "image/jpeg"
             is ExportFrame.ExportFormat.Webp -> "image/webp"
         }
 
-    private fun tileNode(exportFrame: ExportFrame, image: ExportFrame.AddImage): Pair<EventNode, Int> {
+    private fun tileNode(image: ExportFrame.AddImage): Pair<EventNode, Int> {
         val tileCanvasId = nextNodeId()
         image.imageSignature?.let { nodeIds[it] = tileCanvasId }
-        val dataUrl = "data:${imageMimeType(exportFrame.format)};base64,${image.imageBase64}"
+        val dataUrl = "data:${imageMimeType()};base64,${image.imageBase64}"
         val node = EventNode(
             id = tileCanvasId,
             type = NodeType.ELEMENT,
@@ -123,7 +123,7 @@ class RRWebEventGenerator(
         }
 
         val adds = exportFrame.addImages.map { image ->
-            val (node, canvasSize) = tileNode(exportFrame, image)
+            val (node, canvasSize) = tileNode(image)
             totalCanvasSize += canvasSize
             Addition(parentId = bodyId, nextId = null, node = node)
         }
@@ -213,7 +213,7 @@ class RRWebEventGenerator(
         val headNodeId = nextNodeId()
         val currentBodyNodeId = nextNodeId()
         val tileNodes = exportFrame.addImages.map { image ->
-            val (node, canvasSize) = tileNode(exportFrame, image)
+            val (node, canvasSize) = tileNode(image)
             totalCanvasSize += canvasSize
             node
         }

--- a/sdk/@launchdarkly/observability-android/lib/src/test/kotlin/com/launchdarkly/observability/replay/exporter/RRWebEventGeneratorTest.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/test/kotlin/com/launchdarkly/observability/replay/exporter/RRWebEventGeneratorTest.kt
@@ -3,6 +3,7 @@ package com.launchdarkly.observability.replay.exporter
 import com.launchdarkly.observability.replay.Event
 import com.launchdarkly.observability.replay.EventData
 import com.launchdarkly.observability.replay.EventDataUnion
+import com.launchdarkly.observability.replay.EventNode
 import com.launchdarkly.observability.replay.EventType
 import com.launchdarkly.observability.replay.capture.ExportFrame
 import com.launchdarkly.observability.replay.capture.ImageSignature
@@ -14,6 +15,16 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 class RRWebEventGeneratorTest {
+    @Test
+    fun `convenience export frame uses jpeg mime type`() {
+        val generator = RRWebEventGenerator(canvasDrawEntourage = 1)
+        val exportFrame = ExportFrame("AQ==", 88, 120, 1L, "session")
+
+        val events = generator.generateCaptureFullEvents(exportFrame)
+        val src = firstImageSrc(events)
+
+        assertTrue(src.startsWith("data:image/jpeg;base64,"))
+    }
 
     @Test
     fun `keyframe incremental resolves removes before map reset`() {
@@ -134,7 +145,6 @@ class RRWebEventGeneratorTest {
         removeImages = removeImages,
         originalSize = IntSize(width = 120, height = 88),
         scale = 1f,
-        format = ExportFrame.ExportFormat.Webp(quality = 30),
         timestamp = timestamp,
         orientation = 0,
         isKeyframe = isKeyframe,
@@ -158,5 +168,26 @@ class RRWebEventGeneratorTest {
         val event = events.first { it.type == EventType.INCREMENTAL_SNAPSHOT }
         val data = event.data as EventDataUnion.StandardEventData
         return data.data
+    }
+
+    private fun firstImageSrc(events: List<Event>): String {
+        val fullSnapshot = events.first { it.type == EventType.FULL_SNAPSHOT }
+        val data = (fullSnapshot.data as EventDataUnion.StandardEventData).data
+        val root = data.node ?: error("FULL_SNAPSHOT should include a root node")
+        val imageNode = firstNodeWithTag(root, "img") ?: error("FULL_SNAPSHOT should include an image node")
+        return imageNode.attributes?.get("src") ?: error("Image node should include src")
+    }
+
+    private fun firstNodeWithTag(node: EventNode, tagName: String): EventNode? {
+        if (node.tagName == tagName) {
+            return node
+        }
+        for (child in node.childNodes) {
+            val match = firstNodeWithTag(child, tagName)
+            if (match != null) {
+                return match
+            }
+        }
+        return null
     }
 }


### PR DESCRIPTION
WEBP is 4 times more expensive compare Jpeg. Need investigate why?

(cherry picked from commit 0b3ad7d5f28edae7764655ac38cad22a76997cf5)

## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the image encoding format and MIME type used in replay payloads, which could affect replay rendering/compatibility and payload size/quality characteristics.
> 
> **Overview**
> Switches Android session replay tile/image encoding from per-frame `Webp` to a shared `ExportFrame.DEFAULT_EXPORT_FORMAT` (now `Jpeg(quality=0.3)`), and removes the `format` field from `ExportFrame` so capture/export code no longer carries format metadata per frame.
> 
> Updates `RRWebEventGenerator` to build image data URLs using the default format’s MIME type, and adjusts/extends tests to validate JPEG MIME output for the convenience `ExportFrame` constructor.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c29aed9f94db824a37654bf2ea9701ad228ebf45. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->