### PR TITLE
feat: add ReportingObserver and longtask listeners

### DIFF
--- a/sdk/highlight-run/src/client/listeners/longtask-listener.ts
+++ b/sdk/highlight-run/src/client/listeners/longtask-listener.ts
@@ -1,0 +1,77 @@
+export interface LongtaskEntry {
+	/** Duration of the long task in ms. */
+	duration: number
+	/** Entry name — usually `self` for same-origin tasks. */
+	name: string
+	/** `iframe`, `embed`, `object`, or empty when originating from the host page. */
+	containerType?: string
+	/** `src`/`id`/`name` of the container, when one is present. */
+	containerSrc?: string
+	containerId?: string
+	containerName?: string
+	/** startTime relative to navigationStart in ms. */
+	startTime: number
+}
+
+const isLongtaskSupported = (): boolean => {
+	if (typeof window === 'undefined') return false
+	if (typeof PerformanceObserver === 'undefined') return false
+	const supported = (
+		PerformanceObserver as unknown as { supportedEntryTypes?: string[] }
+	).supportedEntryTypes
+	return Array.isArray(supported) && supported.includes('longtask')
+}
+
+/**
+ * Subscribes to the browser PerformanceObserver for `longtask` entries
+ * (main-thread blocks > 50ms) and invokes the callback for each entry.
+ *
+ * Returns a disconnect function. No-ops on environments that do not
+ * support the longtask entry type.
+ */
+export const LongtaskListener = (
+	callback: (entry: LongtaskEntry) => void,
+): (() => void) => {
+	if (!isLongtaskSupported()) return () => {}
+
+	let observer: PerformanceObserver
+	try {
+		observer = new PerformanceObserver((list) => {
+			for (const entry of list.getEntries()) {
+				// PerformanceLongTaskTiming exposes attribution[] but we
+				// surface the first attribution's container context which is
+				// the common useful dimension.
+				const attribution = (
+					entry as PerformanceEntry & {
+						attribution?: ReadonlyArray<{
+							containerType?: string
+							containerSrc?: string
+							containerId?: string
+							containerName?: string
+						}>
+					}
+				).attribution?.[0]
+				callback({
+					duration: entry.duration,
+					name: entry.name,
+					startTime: entry.startTime,
+					containerType: attribution?.containerType,
+					containerSrc: attribution?.containerSrc,
+					containerId: attribution?.containerId,
+					containerName: attribution?.containerName,
+				})
+			}
+		})
+		observer.observe({ entryTypes: ['longtask'], buffered: true })
+	} catch {
+		return () => {}
+	}
+
+	return () => {
+		try {
+			observer.disconnect()
+		} catch {
+			// ignore
+		}
+	}
+}

--- a/sdk/highlight-run/src/client/listeners/longtask-listener.ts
+++ b/sdk/highlight-run/src/client/listeners/longtask-listener.ts
@@ -62,7 +62,7 @@ export const LongtaskListener = (
 				})
 			}
 		})
-		observer.observe({ entryTypes: ['longtask'], buffered: true })
+		observer.observe({ type: 'longtask', buffered: true })
 	} catch {
 		return () => {}
 	}

