### PR TITLE
fix(react-native): propagate afterIdentify propagation in iOS session replay

### DIFF
--- a/sdk/@launchdarkly/react-native-ld-session-replay/example/ios/Podfile.lock
+++ b/sdk/@launchdarkly/react-native-ld-session-replay/example/ios/Podfile.lock
@@ -2512,7 +2512,7 @@ PODS:
     - React-perflogger (= 0.83.0)
     - React-utils (= 0.83.0)
     - SocketRocket
-  - SessionReplayReactNative (0.3.0):
+  - SessionReplayReactNative (0.5.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2882,11 +2882,11 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: ebcf3a78dc1bcdf054c9e8d309244bade6b31568
   ReactCodegen: 11c08ff43a62009d48c71de000352e4515918801
   ReactCommon: 424cc34cf5055d69a3dcf02f3436481afb8b0f6f
-  SessionReplayReactNative: 899a1416f5e99dd765070c83ef78f17dbbdf07e0
+  SessionReplayReactNative: 60664a81e02ef6a64da725c84fe6e709c6f0cd5d
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   SwiftProtobuf: 9e106a71456f4d3f6a3b0c8fd87ef0be085efc38
   Yoga: 6ca93c8c13f56baeec55eb608577619b17a4d64e
 
 PODFILE CHECKSUM: 53fee6f649d87604b0c5ad827154b6c454d1a29a
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.2

--- a/sdk/@launchdarkly/react-native-ld-session-replay/ios/SessionReplayClientAdapter.swift
+++ b/sdk/@launchdarkly/react-native-ld-session-replay/ios/SessionReplayClientAdapter.swift
@@ -122,7 +122,11 @@ public class SessionReplayClientAdapter: NSObject {
         keys[kind] = key
       }
     }
