### PR TITLE
fix: scope tracingOrigins matching to the URL origin

### DIFF
--- a/sdk/@launchdarkly/observability-react-native/src/api/Options.ts
+++ b/sdk/@launchdarkly/observability-react-native/src/api/Options.ts
@@ -84,7 +84,10 @@ export interface ReactNativeOptions {
 	tracingOrigins?: boolean | (string | RegExp)[]
 
 	/**
-	 * A list of URLs to block from tracing.
+	 * URLs to not record headers and bodies for, and to not propagate trace
+	 * headers (e.g. `traceparent`) to. Each entry is matched as a
+	 * case-insensitive substring of the full request URL; a match suppresses
+	 * both recording and trace-header propagation for that request.
 	 * @example urlBlocklist: ['localhost', 'backend.myapp.com']
 	 */
 	urlBlocklist?: string[]

--- a/sdk/@launchdarkly/observability-shared/src/instrumentation/utils.test.ts
+++ b/sdk/@launchdarkly/observability-shared/src/instrumentation/utils.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { getCorsUrlsPattern, shouldNetworkRequestBeTraced } from './utils'
+
+describe('getCorsUrlsPattern', () => {
+	afterEach(() => {
+		vi.unstubAllGlobals()
+	})
+
+	it('returns a nothing-matching regex when tracingOrigins is false', () => {
+		expect(getCorsUrlsPattern(false)).toEqual(/^$/)
+	})
+
+	it('anchors the page host at the origin position', () => {
+		vi.stubGlobal('window', {
+			location: { host: 'example.com' },
+		})
+		const patterns = getCorsUrlsPattern(true) as RegExp[]
+		expect(patterns).toEqual([
+			/localhost/,
+			/^\//,
+			/^https?:\/\/([^/]+\.)?example\.com([:/?#]|$)/,
+		])
+		// Regression: an unanchored /example.com/ used to match third-party
+		// URLs that carried the host as a query-parameter value.
+		expect(
+			patterns.some((p) =>
+				p.test('https://api.third-party.test/?store=example.com'),
+			),
+		).toBe(false)
+	})
+})
+
+describe('shouldNetworkRequestBeTraced', () => {
+	afterEach(() => {
+		vi.unstubAllGlobals()
+	})
+
+	it('does not match the page host as a substring of a third-party URL', () => {
+		vi.stubGlobal('window', {
+			location: { host: 'example.com' },
+		})
+		expect(
+			shouldNetworkRequestBeTraced(
+				'https://api.third-party.test/?store=example.com',
+				true,
+				[],
+			),
+		).toBe(false)
+	})
+
+	it('does not match a user-supplied host pattern against a query value', () => {
+		expect(
+			shouldNetworkRequestBeTraced(
+				'https://api.third-party.test/?store=example.com',
+				[/example\.com/],
+				[],
+			),
+		).toBe(false)
+		expect(
+			shouldNetworkRequestBeTraced(
+				'https://api.third-party.test/?store=example.com',
+				['example.com'],
+				[],
+			),
+		).toBe(false)
+	})
+
+	it('matches same-origin requests when tracingOrigins is true', () => {
+		vi.stubGlobal('window', {
+			location: { host: 'example.com' },
+		})
+		expect(
+			shouldNetworkRequestBeTraced(
+				'https://example.com/api/foo',
+				true,
+				[],
+			),
+		).toBe(true)
+	})
+
+	it('matches subdomains of the page host when tracingOrigins is true', () => {
+		vi.stubGlobal('window', {
+			location: { host: 'example.com' },
+		})
+		expect(
+			shouldNetworkRequestBeTraced(
+				'https://api.example.com/api/foo',
+				true,
+				[],
+			),
+		).toBe(true)
+	})
+
+	it('matches relative URLs when tracingOrigins is true', () => {
+		expect(shouldNetworkRequestBeTraced('/api/foo', true, [])).toBe(true)
+	})
+
+	it('matches localhost when tracingOrigins is true', () => {
+		expect(
+			shouldNetworkRequestBeTraced(
+				'http://localhost:8080/api/foo',
+				true,
+				[],
+			),
+		).toBe(true)
+	})
+
+	it('honours urlBlocklist', () => {
+		expect(
+			shouldNetworkRequestBeTraced(
+				'https://example.com/api/v2/foo',
+				true,
+				['/api/v2'],
+			),
+		).toBe(false)
+	})
+})

--- a/sdk/@launchdarkly/observability-shared/src/instrumentation/utils.ts
+++ b/sdk/@launchdarkly/observability-shared/src/instrumentation/utils.ts
@@ -53,12 +53,18 @@ export const shouldNetworkRequestBeTraced = (
 		return false
 	}
 
+	// Match against the URL's origin rather than the full URL. Otherwise the
+	// configured host can appear as a query-parameter value in a third-party
+	// URL and match the substring regex, leaking trace headers to origins the
+	// user never intended to trace.
+	const matchTarget = getUrlMatchTarget(url)
+
 	const patterns = getCorsUrlsPattern(tracingOrigins)
 	if (Array.isArray(patterns)) {
-		return patterns.some((pattern) => pattern.test(url))
+		return patterns.some((pattern) => pattern.test(matchTarget))
 	}
 
-	return patterns.test(url)
+	return patterns.test(matchTarget)
 }
 
 export const shouldRecordRequest = (
@@ -88,7 +94,7 @@ export function getCorsUrlsPattern(
 	if (tracingOrigins === true) {
 		const patterns = [/localhost/, /^\//]
 		if (typeof window !== 'undefined' && window.location?.host) {
-			patterns.push(new RegExp(window.location.host))
+			patterns.push(buildLocationHostPattern(window.location.host))
 		}
 		return patterns
 	} else if (Array.isArray(tracingOrigins)) {
@@ -98,4 +104,27 @@ export function getCorsUrlsPattern(
 	}
 
 	return /^$/ // Match nothing if tracingOrigins is false or undefined
+}
+
+const escapeRegExp = (s: string): string =>
+	s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+
+// Build a regex that matches the page host (and its subdomains) at the origin
+// position of a URL, not anywhere inside it. Anchoring matters: an unanchored
+// /example.com/ also matches https://third-party.io/?store=example.com.
+const buildLocationHostPattern = (host: string): RegExp =>
+	new RegExp('^https?://([^/]+\\.)?' + escapeRegExp(host) + '([:/?#]|$)')
+
+// Returns the URL's origin for absolute URLs, or the original string for
+// relative paths or inputs that fail to parse.
+const getUrlMatchTarget = (url: string): string => {
+	// Keep relative paths verbatim so patterns like /^\// still match them.
+	if (url.startsWith('/') && !url.startsWith('//')) {
+		return url
+	}
+	try {
+		return new URL(url).origin
+	} catch {
+		return url
+	}
 }

--- a/sdk/highlight-run/src/__tests__/index.test.ts
+++ b/sdk/highlight-run/src/__tests__/index.test.ts
@@ -10,8 +10,28 @@ describe('getCorsUrlsPattern', () => {
 		expect(getCorsUrlsPattern(true)).toEqual([
 			/localhost/,
 			/^\//,
-			/localhost:3000/,
+			/^https?:\/\/([^/]+\.)?localhost:3000([:/?#]|$)/,
 		])
+	})
+
+	it('does not match the page host as a substring of a third-party URL', () => {
+		// Regression for a bug where tracingOrigins: true produced an
+		// unanchored /host/ regex, causing trace headers to be injected into
+		// cross-origin requests that happened to contain the page host as a
+		// query-parameter value (e.g. ?store=<page host>). The page-host
+		// regex is the last entry in the returned pattern array.
+		const pageHostPattern = (getCorsUrlsPattern(true) as RegExp[])[2]
+		const thirdParty =
+			'https://api.third-party.example/timeline?store=127.0.0.1:3000'
+		expect(pageHostPattern.test(thirdParty)).toBe(false)
+	})
+
+	it('still matches the page origin and its subdomains', () => {
+		const pageHostPattern = (getCorsUrlsPattern(true) as RegExp[])[2]
+		expect(pageHostPattern.test('http://localhost:3000/api/foo')).toBe(true)
+		expect(pageHostPattern.test('https://api.localhost:3000/api/foo')).toBe(
+			true,
+		)
 	})
 
 	it('handles `tracingOrigins: [string, string]` correctly', () => {

--- a/sdk/highlight-run/src/__tests__/utils.test.ts
+++ b/sdk/highlight-run/src/__tests__/utils.test.ts
@@ -176,6 +176,48 @@ describe('shouldNetworkRequestBeTraced', () => {
 			),
 		).toBe(false)
 	})
+
+	// Regression: with tracingOrigins: true, an unanchored /<page host>/
+	// regex used to match third-party URLs that carried the page host as a
+	// query-parameter value, leaking trace headers to unrelated origins.
+	it('does not match the page host appearing as a query value on a third-party URL when tracingOrigins is true', () => {
+		window.location.host = 'example.com'
+		expect(
+			shouldNetworkRequestBeTraced(
+				'https://api.third-party.test/timeline?store=example.com',
+				true,
+				[],
+			),
+		).toBe(false)
+	})
+
+	it('does not match a user-supplied host pattern appearing as a query value on a third-party URL', () => {
+		expect(
+			shouldNetworkRequestBeTraced(
+				'https://api.third-party.test/timeline?store=example.com',
+				[/example\.com/],
+				[],
+			),
+		).toBe(false)
+		expect(
+			shouldNetworkRequestBeTraced(
+				'https://api.third-party.test/timeline?store=example.com',
+				['example.com'],
+				[],
+			),
+		).toBe(false)
+	})
+
+	it('matches subdomains of the page host when tracingOrigins is true', () => {
+		window.location.host = 'example.com'
+		expect(
+			shouldNetworkRequestBeTraced(
+				'https://api.example.com/api/foo',
+				true,
+				[],
+			),
+		).toBe(true)
+	})
 })
 
 describe('shouldNetworkRequestBeRecorded', () => {

--- a/sdk/highlight-run/src/client/listeners/network-listener/utils/utils.ts
+++ b/sdk/highlight-run/src/client/listeners/network-listener/utils/utils.ts
@@ -320,7 +320,10 @@ export const shouldNetworkRequestBeTraced = (
 const escapeRegExp = (s: string): string =>
 	s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 
-const buildLocationHostPattern = (host: string): RegExp =>
+// Build a regex that matches the page host (and its subdomains) at the origin
+// position of a URL, not anywhere inside it. Anchoring matters: an unanchored
+// /example.com/ also matches https://third-party.io/?store=example.com.
+export const buildLocationHostPattern = (host: string): RegExp =>
 	new RegExp('^https?://([^/]+\\.)?' + escapeRegExp(host) + '([:/?#]|$)')
 
 const getUrlMatchTarget = (url: string): string => {

--- a/sdk/highlight-run/src/client/listeners/network-listener/utils/utils.ts
+++ b/sdk/highlight-run/src/client/listeners/network-listener/utils/utils.ts
@@ -295,19 +295,43 @@ export const shouldNetworkRequestBeTraced = (
 	if (tracingOrigins === true) {
 		patterns = ['localhost', /^\//]
 		if (window?.location?.host) {
-			patterns.push(window.location.host)
+			// Anchor to the origin; an unanchored host regex also matches the
+			// host appearing as a query-parameter value in a third-party URL.
+			patterns.push(buildLocationHostPattern(window.location.host))
 		}
 	} else if (tracingOrigins instanceof Array) {
 		patterns = tracingOrigins
 	}
 
+	// Match against the URL's origin (or the raw string for relative paths)
+	// rather than the whole URL, so the configured host appearing as a query
+	// value in a third-party URL doesn't leak trace headers.
+	const matchTarget = getUrlMatchTarget(url)
+
 	let result = false
 	patterns.forEach((pattern) => {
-		if (url.match(pattern)) {
+		if (matchTarget.match(pattern)) {
 			result = true
 		}
 	})
 	return result
+}
+
+const escapeRegExp = (s: string): string =>
+	s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+
+const buildLocationHostPattern = (host: string): RegExp =>
+	new RegExp('^https?://([^/]+\\.)?' + escapeRegExp(host) + '([:/?#]|$)')
+
+const getUrlMatchTarget = (url: string): string => {
+	if (url.startsWith('/') && !url.startsWith('//')) {
+		return url
+	}
+	try {
+		return new URL(url).origin
+	} catch {
+		return url
+	}
 }
 
 function makeId(length: number) {

--- a/sdk/highlight-run/src/client/otel/index.ts
+++ b/sdk/highlight-run/src/client/otel/index.ts
@@ -1153,7 +1153,11 @@ export const getCorsUrlsPattern = (
 	tracingOrigins: BrowserTracingConfig['tracingOrigins'],
 ): PropagateTraceHeaderCorsUrls => {
 	if (tracingOrigins === true) {
-		return [/localhost/, /^\//, new RegExp(window.location.host)]
+		return [
+			/localhost/,
+			/^\//,
+			buildLocationHostPattern(window.location.host),
+		]
 	} else if (Array.isArray(tracingOrigins)) {
 		return tracingOrigins.map((pattern) =>
 			typeof pattern === 'string' ? new RegExp(pattern) : pattern,
@@ -1162,6 +1166,15 @@ export const getCorsUrlsPattern = (
 
 	return /^$/ // Match nothing if tracingOrigins is false or undefined
 }
+
+const escapeRegExp = (s: string): string =>
+	s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+
+// Anchor the page host at the origin position of a URL. An unanchored
+// /example.com/ also matches third-party URLs that carry the host as a
+// query-parameter value (e.g. ...?store=example.com), leaking trace headers.
+const buildLocationHostPattern = (host: string): RegExp =>
+	new RegExp('^https?://([^/]+\\.)?' + escapeRegExp(host) + '([:/?#]|$)')
 
 const getUrlFromSpan = (span: ReadableSpan) => {
 	if (span.attributes[SemanticAttributes.ATTR_URL_FULL]) {

--- a/sdk/highlight-run/src/client/otel/index.ts
+++ b/sdk/highlight-run/src/client/otel/index.ts
@@ -32,6 +32,7 @@ import {
 	sanitizeUrl,
 } from '../listeners/network-listener/utils/network-sanitizer'
 import {
+	buildLocationHostPattern,
 	shouldNetworkRequestBeRecorded,
 	shouldNetworkRequestBeTraced,
 } from '../listeners/network-listener/utils/utils'
@@ -1166,15 +1167,6 @@ export const getCorsUrlsPattern = (
 
 	return /^$/ // Match nothing if tracingOrigins is false or undefined
 }
-
-const escapeRegExp = (s: string): string =>
-	s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-
-// Anchor the page host at the origin position of a URL. An unanchored
-// /example.com/ also matches third-party URLs that carry the host as a
-// query-parameter value (e.g. ...?store=example.com), leaking trace headers.
-const buildLocationHostPattern = (host: string): RegExp =>
-	new RegExp('^https?://([^/]+\\.)?' + escapeRegExp(host) + '([:/?#]|$)')
 
 const getUrlFromSpan = (span: ReadableSpan) => {
 	if (span.attributes[SemanticAttributes.ATTR_URL_FULL]) {

--- a/sdk/highlight-run/src/client/types/client.ts
+++ b/sdk/highlight-run/src/client/types/client.ts
@@ -72,7 +72,10 @@ export type NetworkRecordingOptions = {
 	 */
 	networkBodyKeysToRedact?: string[]
 	/**
-	 * URLs to not record headers and bodies for.
+	 * URLs to not record headers and bodies for, and to not propagate trace
+	 * headers (e.g. `traceparent`) to. Each entry is matched as a
+	 * case-insensitive substring of the full request URL; a match suppresses
+	 * both recording and trace-header propagation for that request.
 	 * To disable recording headers and bodies for all URLs, set `recordHeadersAndBody` to `false`.
 	 * @default ['https://www.googleapis.com/identitytoolkit', 'https://securetoken.googleapis.com']
 	 */


### PR DESCRIPTION
## Summary

- `shouldNetworkRequestBeTraced` tested `tracingOrigins` patterns against the full request URL, and `getCorsUrlsPattern` built a raw `new RegExp(window.location.host)` for `tracingOrigins: true`. Any cross-origin URL that happened to contain the page host as a substring (very commonly: third-party widgets that take the customer's domain as a query parameter, e.g. `?store=acme.com`) satisfied the regex and received a `traceparent` header on an origin the user never asked to trace.
- Since `window.location.host` was passed unescaped, the `.` also matched any character — so the pattern was even broader than a string substring.
- Match patterns against `new URL(url).origin` instead of the full URL (relative paths pass through so `/^\//` still works). Anchor the `tracingOrigins: true` page-host pattern to the scheme + host position so same-origin and subdomain requests continue to be propagated, but in-body occurrences of the host no longer match.
- Applied in three places: the shared `observability-shared` propagator utils, the legacy fetch/XHR network-listener path (`x-highlight-request` header), and the `getCorsUrlsPattern` consumed as OpenTelemetry's `propagateTraceHeaderCorsUrls` in both the browser SDK and React Native SDK.

## Behavior changes

- `tracingOrigins: true` on a page at `https://acme.com` still propagates to `https://acme.com/...` and `https://api.acme.com/...`, but no longer propagates to `https://third-party.io/?q=acme.com`.
- User-supplied string/RegExp patterns (`['acme.com']`, `[/acme\.com/]`) now match against the request's origin. Patterns that were intended to match paths (e.g. `[/\/api\//]`) would no longer match — I did not find any docs recommending that shape, and the public example in the docstring (`['localhost', /^\//, 'backend.myapp.com']`) is all origin-ish. Relative paths still match raw because they go through unchanged.

## Test plan

- [x] New regression tests in `sdk/highlight-run/src/__tests__/utils.test.ts`, `sdk/highlight-run/src/__tests__/index.test.ts`, and a new `sdk/@launchdarkly/observability-shared/src/instrumentation/utils.test.ts` that cover the page host appearing as a query value on a third-party URL, user-supplied `/host/` patterns doing the same, and that same-origin plus subdomain matching still succeed.
- [x] `yarn turbo run test --filter @launchdarkly/observability-shared --filter highlight.run` — 406 + 9 tests pass.
- [x] `yarn format-check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes trace-header propagation and network tracing decisions, which can affect where `traceparent`/`X-Highlight-Request` headers are injected; regressions could break intended backend tracing or still leak headers if matching is wrong.
> 
> **Overview**
> Prevents trace headers from being propagated to unintended third-party requests by scoping `tracingOrigins` matching to the request *origin* (keeping relative-path matching intact) instead of the full URL.
> 
> For `tracingOrigins: true`, replaces the previous unescaped/unanchored `window.location.host` regex with an origin-anchored, escaped host+subdomain pattern, and updates both the shared LaunchDarkly observability utilities and the Highlight browser SDK paths to use it.
> 
> Adds regression tests covering query-parameter host substring false-positives, user-supplied patterns, and continued same-origin/subdomain/localhost behavior, and clarifies `urlBlocklist` docs to note it also suppresses trace-header propagation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8bcde6c6692278160e315cc20cec4ccc6776eb9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->