### PR TITLE
feat(react-native): Propagate LDContext to Android session replay via afterIdentify hook

### DIFF
--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/plugin/SessionReplayHookProxy.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/plugin/SessionReplayHookProxy.kt
@@ -3,11 +3,12 @@ package com.launchdarkly.observability.replay.plugin
 import com.launchdarkly.observability.sdk.SessionReplayServicing
 
 /**
- * JVM adapter for the C# / MAUI bridge.
+ * JVM adapter for cross-platform bridges (C# / MAUI, React Native, etc.).
  *
  * Accepts simple JVM types (String, Map) and delegates
  * to [SessionReplayServicing] so the replay logic is written once.
  * The C# NativeHookProxy delegates here via the Xamarin.Android binding.
+ * The React Native turbo module delegates here via LDReplay.hookProxy.
  */
 class SessionReplayHookProxy internal constructor(
     private val sessionReplayService: SessionReplayServicing

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/sdk/LDReplay.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/sdk/LDReplay.kt
@@ -13,7 +13,7 @@ object LDReplay {
     internal var client: SessionReplayServicing? = null
 
     /**
-     * Hook proxy for the C# / MAUI bridge.
+     * Hook proxy for cross-platform bridges (C# / MAUI, React Native, etc.).
      */
     val hookProxy: SessionReplayHookProxy?
         get() = client?.let { SessionReplayHookProxy(it) }

--- a/sdk/@launchdarkly/react-native-ld-session-replay/android/src/main/java/com/sessionreplayreactnative/SessionReplayClientAdapter.kt
+++ b/sdk/@launchdarkly/react-native-ld-session-replay/android/src/main/java/com/sessionreplayreactnative/SessionReplayClientAdapter.kt
@@ -27,6 +27,8 @@ internal class SessionReplayClientAdapter private constructor() {
     private var replayOptions: ReplayOptions? = null
     // Only accessed from the main thread (all reads/writes are inside Handler(mainLooper).post blocks).
     private var initialized = false
+    // The most recently identified context. Used on init if one arrived before LDClient.init() ran.
+    private var cachedContextKeys: Map<String, String>? = null
     private val logger = LDLogger.withAdapter(LDAndroidLogging.adapter(), TAG)
 
     fun setMobileKey(mobileKey: String, options: ReadableMap?) {
@@ -95,7 +97,14 @@ internal class SessionReplayClientAdapter private constructor() {
             val kind = iterator.nextKey()
             contextKeys.getString(kind)?.let { keys[kind] = it }
         }
-        LDReplay.hookProxy?.afterIdentify(keys, canonicalKey, completed)
+        Handler(Looper.getMainLooper()).post {
+            if (completed) {
+                cachedContextKeys = keys
+            }
+            if (initialized) {
+                LDReplay.hookProxy?.afterIdentify(keys, canonicalKey, completed)
+            }
+        }
     }
 
     fun stop(completion: () -> Unit) {
@@ -135,17 +144,14 @@ internal class SessionReplayClientAdapter private constructor() {
             )
             .build()
 
-        // The context key is a placeholder. The LDClient is offline and never sends it to
-        // LaunchDarkly servers, but SessionReplay does use it locally to attribute sessions.
-        //
-        // TODO: Pass the actual initial context here once the LaunchDarkly React Native SDK
-        // supports providing a context at initialization time. Currently, context is only
-        // available after an explicit client.identify() call — getContext() always returns
-        // undefined when register() runs during the LDClient constructor.
-        val placeholderContext = LDContext.builder(ContextKind.DEFAULT, "placeholder").build()
+        // Use a real context if one arrived via afterIdentify() before init; otherwise fall back
+        // to a placeholder. The LDClient is offline and never sends the context to LaunchDarkly
+        // servers, but SessionReplay uses it locally to attribute sessions.
+        val initialContext = buildContextFromKeys(cachedContextKeys)
+            ?: LDContext.builder(ContextKind.DEFAULT, "placeholder").build()
         // timeout=0: return immediately without blocking the main thread waiting for flags.
         // onPluginsReady() fires synchronously during init() before it returns.
-        LDClient.init(application, config, placeholderContext, 0)
+        LDClient.init(application, config, initialContext, 0)
     }
 
     private fun applyEnabled(enabled: Boolean) {
@@ -154,6 +160,20 @@ internal class SessionReplayClientAdapter private constructor() {
         } else {
             LDReplay.stop()
         }
+    }
+
+    // Analogous to buildObserveContext() in SessionReplayService.kt (observability-android),
+    // but builds an LDContext (for LDClient.init()) instead of an LDObserveContext.
+    internal fun buildContextFromKeys(contextKeys: Map<String, String>?): LDContext? {
+        if (contextKeys == null) return null
+        if (contextKeys.size == 1) {
+            val (kind, key) = contextKeys.entries.first()
+            return LDContext.builder(ContextKind.of(kind), key).build()
+        }
+        val contexts = contextKeys.map { (kind, key) ->
+            LDContext.builder(ContextKind.of(kind), key).build()
+        }
+        return LDContext.createMulti(*contexts.toTypedArray())
     }
 
     internal fun replayOptionsFrom(map: ReadableMap?): ReplayOptions {

--- a/sdk/@launchdarkly/react-native-ld-session-replay/android/src/main/java/com/sessionreplayreactnative/SessionReplayClientAdapter.kt
+++ b/sdk/@launchdarkly/react-native-ld-session-replay/android/src/main/java/com/sessionreplayreactnative/SessionReplayClientAdapter.kt
@@ -88,6 +88,16 @@ internal class SessionReplayClientAdapter private constructor() {
         }
     }
 
+    fun afterIdentify(contextKeys: ReadableMap, canonicalKey: String, completed: Boolean) {
+        val keys = mutableMapOf<String, String>()
+        val iterator = contextKeys.keySetIterator()
+        while (iterator.hasNextKey()) {
+            val kind = iterator.nextKey()
+            contextKeys.getString(kind)?.let { keys[kind] = it }
+        }
+        LDReplay.hookProxy?.afterIdentify(keys, canonicalKey, completed)
+    }
+
     fun stop(completion: () -> Unit) {
         logger.debug("stop")
         // Post to the main thread so that stop() queues behind any in-progress start().

--- a/sdk/@launchdarkly/react-native-ld-session-replay/android/src/main/java/com/sessionreplayreactnative/SessionReplayClientAdapter.kt
+++ b/sdk/@launchdarkly/react-native-ld-session-replay/android/src/main/java/com/sessionreplayreactnative/SessionReplayClientAdapter.kt
@@ -99,11 +99,15 @@ internal class SessionReplayClientAdapter private constructor() {
             contextKeys.getString(kind)?.let { keys[kind] = it }
         }
         Handler(Looper.getMainLooper()).post {
-            if (completed) {
-                buildContextFromKeys(keys)?.let { cachedContext = it }
-            }
-            if (initialized) {
-                LDReplay.hookProxy?.afterIdentify(keys, canonicalKey, completed)
+            try {
+                if (completed) {
+                    buildContextFromKeys(keys)?.let { cachedContext = it }
+                }
+                if (initialized) {
+                    LDReplay.hookProxy?.afterIdentify(keys, canonicalKey, completed)
+                }
+            } catch (e: Exception) {
+                logger.error("afterIdentify: threw {0}: {1}", e::class.simpleName, e.message)
             }
         }
     }
@@ -161,7 +165,7 @@ internal class SessionReplayClientAdapter private constructor() {
     // Analogous to buildObserveContext() in SessionReplayService.kt (observability-android),
     // but builds an LDContext (for LDClient.init()) instead of an LDObserveContext.
     internal fun buildContextFromKeys(contextKeys: Map<String, String>?): LDContext? {
-        if (contextKeys == null) return null
+        if (contextKeys.isNullOrEmpty()) return null
         if (contextKeys.size == 1) {
             val (kind, key) = contextKeys.entries.first()
             return LDContext.builder(ContextKind.of(kind), key).build()

--- a/sdk/@launchdarkly/react-native-ld-session-replay/android/src/main/java/com/sessionreplayreactnative/SessionReplayClientAdapter.kt
+++ b/sdk/@launchdarkly/react-native-ld-session-replay/android/src/main/java/com/sessionreplayreactnative/SessionReplayClientAdapter.kt
@@ -27,8 +27,9 @@ internal class SessionReplayClientAdapter private constructor() {
     private var replayOptions: ReplayOptions? = null
     // Only accessed from the main thread (all reads/writes are inside Handler(mainLooper).post blocks).
     private var initialized = false
-    // The most recently identified context. Used on init if one arrived before LDClient.init() ran.
-    private var cachedContextKeys: Map<String, String>? = null
+    // The most recently identified context. Defaults to anonymous; updated on each successful identify.
+    private var cachedContext: LDContext =
+        LDContext.builder(ContextKind.DEFAULT, "anonymous").anonymous(true).build()
     private val logger = LDLogger.withAdapter(LDAndroidLogging.adapter(), TAG)
 
     fun setMobileKey(mobileKey: String, options: ReadableMap?) {
@@ -99,7 +100,7 @@ internal class SessionReplayClientAdapter private constructor() {
         }
         Handler(Looper.getMainLooper()).post {
             if (completed) {
-                cachedContextKeys = keys
+                buildContextFromKeys(keys)?.let { cachedContext = it }
             }
             if (initialized) {
                 LDReplay.hookProxy?.afterIdentify(keys, canonicalKey, completed)
@@ -144,14 +145,9 @@ internal class SessionReplayClientAdapter private constructor() {
             )
             .build()
 
-        // Use a real context if one arrived via afterIdentify() before init; otherwise fall back
-        // to a placeholder. The LDClient is offline and never sends the context to LaunchDarkly
-        // servers, but SessionReplay uses it locally to attribute sessions.
-        val initialContext = buildContextFromKeys(cachedContextKeys)
-            ?: LDContext.builder(ContextKind.DEFAULT, "placeholder").build()
         // timeout=0: return immediately without blocking the main thread waiting for flags.
         // onPluginsReady() fires synchronously during init() before it returns.
-        LDClient.init(application, config, initialContext, 0)
+        LDClient.init(application, config, cachedContext, 0)
     }
 
     private fun applyEnabled(enabled: Boolean) {

--- a/sdk/@launchdarkly/react-native-ld-session-replay/android/src/main/java/com/sessionreplayreactnative/SessionReplayReactNativeModule.kt
+++ b/sdk/@launchdarkly/react-native-ld-session-replay/android/src/main/java/com/sessionreplayreactnative/SessionReplayReactNativeModule.kt
@@ -55,6 +55,20 @@ class SessionReplayReactNativeModule(reactContext: ReactApplicationContext) :
     }
   }
 
+  override fun afterIdentify(
+    contextKeys: ReadableMap,
+    canonicalKey: String,
+    completed: Boolean,
+    promise: Promise
+  ) {
+    try {
+      SessionReplayClientAdapter.shared.afterIdentify(contextKeys, canonicalKey, completed)
+      promise.resolve(null)
+    } catch (e: Exception) {
+      promise.reject("after_identify_failed", e.message, e)
+    }
+  }
+
   companion object {
     const val NAME = "SessionReplayReactNative"
   }

--- a/sdk/@launchdarkly/react-native-ld-session-replay/android/src/test/java/com/sessionreplayreactnative/SessionReplayClientAdapterTest.kt
+++ b/sdk/@launchdarkly/react-native-ld-session-replay/android/src/test/java/com/sessionreplayreactnative/SessionReplayClientAdapterTest.kt
@@ -56,6 +56,12 @@ class SessionReplayClientAdapterTest {
     }
 
     @Test
+    fun `buildContextFromKeys returns null for empty map`() {
+        val adapter = newAdapter()
+        assertNull(adapter.buildContextFromKeys(emptyMap()))
+    }
+
+    @Test
     fun `buildContextFromKeys returns single-kind context`() {
         val adapter = newAdapter()
         val context = adapter.buildContextFromKeys(mapOf("user" to "abc123"))

--- a/sdk/@launchdarkly/react-native-ld-session-replay/android/src/test/java/com/sessionreplayreactnative/SessionReplayClientAdapterTest.kt
+++ b/sdk/@launchdarkly/react-native-ld-session-replay/android/src/test/java/com/sessionreplayreactnative/SessionReplayClientAdapterTest.kt
@@ -2,10 +2,13 @@ package com.sessionreplayreactnative
 
 import android.app.Application
 import com.facebook.react.bridge.ReadableMap
+import com.launchdarkly.sdk.ContextKind
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
@@ -47,12 +50,39 @@ class SessionReplayClientAdapterTest {
     }
 
     @Test
+    fun `buildContextFromKeys returns null for null input`() {
+        val adapter = newAdapter()
+        assertNull(adapter.buildContextFromKeys(null))
+    }
+
+    @Test
+    fun `buildContextFromKeys returns single-kind context`() {
+        val adapter = newAdapter()
+        val context = adapter.buildContextFromKeys(mapOf("user" to "abc123"))
+        assertNotNull(context)
+        assertEquals("abc123", context!!.key)
+        assertEquals(ContextKind.of("user"), context.kind)
+    }
+
+    @Test
+    fun `buildContextFromKeys returns multi-kind context`() {
+        val adapter = newAdapter()
+        val context = adapter.buildContextFromKeys(mapOf("user" to "abc", "org" to "acme"))
+        assertNotNull(context)
+        assertTrue(context!!.isMultiple)
+        assertNotNull(context.getIndividualContext(ContextKind.of("user")))
+        assertEquals("abc", context.getIndividualContext(ContextKind.of("user"))!!.key)
+        assertNotNull(context.getIndividualContext(ContextKind.of("org")))
+        assertEquals("acme", context.getIndividualContext(ContextKind.of("org"))!!.key)
+    }
+
+    @Test
     fun `start before setMobileKey calls completion with failure`() {
         val adapter = newAdapter()
         var success: Boolean? = null
         var errorMessage: String? = null
 
-        adapter.start(mockk<Application>(relaxed = true)) { s, e ->
+        adapter.start(mockk<Application>(relaxed = true), null) { s, e ->
             success = s
             errorMessage = e
         }

--- a/sdk/@launchdarkly/react-native-ld-session-replay/ios/SessionReplayReactNative.mm
+++ b/sdk/@launchdarkly/react-native-ld-session-replay/ios/SessionReplayReactNative.mm
@@ -53,6 +53,15 @@
     }
 }
 
+- (void)afterIdentify:(NSDictionary *)contextKeys
+         canonicalKey:(NSString *)canonicalKey
+            completed:(BOOL)completed
+              resolve:(RCTPromiseResolveBlock)resolve
+               reject:(RCTPromiseRejectBlock)reject
+{
+    resolve(nil);
+}
+
 - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:
     (const facebook::react::ObjCTurboModule::InitParams &)params
 {

--- a/sdk/@launchdarkly/react-native-ld-session-replay/src/NativeSessionReplayReactNative.ts
+++ b/sdk/@launchdarkly/react-native-ld-session-replay/src/NativeSessionReplayReactNative.ts
@@ -17,6 +17,11 @@ export interface Spec extends TurboModule {
   configure(mobileKey: string, options?: Object): Promise<void>;
   startSessionReplay(): Promise<void>;
   stopSessionReplay(): Promise<void>;
+  afterIdentify(
+    contextKeys: Object,
+    canonicalKey: string,
+    completed: boolean
+  ): Promise<void>;
 }
 
 export default TurboModuleRegistry.getEnforcing<Spec>(

--- a/sdk/@launchdarkly/react-native-ld-session-replay/src/__tests__/index.test.tsx
+++ b/sdk/@launchdarkly/react-native-ld-session-replay/src/__tests__/index.test.tsx
@@ -94,6 +94,54 @@ describe('afterIdentify', () => {
 });
 
 describe('SessionReplayPluginAdapter', () => {
+  it('returns a hook from getHooks', () => {
+    const plugin = createSessionReplayPlugin();
+    const hooks = plugin.getHooks!({
+      sdk: { name: 'test', version: '0.0.0' },
+      mobileKey: 'mob-key-123',
+    });
+    expect(hooks).toHaveLength(1);
+    expect(hooks[0]!.getMetadata().name).toBe('session-replay-react-native');
+  });
+
+  it('hook afterIdentify calls native afterIdentify with context', async () => {
+    const plugin = createSessionReplayPlugin();
+    const [hook] = plugin.getHooks!({
+      sdk: { name: 'test', version: '0.0.0' },
+      mobileKey: 'mob-key-123',
+    });
+    hook!.afterIdentify!(
+      { context: { kind: 'user', key: 'abc' } },
+      {},
+      { status: 'completed' }
+    );
+    await new Promise(process.nextTick);
+    expect(NativeSessionReplayReactNative.afterIdentify).toHaveBeenCalledWith(
+      { user: 'abc' },
+      'abc',
+      true
+    );
+  });
+
+  it('hook afterIdentify passes completed=false for shed status', async () => {
+    const plugin = createSessionReplayPlugin();
+    const [hook] = plugin.getHooks!({
+      sdk: { name: 'test', version: '0.0.0' },
+      mobileKey: 'mob-key-123',
+    });
+    hook!.afterIdentify!(
+      { context: { kind: 'user', key: 'abc' } },
+      {},
+      { status: 'shed' }
+    );
+    await new Promise(process.nextTick);
+    expect(NativeSessionReplayReactNative.afterIdentify).toHaveBeenCalledWith(
+      { user: 'abc' },
+      'abc',
+      false
+    );
+  });
+
   it('calls configure and startSessionReplay on register', async () => {
     const plugin = createSessionReplayPlugin();
     plugin.register(

--- a/sdk/@launchdarkly/react-native-ld-session-replay/src/__tests__/index.test.tsx
+++ b/sdk/@launchdarkly/react-native-ld-session-replay/src/__tests__/index.test.tsx
@@ -74,6 +74,20 @@ describe('afterIdentify', () => {
     );
   });
 
+  it('sorts by kind name, not by kind:key string', async () => {
+    // "org-team" sorts before "org" when sorting full "kind:key" strings because
+    // '-' (45) < ':' (58). Sorting by kind name only keeps "org" first.
+    await afterIdentify(
+      { 'kind': 'multi', 'org-team': { key: 'eng' }, 'org': { key: 'acme' } },
+      true
+    );
+    expect(NativeSessionReplayReactNative.afterIdentify).toHaveBeenCalledWith(
+      { 'org-team': 'eng', 'org': 'acme' },
+      'org:acme:org-team:eng',
+      true
+    );
+  });
+
   it('handles legacy LDUser with implicit user kind', async () => {
     await afterIdentify({ key: 'legacy-user' }, true);
     expect(NativeSessionReplayReactNative.afterIdentify).toHaveBeenCalledWith(

--- a/sdk/@launchdarkly/react-native-ld-session-replay/src/__tests__/index.test.tsx
+++ b/sdk/@launchdarkly/react-native-ld-session-replay/src/__tests__/index.test.tsx
@@ -1,10 +1,15 @@
 import NativeSessionReplayReactNative from '../NativeSessionReplayReactNative';
-import { configureSessionReplay, createSessionReplayPlugin } from '../index';
+import {
+  afterIdentify,
+  configureSessionReplay,
+  createSessionReplayPlugin,
+} from '../index';
 
 jest.mock('../NativeSessionReplayReactNative', () => ({
   configure: jest.fn().mockResolvedValue(undefined),
   startSessionReplay: jest.fn().mockResolvedValue(undefined),
   stopSessionReplay: jest.fn().mockResolvedValue(undefined),
+  afterIdentify: jest.fn().mockResolvedValue(undefined),
 }));
 
 describe('configureSessionReplay', () => {
@@ -14,6 +19,77 @@ describe('configureSessionReplay', () => {
 
   it('rejects if key is whitespace', async () => {
     await expect(configureSessionReplay('   ')).rejects.toThrow();
+  });
+});
+
+describe('afterIdentify', () => {
+  it('passes kind and key for a single-kind context', async () => {
+    await afterIdentify({ kind: 'user', key: 'abc' }, true);
+    expect(NativeSessionReplayReactNative.afterIdentify).toHaveBeenCalledWith(
+      { user: 'abc' },
+      'abc',
+      true
+    );
+  });
+
+  it('uses kind:key canonical key for non-user single-kind context', async () => {
+    await afterIdentify({ kind: 'org', key: 'acme' }, true);
+    expect(NativeSessionReplayReactNative.afterIdentify).toHaveBeenCalledWith(
+      { org: 'acme' },
+      'org:acme',
+      true
+    );
+  });
+
+  it('escapes colons and percent signs in keys', async () => {
+    await afterIdentify({ kind: 'org', key: 'a:b%c' }, true);
+    expect(NativeSessionReplayReactNative.afterIdentify).toHaveBeenCalledWith(
+      { org: 'a:b%c' },
+      'org:a%3Ab%25c',
+      true
+    );
+  });
+
+  it('passes all sub-context kind/key pairs for a multi-kind context', async () => {
+    await afterIdentify(
+      { kind: 'multi', org: { key: 'acme' }, user: { key: 'abc' } },
+      true
+    );
+    expect(NativeSessionReplayReactNative.afterIdentify).toHaveBeenCalledWith(
+      { org: 'acme', user: 'abc' },
+      'org:acme:user:abc',
+      true
+    );
+  });
+
+  it('sorts sub-contexts by kind for the canonical key', async () => {
+    await afterIdentify(
+      { kind: 'multi', user: { key: 'abc' }, org: { key: 'acme' } },
+      true
+    );
+    expect(NativeSessionReplayReactNative.afterIdentify).toHaveBeenCalledWith(
+      { user: 'abc', org: 'acme' },
+      'org:acme:user:abc',
+      true
+    );
+  });
+
+  it('handles legacy LDUser with implicit user kind', async () => {
+    await afterIdentify({ key: 'legacy-user' }, true);
+    expect(NativeSessionReplayReactNative.afterIdentify).toHaveBeenCalledWith(
+      { user: 'legacy-user' },
+      'legacy-user',
+      true
+    );
+  });
+
+  it('passes completed=false through', async () => {
+    await afterIdentify({ kind: 'user', key: 'abc' }, false);
+    expect(NativeSessionReplayReactNative.afterIdentify).toHaveBeenCalledWith(
+      { user: 'abc' },
+      'abc',
+      false
+    );
   });
 });
 

--- a/sdk/@launchdarkly/react-native-ld-session-replay/src/index.tsx
+++ b/sdk/@launchdarkly/react-native-ld-session-replay/src/index.tsx
@@ -5,12 +5,74 @@ import type {
   LDClientMin,
 } from '@launchdarkly/observability-react-native';
 import type {
+  LDContext,
   LDPluginEnvironmentMetadata,
   LDPluginMetadata,
 } from '@launchdarkly/js-sdk-common';
 
 const MOBILE_KEY_REQUIRED_MESSAGE =
   'Session replay requires a non-empty mobile key. Provide metadata.sdkKey or metadata.mobileKey when initializing the LaunchDarkly client.';
+
+// Mirrors escapeKey() in LDObserveContext.kt (observability-android)
+function escapeContextKey(key: string): string {
+  return key.replace(/%/g, '%25').replace(/:/g, '%3A');
+}
+
+// Mirrors SessionReplayHook.afterIdentify() in SessionReplayHook.kt (observability-android)
+function contextKeysFromContext(context: LDContext): Record<string, string> {
+  const keys: Record<string, string> = {};
+  if (!('kind' in context)) {
+    // Legacy LDUser — no 'kind' field, implicitly 'user'
+    keys['user'] = context.key;
+    return keys;
+  }
+  if (context.kind === 'multi') {
+    for (const [kindName, value] of Object.entries(context)) {
+      if (kindName !== 'kind' && typeof value === 'object' && value !== null) {
+        keys[kindName] = (value as { key: string }).key;
+      }
+    }
+    return keys;
+  }
+  keys[context.kind] = context.key;
+  return keys;
+}
+
+// Mirrors LDObserveContext.fullyQualifiedKey in LDObserveContext.kt (observability-android)
+function canonicalKeyFromContext(context: LDContext): string {
+  if (!('kind' in context)) {
+    // Legacy LDUser
+    return context.key;
+  }
+  if (context.kind === 'multi') {
+    const parts: string[] = [];
+    for (const [kindName, value] of Object.entries(context)) {
+      if (kindName !== 'kind' && typeof value === 'object' && value !== null) {
+        parts.push(
+          `${kindName}:${escapeContextKey((value as { key: string }).key)}`
+        );
+      }
+    }
+    return parts.sort().join(':');
+  }
+  if (context.kind === 'user') {
+    return context.key;
+  }
+  return `${context.kind}:${escapeContextKey(context.key)}`;
+}
+
+export function afterIdentify(
+  context: LDContext,
+  completed: boolean
+): Promise<void> {
+  const contextKeys = contextKeysFromContext(context);
+  const canonicalKey = canonicalKeyFromContext(context);
+  return SessionReplayReactNative.afterIdentify(
+    contextKeys,
+    canonicalKey,
+    completed
+  );
+}
 
 export function configureSessionReplay(
   mobileKey: string,

--- a/sdk/@launchdarkly/react-native-ld-session-replay/src/index.tsx
+++ b/sdk/@launchdarkly/react-native-ld-session-replay/src/index.tsx
@@ -52,15 +52,15 @@ function canonicalKeyFromContext(context: LDContext): string {
     return context.key;
   }
   if (context.kind === 'multi') {
-    const parts: string[] = [];
+    const entries: Array<[string, string]> = [];
     for (const [kindName, value] of Object.entries(context)) {
       if (kindName !== 'kind' && typeof value === 'object' && value !== null) {
-        parts.push(
-          `${kindName}:${escapeContextKey((value as { key: string }).key)}`
-        );
+        entries.push([kindName, (value as { key: string }).key]);
       }
     }
-    return parts.sort().join(':');
+    // Sort by kind name only, matching LDObserveContext.fullyQualifiedKey in (observability-android)
+    entries.sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+    return entries.map(([k, v]) => `${k}:${escapeContextKey(v)}`).join(':');
   }
   if (context.kind === 'user') {
     return context.key;

--- a/sdk/@launchdarkly/react-native-ld-session-replay/src/index.tsx
+++ b/sdk/@launchdarkly/react-native-ld-session-replay/src/index.tsx
@@ -9,6 +9,13 @@ import type {
   LDPluginEnvironmentMetadata,
   LDPluginMetadata,
 } from '@launchdarkly/js-sdk-common';
+import type {
+  Hook,
+  HookMetadata,
+  IdentifySeriesContext,
+  IdentifySeriesData,
+  IdentifySeriesResult,
+} from '@launchdarkly/react-native-client-sdk';
 
 const MOBILE_KEY_REQUIRED_MESSAGE =
   'Session replay requires a non-empty mobile key. Provide metadata.sdkKey or metadata.mobileKey when initializing the LaunchDarkly client.';
@@ -93,6 +100,28 @@ export function stopSessionReplay(): Promise<void> {
   return SessionReplayReactNative.stopSessionReplay();
 }
 
+class SessionReplayHook implements Hook {
+  getMetadata(): HookMetadata {
+    return { name: 'session-replay-react-native' };
+  }
+
+  afterIdentify(
+    hookContext: IdentifySeriesContext,
+    data: IdentifySeriesData,
+    result: IdentifySeriesResult
+  ): IdentifySeriesData {
+    afterIdentify(hookContext.context, result.status === 'completed').catch(
+      (error) => {
+        console.error(
+          '[SessionReplay] Failed to forward identify context:',
+          error
+        );
+      }
+    );
+    return data;
+  }
+}
+
 class SessionReplayPluginAdapter implements LDPlugin {
   private options: SessionReplayOptions;
 
@@ -104,6 +133,10 @@ class SessionReplayPluginAdapter implements LDPlugin {
     return {
       name: 'session-replay-react-native',
     };
+  }
+
+  getHooks(_metadata: LDPluginEnvironmentMetadata): Hook[] {
+    return [new SessionReplayHook()];
   }
 
   register(_client: LDClientMin, metadata: LDPluginEnvironmentMetadata): void {

--- a/sdk/@launchdarkly/react-native-ld-session-replay/src/index.tsx
+++ b/sdk/@launchdarkly/react-native-ld-session-replay/src/index.tsx
@@ -41,7 +41,7 @@ function contextKeysFromContext(context: LDContext): Record<string, string> {
     }
     return keys;
   }
-  keys[context.kind] = context.key;
+  keys[context.kind] = context.key as string;
   return keys;
 }
 
@@ -65,7 +65,7 @@ function canonicalKeyFromContext(context: LDContext): string {
   if (context.kind === 'user') {
     return context.key;
   }
-  return `${context.kind}:${escapeContextKey(context.key)}`;
+  return `${context.kind}:${escapeContextKey(context.key as string)}`;
 }
 
 export function afterIdentify(


### PR DESCRIPTION
## Summary

Wires `LDContext` changes from the React Native LaunchDarkly SDK through to the Android Session Replay instance so that session replay sessions are correctly attributed to the identified user/context. Re-uses the existing hook for MAUI.

Also changes the default context to be an anonymous context, rather than "placeholder", per advice from the JS SDK team.

## Test plan

- [X] New unit tests in JS and Android.
- [X] Manual: run the React Native example app and verify sessions are attributed correctly in the session replay backend.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new cross-platform `afterIdentify` bridge and changes Android initialization context handling, which can affect session attribution and replay data if the context/canonical key logic is wrong. Scope is limited to session replay integrations and includes new unit tests to reduce regression risk.
> 
> **Overview**
> Propagates React Native `identify()` context changes into native Session Replay so replay sessions are attributed to the correct user/context.
> 
> On React Native, adds an `afterIdentify` TurboModule API plus a plugin `Hook.afterIdentify` that converts `LDContext` (single/multi/legacy) into `{kind: key}` maps and a canonical key (with escaping and deterministic ordering) before calling native.
> 
> On Android, the RN adapter now accepts `afterIdentify`, caches the latest completed `LDContext`, forwards it to `LDReplay.hookProxy?.afterIdentify(...)`, and uses the cached (anonymous-by-default) context during `LDClient.init` instead of a placeholder; includes Android + JS unit tests. iOS stubs the new method for parity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e58d17513ef6e7fbd6e34e48c0844d82ea02a9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->