### PR TITLE
fix: avoid ReDoS in error-stack-parser by not re-parsing console stacks

### DIFF
--- a/sdk/highlight-run/src/sdk/observe.ts
+++ b/sdk/highlight-run/src/sdk/observe.ts
@@ -241,7 +241,7 @@ export class ObserveSDK implements Observe {
 			const msg =
 				typeof message === 'string' ? message : stringify(message)
 			const stackTrace = trace
-				? stringify(trace.map((s) => s.toString()))
+				? trace.map((s) => s.toString()).join('\n')
 				: undefined
 			span?.addEvent('log', {
 				[ATTR_LOG_SEVERITY]: level,
@@ -250,16 +250,33 @@ export class ObserveSDK implements Observe {
 				...metadata,
 			})
 			if (this._options.reportConsoleErrors && level === 'error') {
-				span?.recordException(new Error(msg))
+				const err = new Error(msg)
+				span?.recordException(err)
 				span?.setStatus({
 					code: SpanStatusCode.ERROR,
 					message: msg,
 				})
-				const err = new Error(msg)
 				if (trace) {
-					err.stack = stackTrace
+					// Pass the pre-parsed trace through directly. The prior
+					// code stuffed a JSON-stringified array into err.stack and
+					// let recordError → parseError re-parse it, which triggers
+					// catastrophic backtracking in error-stack-parser's
+					// parseFFOrSafari regex.
+					this._recordErrorMessage({
+						error: err,
+						event: err.message,
+						type: 'custom',
+						url: window.location.href,
+						source: 'frontend',
+						lineNumber: trace[0]?.lineNumber ?? 0,
+						columnNumber: trace[0]?.columnNumber ?? 0,
+						stackTrace: trace,
+						timestamp: new Date().toISOString(),
+						id: randomUuidV4(),
+					})
+				} else {
+					this.recordError(err)
 				}
-				this.recordError(err)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Console logs were spending enormous amounts of CPU time in `error-stack-parser`. In a captured Chrome trace over 133 s of wall time, a single regex in `parseFFOrSafari` — `((.*".+"[^@]*)?[^@]*)(?:@)` — burned **42.9 s** of self-time (~32% of the trace).

### Root cause

`ObserveSDK._recordLog` builds a synthetic `Error` and sets `err.stack` to a JSON-stringified array of the pre-parsed `StackFrame[]`:

```ts
const stackTrace = trace
    ? stringify(trace.map((s) => s.toString()))
    : undefined
...
const err = new Error(msg)
if (trace) err.stack = stackTrace
this.recordError(err)   // → parseError(err) → ErrorStackParser.parse
```

That stack looks like `["fn (file:1:2)","fn2 (file:3:4)",…]` — long, `"`-heavy, and contains no `at ` anchor. `ErrorStackParser.parse` therefore falls out of `parseV8OrIE` into `parseFFOrSafari`, and the `functionNameRegex` catastrophic-backtracks on it. The library's regex is identical in v2.0.6 (pinned) and v3.0.0; upgrading does not help.

### Fix

- Pass the already-parsed `StackFrame[]` directly to `_recordErrorMessage` and skip the `new Error() + err.stack = JSON → parseError` round trip entirely.
- While here, emit `code.stacktrace` as a newline-joined stack string (what OTel semantic conventions expect) instead of a JSON-encoded array.

### Empirical verification

A Node microbench (`/tmp/redos-bench/bench.js`) exercises the pre-fix inner path (`jsonStringify(trace.map(f => f.toString()))` → `err.stack` → `ErrorStackParser.parse`) vs. the post-fix pass-through, loading the exact pinned `error-stack-parser@2.0.6` from the worktree's `node_modules`. 5 iters per size, median ms:

| frames | before (ms) | after (ms) | speedup |
|---|---|---|---|
| 5  | 477 | 0.002 | 243,000× |
| 10 | 16,863 | 0.001 | 13,700,000× |
| 15 | 126,939 | 0.001 | 86,500,000× |

Super-linear growth in `before` (~35× from 5→10 frames, ~7.5× from 10→15) is the signature of catastrophic backtracking. Size 20 wasn't attempted — size 15 already blew a 60 s per-call cap.

**Correctness bonus**: the pre-fix path returned a **length-1** `StackFrame[]` regardless of input size — the mangled JSON stack is unparseable and ESP only recognizes one frame. So the old code was producing garbage stack traces *in addition to* burning CPU. The new path preserves the true frame count.

## Test plan

- [x] `yarn typegen:check` clean
- [x] `yarn test` — 401/401 pass
- [x] Microbench confirms the regex hot spot is gone and stack output is no longer truncated to 1 frame
- [ ] Verify on a reproducer page that the `parseFFOrSafari` hot frame is gone from a fresh Chrome profile
- [ ] Confirm `code.stacktrace` attribute on log spans renders as a readable stack in the backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)