### PR TITLE
docs: [SDK-2206] add README for .NET AspSampleApp

### DIFF
--- a/sdk/@launchdarkly/observability-dotnet/AspSampleApp/Program.cs
+++ b/sdk/@launchdarkly/observability-dotnet/AspSampleApp/Program.cs
@@ -12,7 +12,7 @@ builder.Services.AddSwaggerGen();
 var config = Configuration.Builder(Environment.GetEnvironmentVariable("LAUNCHDARKLY_SDK_KEY"))
     .Plugins(new PluginConfigurationBuilder()
         .Add(ObservabilityPlugin.Builder(builder.Services)
-            .WithServiceName("ryan-test-service")
+            .WithServiceName("asp-core-test-service")
             .WithServiceVersion("0.0.0")
             .Build())).Build();
 

--- a/sdk/@launchdarkly/observability-dotnet/AspSampleApp/README.md
+++ b/sdk/@launchdarkly/observability-dotnet/AspSampleApp/README.md
@@ -1,0 +1,77 @@
+# AspSampleApp
+
+A minimal ASP.NET Core (net8.0) app that demonstrates the
+`LaunchDarkly.Observability` plugin. It exercises the public `Observe` APIs —
+exception recording, metrics, logs, manual spans — alongside a LaunchDarkly
+feature flag evaluation, so you can verify telemetry flows end-to-end.
+
+The project references the local plugin source
+(`../src/LaunchDarkly.Observability`) rather than the published NuGet package,
+making it useful for plugin development as well.
+
+## Prerequisites
+
+- .NET 8 SDK
+- A LaunchDarkly server-side SDK key
+
+## Running
+
+From the `AspSampleApp/` directory:
+
+```shell
+export LAUNCHDARKLY_SDK_KEY="<your-server-sdk-key>"
+dotnet run
+```
+
+The app listens on the ports configured by the ASP.NET Core launch profile
+(HTTPS redirect is enabled). In `Development`, Swagger UI is exposed at
+`/swagger`.
+
+If you want the `/weatherforecast` and `/manualinstrumentation` endpoints to
+exhibit non-default behavior, create boolean flags named `isMercury` and
+`enableMetrics` in your LaunchDarkly project.
+
+### Configuring the service
+
+The plugin is configured in `Program.cs`:
+
+```csharp
+var config = Configuration.Builder(Environment.GetEnvironmentVariable("LAUNCHDARKLY_SDK_KEY"))
+    .Plugins(new PluginConfigurationBuilder()
+        .Add(ObservabilityPlugin.Builder(builder.Services)
+            .WithServiceName("asp-core-test-service")
+            .WithServiceVersion("0.0.0")
+            .Build())).Build();
+```
+
+Change `WithServiceName` / `WithServiceVersion` to label the telemetry emitted
+by your run.
+
+## Endpoints
+
+| Method | Path                      | What it demonstrates                                                                                 |
+| ------ | ------------------------- | ---------------------------------------------------------------------------------------------------- |
+| GET    | `/recordexception`        | `Observe.RecordException` with custom attributes.                                                    |
+| GET    | `/recordmetrics`          | `RecordMetric` (gauge), `RecordCount`, `RecordIncr`, `RecordHistogram`, and `RecordUpDownCounter`.   |
+| GET    | `/recordlog`              | `Observe.RecordLog` at varying severities with structured attributes.                                |
+| GET    | `/manualinstrumentation`  | `Observe.StartActivity` to create a manual span; gated by the `enableMetrics` flag.                  |
+| GET    | `/weatherforecast`        | Evaluates the `isMercury` flag and returns a forecast whose temperature range depends on the value. |
+| GET    | `/crash`                  | Throws `NotImplementedException` to test unhandled-exception capture.                                |
+
+Example:
+
+```shell
+curl http://localhost:5247/recordmetrics
+curl http://localhost:5247/weatherforecast
+```
+
+A ready-to-run request is also in `AspSampleApp.http` for JetBrains / VS Code
+HTTP clients.
+
+## Verifying telemetry
+
+Once the endpoints have been hit, traces, metrics, logs, and errors should
+appear in the LaunchDarkly observability UI under the service name configured
+above. The default backend is
+`https://pub.observability.app.launchdarkly.com`; override it on the plugin
+builder if you're pointing at a different environment.

--- a/sdk/@launchdarkly/observability-dotnet/src/LaunchDarkly.Observability/Asp/Core/ObservabilityPlugin.cs
+++ b/sdk/@launchdarkly/observability-dotnet/src/LaunchDarkly.Observability/Asp/Core/ObservabilityPlugin.cs
@@ -42,7 +42,7 @@ namespace LaunchDarkly.Observability
         /// var config = Configuration.Builder("your-sdk-key")
         ///     .Plugins(new PluginConfigurationBuilder()
         ///         .Add(ObservabilityPlugin.Builder(builder.Services)
-        ///             .WithServiceName("ryan-test-service")
+        ///             .WithServiceName("asp-core-test-service")
         ///             .WithServiceVersion("example-sha")
         ///             .Build())).Build();
         /// // Building the LdClient with the Observability plugin. This line will add services to the web application.


### PR DESCRIPTION
## Summary

Document how to run the sample ASP.NET Core app that exercises the LaunchDarkly.Observability plugin, including required env vars, endpoints, and flag names. Also rename the placeholder service name from "ryan-test-service" to "asp-core-test-service" in the sample and in the XML doc example on ObservabilityPlugin.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only plus a sample configuration string change; no production/runtime logic is modified.
> 
> **Overview**
> Adds a new `AspSampleApp/README.md` documenting prerequisites, how to run the sample (including `LAUNCHDARKLY_SDK_KEY`), relevant flag names, and the available demo endpoints for exercising `Observe` APIs and flag evaluation.
> 
> Renames the sample/placeholder `WithServiceName` value to `asp-core-test-service` in both `AspSampleApp/Program.cs` and the XML-doc example in `ObservabilityPlugin` to keep emitted telemetry labeling consistent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61932f2d57a2191dc0f110fdc6f08091f0af31ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
<!-- ld-jira-link -->
---
Related Jira issue: [SDK-2206: Improve ASP.Net Core example.](https://launchdarkly.atlassian.net/browse/SDK-2206)
<!-- end-ld-jira-link -->