### PR TITLE
feat: Disable CrashReporting for RN iOS and Android

### DIFF
--- a/sdk/@launchdarkly/react-native-ld-session-replay/SessionReplayReactNative.podspec
+++ b/sdk/@launchdarkly/react-native-ld-session-replay/SessionReplayReactNative.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm,swift,cpp}"
   s.private_header_files = "ios/**/*.h"
 
-  s.dependency 'LaunchDarklySessionReplay', '~> 0.26.2'
+  s.dependency 'LaunchDarklySessionReplay', '~> 0.33.1'
 
   install_modules_dependencies(s)
 end

--- a/sdk/@launchdarkly/react-native-ld-session-replay/android/src/main/java/com/sessionreplayreactnative/SessionReplayClientAdapter.kt
+++ b/sdk/@launchdarkly/react-native-ld-session-replay/android/src/main/java/com/sessionreplayreactnative/SessionReplayClientAdapter.kt
@@ -141,6 +141,10 @@ internal class SessionReplayClientAdapter private constructor() {
                             options = ObservabilityOptions(
                                 serviceName = serviceName,
                                 logAdapter = LDAndroidLogging.adapter(),
+                                // Disable the OpenTelemetry Android CrashReporterInstrumentation
+                                instrumentations = ObservabilityOptions.Instrumentations(
+                                    crashReporting = false,
+                                ),
                             )
                         ),
                         SessionReplay(options = replayOptions),

--- a/sdk/@launchdarkly/react-native-ld-session-replay/ios/SessionReplayClientAdapter.swift
+++ b/sdk/@launchdarkly/react-native-ld-session-replay/ios/SessionReplayClientAdapter.swift
@@ -43,7 +43,9 @@ public class SessionReplayClientAdapter: NSObject {
       Observability(
         options: .init(
           serviceName: options.serviceName,
-          sessionBackgroundTimeout: 10
+          sessionBackgroundTimeout: 10,
+          /// Disable the underlying KSCrash-based crash reporter that
+          crashReporting: .init(source: .none)
         )
       ),
       SessionReplay(options: options)


### PR DESCRIPTION
## Summary

RN need specific RN crash reporting and it should be parametrized as well (in future)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk due to upgrading the iOS `LaunchDarklySessionReplay` pod and changing observability instrumentation defaults on both iOS and Android, which could affect telemetry/crash capture behavior.
> 
> **Overview**
> Disables native crash-reporting instrumentation in the React Native Session Replay adapters by turning off OpenTelemetry crash reporting on Android (`ObservabilityOptions.Instrumentations(crashReporting = false)`) and disabling the KSCrash-based reporter on iOS (`crashReporting: .init(source: .none)`).
> 
> Also bumps the iOS `LaunchDarklySessionReplay` CocoaPods dependency from `~> 0.26.2` to `~> 0.33.1`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdd3a299246f0f71d101fdfd18c76520c7e5f6cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->