--- a/sdk/highlight-run/src/client/listeners/reporting-observer-listener.ts
+++ b/sdk/highlight-run/src/client/listeners/reporting-observer-listener.ts
@@ -1,0 +1,145 @@
+import type { ConsoleMethods } from '../types/client'
+
+export type ReportingObserverReportKind = 'error' | 'log'
+
+export interface ReportingObserverReport {
+	kind: ReportingObserverReportKind
+	/** Log level when kind === 'log'. */
+	level?: ConsoleMethods
+	/** `deprecation`, `intervention`, `csp-violation`, ... */
+	type: string
+	/** Human-readable message for error/log routing. */
+	message: string
+	/** URL the report originated from. */
+	url?: string
+	/** Flattened `report.body` fields (prefixed with `report.body.`). */
+	attributes: Record<string, string | number | boolean | undefined>
+}
+
+const BODY_PRIMITIVE = new Set(['string', 'number', 'boolean'])
+
+const isReportingObserverSupported = (): boolean =>
+	typeof window !== 'undefined' &&
+	typeof (window as unknown as { ReportingObserver?: unknown })
+		.ReportingObserver !== 'undefined'
+
+const flattenBody = (
+	body: unknown,
+): Record<string, string | number | boolean> => {
+	const attrs: Record<string, string | number | boolean> = {}
+	if (!body || typeof body !== 'object') return attrs
+	for (const [key, value] of Object.entries(
+		body as Record<string, unknown>,
+	)) {
+		if (value === null || value === undefined) continue
+		if (BODY_PRIMITIVE.has(typeof value)) {
+			attrs[`report.body.${key}`] = value as string | number | boolean
+		} else {
+			try {
+				attrs[`report.body.${key}`] = JSON.stringify(value)
+			} catch {
+				// ignore un-serializable fields
+			}
+		}
+	}
+	return attrs
+}
+
+const messageFromReport = (report: {
+	type: string
+	body?: Record<string, unknown> | null
+}): string => {
+	const body = report.body ?? {}
+	const message =
+		(body['message'] as string | undefined) ||
+		(body['reason'] as string | undefined) ||
+		(body['id'] as string | undefined) ||
+		report.type
+	return typeof message === 'string' ? message : report.type
+}
+
+export interface ReportingObserverListenerOptions {
+	/**
+	 * Which report types to observe. Defaults to all three browser types
+	 * that contribute actionable diagnostics.
+	 */
+	types?: string[]
+}
+
+/**
+ * Subscribes to the browser's Reporting API and fans reports out to the
+ * provided callback. CSP and intervention reports are emitted as errors;
+ * deprecation reports are emitted as warn-level logs.
+ *
+ * Returns a disconnect function. If `ReportingObserver` is unavailable in
+ * the current environment, returns a no-op.
+ */
+export const ReportingObserverListener = (
+	callback: (report: ReportingObserverReport) => void,
+	options?: ReportingObserverListenerOptions,
+): (() => void) => {
+	if (!isReportingObserverSupported()) return () => {}
+
+	const types = options?.types ?? [
+		'deprecation',
+		'intervention',
+		'csp-violation',
+	]
+
+	const ReportingObserverCtor = (
+		window as unknown as {
+			ReportingObserver: new (
+				cb: (reports: ReadonlyArray<any>) => void,
+				opts: { buffered?: boolean; types?: string[] },
+			) => { observe(): void; disconnect(): void }
+		}
+	).ReportingObserver
+
+	const observer = new ReportingObserverCtor(
+		(reports) => {
+			for (const report of reports) {
+				const type = report.type ?? 'unknown'
+				const body = (report.body ?? {}) as Record<string, unknown>
+				const attributes = {
+					'report.type': type,
+					'report.url': report.url,
+					...flattenBody(body),
+				}
+				const message = messageFromReport({ type, body })
+				if (type === 'deprecation') {
+					callback({
+						kind: 'log',
+						level: 'warn',
+						type,
+						message,
+						url: report.url,
+						attributes,
+					})
+				} else {
+					callback({
+						kind: 'error',
+						type,
+						message,
+						url: report.url,
+						attributes,
+					})
+				}
+			}
+		},
+		{ buffered: true, types },
+	)
+
+	try {
+		observer.observe()
+	} catch {
+		return () => {}
+	}
+
+	return () => {
+		try {
+			observer.disconnect()
+		} catch {
+			// ignore
+		}
+	}
+}

--- a/sdk/highlight-run/src/client/listeners/reporting-observer-listener.ts
+++ b/sdk/highlight-run/src/client/listeners/reporting-observer-listener.ts
@@ -95,41 +95,41 @@ export const ReportingObserverListener = (
 		}
 	).ReportingObserver
 
