### PR TITLE
chore: silence otlp localhost connection exceptions in e2e tests

### DIFF
--- a/e2e/android/app/build.gradle.kts
+++ b/e2e/android/app/build.gradle.kts
@@ -84,6 +84,13 @@ android {
     }
 }
 
+tasks.withType<Test>().configureEach {
+    systemProperty(
+        "java.util.logging.config.file",
+        project.file("src/test/resources/logging.properties").absolutePath
+    )
+}
+
 dependencies {
     // Uncomment to use the local project
     implementation(project(":observability-android"))

--- a/e2e/android/app/src/test/resources/logging.properties
+++ b/e2e/android/app/src/test/resources/logging.properties
@@ -1,0 +1,19 @@
+# JUL configuration for unit tests.
+#
+# The OTLP HTTP exporter logs SEVERE stack traces whenever it can't reach its
+# endpoint. In tests the exporter is pointed at a per-test MockWebServer that
+# only has the sampling-config response enqueued, so every span/log/metric
+# export fails with either "unexpected end of stream" (no response in queue)
+# or "Connection refused" (previous test's server already shut down). These
+# failures are irrelevant because assertions read telemetry from
+# InMemoryTelemetryInspector, not HTTP. Silence those loggers to keep test
+# output readable.
+
+handlers = java.util.logging.ConsoleHandler
+.level = INFO
+
+java.util.logging.ConsoleHandler.level = INFO
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+io.opentelemetry.exporter.internal.http.HttpExporter.level = OFF
+io.opentelemetry.exporter.internal.grpc.GrpcExporter.level = OFF


### PR DESCRIPTION
## Summary

Silence otlp localhost exception in e2e tests, it is hard to read actual fail with them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only logging configuration change; no production runtime or telemetry behavior changes outside unit test output.
> 
> **Overview**
> Android e2e unit tests now load a dedicated Java Util Logging config via Gradle `Test` task `systemProperty("java.util.logging.config.file", ...)`.
> 
> Adds `src/test/resources/logging.properties` to keep test output readable by turning off noisy OpenTelemetry OTLP exporter loggers (`io.opentelemetry.exporter.internal.http.HttpExporter` / `GrpcExporter`) that emit SEVERE stack traces when mock endpoints are unreachable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 032938f356ebb02736ccb4c22899c9f2e9a9bf42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->