### PR TITLE
fix(observability-node): move @graphql-codegen/cli to devDependencies

### DIFF
--- a/sdk/@launchdarkly/observability-node/package.json
+++ b/sdk/@launchdarkly/observability-node/package.json
@@ -29,7 +29,6 @@
 		"access": "public"
 	},
 	"dependencies": {
-		"@graphql-codegen/cli": "^5.0.7",
 		"@launchdarkly/node-server-sdk-otel": "^1.3.0",
 		"@prisma/instrumentation": ">=5.0.0",
 		"require-in-the-middle": "^7.4.0"
@@ -39,6 +38,7 @@
 		"@launchdarkly/node-server-sdk": "^9.9.2"
 	},
 	"devDependencies": {
+		"@graphql-codegen/cli": "^5.0.7",
 		"@launchdarkly/js-server-sdk-common": "^2.15.2",
 		"@launchdarkly/node-server-sdk": "^9.9.2",
 		"@opentelemetry/api": "^1.9.0",


### PR DESCRIPTION
## Summary
- Resolves 13 high-severity npm audit findings reported against `@launchdarkly/observability-node@1.1.0` that traced back to `lodash` via `@graphql-codegen/cli → @graphql-codegen/plugin-helpers`.
- Advisories eliminated from consumers' trees: GHSA-r5fr-rjxr-66jc, GHSA-f23m-r3pf-42rh, GHSA-xxjr-mmjv-4gpg.
- `@graphql-codegen/cli` is only used by the `codegen` script (`codegen.ts`) for build-time GraphQL type generation; runtime imports come from `@graphql-typed-document-node/core`. Every other package in this monorepo already places it under `devDependencies`.

## Test plan
- [x] `yarn turbo run build --filter @launchdarkly/observability-node`
- [x] `yarn turbo run test --filter @launchdarkly/observability-node` (63 tests pass)
- [ ] Verify a downstream consumer no longer sees the three lodash advisories after publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency metadata change; the main impact is on build tooling availability rather than runtime behavior.
> 
> **Overview**
> Moves `@graphql-codegen/cli` from `dependencies` to `devDependencies` in `@launchdarkly/observability-node`, so the GraphQL codegen tool is no longer installed for downstream consumers and only used during development/build.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73968c04fe2546b9693c61c637fe9ca922bfe991. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->