-	const observer = new ReportingObserverCtor(
-		(reports) => {
-			for (const report of reports) {
-				const type = report.type ?? 'unknown'
-				const body = (report.body ?? {}) as Record<string, unknown>
-				const attributes = {
-					'report.type': type,
-					'report.url': report.url,
-					...flattenBody(body),
-				}
-				const message = messageFromReport({ type, body })
-				if (type === 'deprecation') {
-					callback({
-						kind: 'log',
-						level: 'warn',
-						type,
-						message,
-						url: report.url,
-						attributes,
-					})
-				} else {
-					callback({
-						kind: 'error',
-						type,
-						message,
-						url: report.url,
-						attributes,
-					})
-				}
-			}
-		},
-		{ buffered: true, types },
-	)
-
+	let observer: { observe(): void; disconnect(): void }
 	try {
+		observer = new ReportingObserverCtor(
+			(reports) => {
+				for (const report of reports) {
+					const type = report.type ?? 'unknown'
+					const body = (report.body ?? {}) as Record<string, unknown>
+					const attributes = {
+						'report.type': type,
+						'report.url': report.url,
+						...flattenBody(body),
+					}
+					const message = messageFromReport({ type, body })
+					if (type === 'deprecation') {
+						callback({
+							kind: 'log',
+							level: 'warn',
+							type,
+							message,
+							url: report.url,
+							attributes,
+						})
+					} else {
+						callback({
+							kind: 'error',
+							type,
+							message,
+							url: report.url,
+							attributes,
+						})
+					}
+				}
+			},
+			{ buffered: true, types },
+		)
 		observer.observe()
 	} catch {
 		return () => {}

--- a/sdk/highlight-run/src/client/types/observe.ts
+++ b/sdk/highlight-run/src/client/types/observe.ts
@@ -41,6 +41,18 @@ export type ObserveOptions = CommonOptions & {
 	 */
 	enablePerformanceRecording?: boolean
 	/**
+	 * Specifies whether to record main-thread `longtask` entries (>50ms) as
+	 * `long_task.duration` histogram samples.
+	 * @default true
+	 */
+	enableLongtaskRecording?: boolean
+	/**
+	 * Specifies whether to subscribe to the browser Reporting API and emit
+	 * CSP/intervention reports as errors and deprecation reports as warn logs.
+	 * @default true
+	 */
+	enableReportingObserver?: boolean
+	/**
 	 * Specifies the environment your application is running in.
 	 * This is useful to distinguish whether your session was recorded on localhost or in production.
 	 * @default 'production'

--- a/sdk/highlight-run/src/sdk/observe.ts
+++ b/sdk/highlight-run/src/sdk/observe.ts
@@ -75,6 +75,8 @@ import {
 	NetworkPerformanceListener,
 	NetworkPerformancePayload,
 } from '../client/listeners/network-listener/performance-listener'
+import { LongtaskListener } from '../client/listeners/longtask-listener'
+import { ReportingObserverListener } from '../client/listeners/reporting-observer-listener'
 import randomUuidV4 from '../client/utils/randomUuidV4'
 import { recordException } from '../client/otel/recordException'
 import { ObserveOptions, ProductAnalyticsEvents } from '../client/types/observe'
@@ -680,6 +682,63 @@ export class ObserveSDK implements Observe {
 					category: MetricCategory.Device,
 					group: window.location.href,
 				},
+			})
+		}
+		if (this._options.enableLongtaskRecording !== false) {
+			LongtaskListener((entry) => {
+				const attributes: Attributes = {
+					category: MetricCategory.Performance,
+					name: entry.name,
+					[SemanticAttributes.ATTR_URL_PATH]:
+						window.location.pathname,
+				}
+				if (entry.containerType) {
+					attributes['container_type'] = entry.containerType
+				}
+				if (entry.containerSrc) {
+					attributes['container_src'] = entry.containerSrc
+				}
+				if (entry.containerId) {
+					attributes['container_id'] = entry.containerId
+				}
+				if (entry.containerName) {
+					attributes['container_name'] = entry.containerName
+				}
+				this.recordHistogram({
+					name: 'long_task.duration',
+					value: entry.duration,
+					attributes,
+				})
+			})
+		}
+		if (this._options.enableReportingObserver !== false) {
+			ReportingObserverListener((report) => {
+				const attributes: Attributes = {
+					...report.attributes,
+					[SemanticAttributes.ATTR_URL_PATH]:
+						window.location.pathname,
+				}
+				if (report.kind === 'log') {
+					this._recordLog(
+						report.message,
+						report.level ?? 'warn',
+						attributes,
+					)
+				} else {
+					const err = new Error(report.message)
+					this.recordError(
+						err,
+						report.message,
+						Object.fromEntries(
+							Object.entries(attributes).map(([k, v]) => [
+								k,
+								v === undefined ? '' : String(v),
+							]),
+						),
+						'reporting-observer',
+						'custom',
+					)
+				}
 			})
 		}
 	}

--- a/sdk/highlight-run/src/sdk/observe.ts
+++ b/sdk/highlight-run/src/sdk/observe.ts
@@ -728,7 +728,7 @@ export class ObserveSDK implements Observe {
 					const err = new Error(report.message)
 					this.recordError(
 						err,
-						report.message,
+						undefined,
 						Object.fromEntries(
 							Object.entries(attributes).map(([k, v]) => [
 								k,


### PR DESCRIPTION
## Summary

Adds two new browser listeners to `highlight.run` / `@launchdarkly/observability`, both default-on with `ObserveOptions` opt-outs:

- **`ReportingObserverListener`** — subscribes to the browser Reporting API and emits `csp-violation` / `intervention` reports as errors and `deprecation` reports as warn logs. Gated on `enableReportingObserver`.
- **`LongtaskListener`** — taps `PerformanceObserver({ entryTypes: ['longtask'] })` for main-thread blocks >50ms and records a `long_task.duration` histogram with container attribution. Gated on `enableLongtaskRecording`.

## Test plan

- [x] `yarn turbo run build --filter 'highlight.run'` passes
- [x] `yarn turbo run test --filter 'highlight.run'` — all 401 tests pass
- [x] `yarn format-check` clean
- [ ] Browser smoke: flip `enableReportingObserver` and `enableLongtaskRecording` in a consumer app; confirm reports + `long_task.duration` samples land in the backend
- [ ] Confirm default-on behavior doesn't regress bundle size (size-limit is still 256KB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new default-on browser observers that generate additional metrics and error/log events, which could increase telemetry volume/noise or surface new error sources in production. Behavior is gated by new `ObserveOptions` flags but still changes runtime listeners and emitted data by default.
> 
> **Overview**
> Adds two new browser listeners to the `ObserveSDK` that are enabled by default with opt-out flags.
> 
> The SDK now records main-thread `longtask` entries as a `long_task.duration` histogram (including optional container attribution), and subscribes to the browser Reporting API to emit `csp-violation`/`intervention` reports as errors and `deprecation` reports as warn logs, attaching flattened report-body attributes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49dceba069683d085bc4a076542dd5f15b274aee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->