-    Task { @MainActor [weak self] in
+    lock.lock()
+    defer { lock.unlock() }
+    let prev = lastTask
+    lastTask = Task { @MainActor [weak self] in
+      await prev.value
       guard let self else { return }
       if completed {
         self.cachedContext = self.buildContextFromKeys(keys)

--- a/sdk/@launchdarkly/react-native-ld-session-replay/ios/SessionReplayClientAdapter.swift
+++ b/sdk/@launchdarkly/react-native-ld-session-replay/ios/SessionReplayClientAdapter.swift
@@ -15,6 +15,9 @@ public class SessionReplayClientAdapter: NSObject {
   private var lastTask: Task<Void, Never> = Task {}
 
   @MainActor private var initialized = false
+  // The most recently identified LDContext. Defaults to nil (LDClient will use its own anonymous
+  // context). Updated on each successful identify via afterIdentify.
+  @MainActor private var cachedContext: LDContext? = nil
 
   private override init() {
     super.init()
@@ -52,17 +55,33 @@ public class SessionReplayClientAdapter: NSObject {
     return config
   }
 
-  private func makeContext() -> LDContext? {
-    var contextBuilder = LDContextBuilder(
-      key: "12345"
-    )
-    contextBuilder.kind("user")
-    do {
-      return try contextBuilder.build().get()
-    } catch {
-      NSLog("[SessionReplayAdapter] Failed to build LDContext: %@", error.localizedDescription)
+  // Builds an LDContext from a [kind: key] map. Returns nil if the map is empty or a context
+  // cannot be built. Mirrors buildContextFromKeys() in SessionReplayClientAdapter.kt.
+  private func buildContextFromKeys(_ keys: [String: String]) -> LDContext? {
+    guard !keys.isEmpty else { return nil }
+    if keys.count == 1 {
+      let (kind, key) = keys.first!
+      var builder = LDContextBuilder(key: key)
+      builder.kind(kind)
+      guard case .success(let context) = builder.build() else {
+        NSLog("[SessionReplayAdapter] Failed to build LDContext for kind=%@", kind)
+        return nil
+      }
+      return context
+    }
+    var multiBuilder = LDMultiContextBuilder()
+    for (kind, key) in keys {
+      var builder = LDContextBuilder(key: key)
+      builder.kind(kind)
+      if case .success(let context) = builder.build() {
+        multiBuilder.addContext(context)
+      }
+    }
+    guard case .success(let context) = multiBuilder.build() else {
+      NSLog("[SessionReplayAdapter] Failed to build multi-context")
       return nil
     }
+    return context
   }
 
   @objc public func start(completion: @escaping (Bool, String?) -> Void) {
@@ -78,7 +97,7 @@ public class SessionReplayClientAdapter: NSObject {
       guard let self else { return }
       if !self.initialized {
         let config = self.makeConfig(mobileKey: mobileKey, options: sessionReplayOptions)
-        let context = self.makeContext()
+        let context = self.cachedContext
         await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
           LDClient.start(config: config, context: context, startWaitSeconds: 0) { _ in
             cont.resume()
@@ -93,6 +112,28 @@ public class SessionReplayClientAdapter: NSObject {
       }
       LDReplay.shared.isEnabled = sessionReplayOptions.isEnabled
       completion(true, nil)
+    }
+  }
+
+  @objc public func afterIdentify(contextKeys: NSDictionary, canonicalKey: String, completed: Bool) {
+    var keys = [String: String]()
+    for (k, v) in contextKeys {
+      if let kind = k as? String, let key = v as? String {
+        keys[kind] = key
+      }
+    }
+    Task { @MainActor [weak self] in
+      guard let self else { return }
+      if completed {
+        self.cachedContext = self.buildContextFromKeys(keys)
+      }
+      if self.initialized {
+        LDReplay.shared.hookProxy?.afterIdentify(
+          contextKeys: contextKeys,
+          canonicalKey: canonicalKey,
+          completed: completed
+        )
+      }
     }
   }
 

--- a/sdk/@launchdarkly/react-native-ld-session-replay/ios/SessionReplayClientAdapter.swift
+++ b/sdk/@launchdarkly/react-native-ld-session-replay/ios/SessionReplayClientAdapter.swift
@@ -58,9 +58,9 @@ public class SessionReplayClientAdapter: NSObject {
   // Builds an LDContext from a [kind: key] map. Returns nil if the map is empty or a context
   // cannot be built. Mirrors buildContextFromKeys() in SessionReplayClientAdapter.kt.
   private func buildContextFromKeys(_ keys: [String: String]) -> LDContext? {
-    guard !keys.isEmpty else { return nil }
+    guard let first = keys.first else { return nil }
     if keys.count == 1 {
-      let (kind, key) = keys.first!
+      let (kind, key) = first
       var builder = LDContextBuilder(key: key)
       builder.kind(kind)
       guard case .success(let context) = builder.build() else {

--- a/sdk/@launchdarkly/react-native-ld-session-replay/ios/SessionReplayClientAdapter.swift
+++ b/sdk/@launchdarkly/react-native-ld-session-replay/ios/SessionReplayClientAdapter.swift
@@ -129,6 +129,8 @@ public class SessionReplayClientAdapter: NSObject {
       await prev.value
       guard let self else { return }
       if completed {
+        // If buildContextFromKeys returns nil, that's fine — LaunchDarkly will
+        // use a default anonymous context.
         self.cachedContext = self.buildContextFromKeys(keys)
       }
       if self.initialized {

--- a/sdk/@launchdarkly/react-native-ld-session-replay/ios/SessionReplayReactNative.mm
+++ b/sdk/@launchdarkly/react-native-ld-session-replay/ios/SessionReplayReactNative.mm
@@ -59,7 +59,13 @@
               resolve:(RCTPromiseResolveBlock)resolve
                reject:(RCTPromiseRejectBlock)reject
 {
-    resolve(nil);
+    @try {
+      [[SessionReplayClientAdapter shared] afterIdentify:contextKeys canonicalKey:canonicalKey completed:completed];
+      resolve(nil);
+    } @catch(NSException *exception) {
+      NSLog(@"⚠️ afterIdentify crash: %@", exception);
+      reject(@"after_identify_failed", exception.reason, nil);
+    }
 }
 
 - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:

--- a/sdk/@launchdarkly/react-native-ld-session-replay/ios/SessionReplayReactNative.mm
+++ b/sdk/@launchdarkly/react-native-ld-session-replay/ios/SessionReplayReactNative.mm
@@ -60,7 +60,7 @@
                reject:(RCTPromiseRejectBlock)reject
 {
     @try {
-      [[SessionReplayClientAdapter shared] afterIdentify:contextKeys canonicalKey:canonicalKey completed:completed];
+      [[SessionReplayClientAdapter shared] afterIdentifyWithContextKeys:contextKeys canonicalKey:canonicalKey completed:completed];
       resolve(nil);
     } @catch(NSException *exception) {
       NSLog(@"⚠️ afterIdentify crash: %@", exception);


### PR DESCRIPTION
## Summary

Propagate afterIdentify to session replay in iOS the same as Android.

## How did you test this change?

Manually ran the example app and verified the session replay shows up as desired.

## Are there any deployment considerations?

N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches iOS session replay initialization and context handling; mistakes could cause incorrect/anonymous replay attribution or missed identify hooks, but the change is localized and non-security-critical.
> 
> **Overview**
> **iOS session replay now mirrors Android’s identify behavior.** `SessionReplayClientAdapter` caches the latest identified `LDContext` (built from provided context kind/key pairs, including multi-context) and uses it when starting `LDClient`.
> 
> Adds an `afterIdentify` bridge that updates the cached context on successful identify and, when initialized, forwards the call to `LDReplay.shared.hookProxy?.afterIdentify(...)`. The React Native iOS module now actually invokes this adapter method (with exception handling) instead of no-op’ing.
> 
> Updates the example app’s iOS `Podfile.lock` to `SessionReplayReactNative` `0.5.0` (and Cocoapods `1.16.2`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3508696b3cc55715e34e30f7aefc216e12e9e09d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->