### PR TITLE
feat: Android - downgrade Kotlin to 2.0.21, upgrade JVM to 11

### DIFF
--- a/e2e/android/app/build.gradle.kts
+++ b/e2e/android/app/build.gradle.kts
@@ -136,6 +136,10 @@ dependencies {
 
     // noCompose uses AppCompatActivity for proper Material Components theme resolution
     "noComposeImplementation"("androidx.appcompat:appcompat:1.7.0")
+    // Provides the `by viewModels()` Kotlin extension on ComponentActivity. Required because
+    // androidx.activity is resolved at 1.7.x here (transitively via appcompat / observability-android),
+    // and the Kotlin extensions only moved into the base `activity` artifact starting in 1.8.0.
+    "noComposeImplementation"("androidx.activity:activity-ktx:1.7.0")
 
     testImplementation(libs.junit)
     testImplementation(libs.core.ktx)

--- a/sdk/@launchdarkly/mobile-dotnet/android/native/LDObserve/build.gradle.kts
+++ b/sdk/@launchdarkly/mobile-dotnet/android/native/LDObserve/build.gradle.kts
@@ -25,12 +25,12 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
     }
     kotlin {
         compilerOptions {
-            jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8)
+            jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11)
         }
     }
 }

--- a/sdk/@launchdarkly/mobile-dotnet/android/native/build.gradle.kts
+++ b/sdk/@launchdarkly/mobile-dotnet/android/native/build.gradle.kts
@@ -1,5 +1,5 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     id("com.android.library") apply false
-    id("org.jetbrains.kotlin.android") version "2.0.21" apply false
+    id("org.jetbrains.kotlin.android") version "2.2.0" apply false
 }

--- a/sdk/@launchdarkly/mobile-dotnet/android/native/build.gradle.kts
+++ b/sdk/@launchdarkly/mobile-dotnet/android/native/build.gradle.kts
@@ -1,5 +1,5 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     id("com.android.library") apply false
-    id("org.jetbrains.kotlin.android") version "2.2.0" apply false
+    id("org.jetbrains.kotlin.android") version "2.0.21" apply false
 }

--- a/sdk/@launchdarkly/observability-android/gradle/libs.versions.toml
+++ b/sdk/@launchdarkly/observability-android/gradle/libs.versions.toml
@@ -2,5 +2,5 @@
 # https://docs.gradle.org/current/userguide/platforms.html#sub::toml-dependencies-format
 
 [plugins]
-kotlin-android = { id = "org.jetbrains.kotlin.android", version = "2.2.0" }
-kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version = "2.2.0" }
+kotlin-android = { id = "org.jetbrains.kotlin.android", version = "2.0.21" }
+kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version = "2.0.21" }

--- a/sdk/@launchdarkly/observability-android/lib/build.gradle.kts
+++ b/sdk/@launchdarkly/observability-android/lib/build.gradle.kts
@@ -22,6 +22,20 @@ allprojects {
 
 val isIncludedByMaui = gradle.parent?.rootProject?.name == "LDObserve"
 
+// Pin all Kotlin artifacts (stdlib, reflect, etc.) on this build's classpath to the same
+// version as the configured Kotlin compiler. Without this, transitive deps such as the
+// io.opentelemetry.android:*:0.11.0-alpha modules drag in a newer kotlin-stdlib whose
+// metadata version this compiler cannot read, producing
+// "Module was compiled with an incompatible version of Kotlin" errors at compileDebugKotlin.
+configurations.all {
+    resolutionStrategy.eachDependency {
+        if (requested.group == "org.jetbrains.kotlin" && requested.name.startsWith("kotlin-stdlib")) {
+            useVersion("2.0.21")
+            because("Align kotlin-stdlib with the project's Kotlin compiler version (2.0.21).")
+        }
+    }
+}
+
 dependencies {
     if (isIncludedByMaui) {
         compileOnly("com.launchdarkly:launchdarkly-android-client-sdk:5.11.1")

--- a/sdk/@launchdarkly/observability-android/lib/build.gradle.kts
+++ b/sdk/@launchdarkly/observability-android/lib/build.gradle.kts
@@ -22,18 +22,26 @@ allprojects {
 
 val isIncludedByMaui = gradle.parent?.rootProject?.name == "LDObserve"
 
-// Pin all Kotlin artifacts (stdlib, reflect, etc.) on this build's classpath to the same
-// version as the configured Kotlin compiler. Without this, transitive deps such as the
-// io.opentelemetry.android:*:0.11.0-alpha modules drag in newer Kotlin artifacts whose
-// metadata version this compiler cannot read, producing
+// Pin Kotlin runtime artifacts on this build's classpath to match the configured Kotlin
+// compiler version (2.0.21). Without this, transitive deps such as the
+// io.opentelemetry.android:*:0.11.0-alpha modules drag in newer kotlin-stdlib / kotlin-reflect
+// whose metadata version the 2.0.21 compiler cannot read, producing
 // "Module was compiled with an incompatible version of Kotlin" errors at compileDebugKotlin.
-// All org.jetbrains.kotlin:* artifacts ship in lock-step with the compiler, so aligning the
-// whole group is the right scope here (covers kotlin-stdlib*, kotlin-reflect, etc.).
+//
+// Scope is intentionally limited to stdlib / reflect / test — the @Metadata-bearing artifacts
+// that end up on user-code compile/runtime classpaths. KGP-internal artifacts
+// (kotlin-build-tools-impl, kotlin-compiler-embeddable, kotlin-gradle-plugin-api, etc.) are
+// NOT pinned because they must match the active KGP version; downgrading them triggers KGP
+// 2.x's "Build Tools API Version Mismatch Detected" check during artifact transforms.
 configurations.all {
     resolutionStrategy.eachDependency {
-        if (requested.group == "org.jetbrains.kotlin") {
+        val name = requested.name
+        val isRuntimeArtifact = name.startsWith("kotlin-stdlib") ||
+                name == "kotlin-reflect" ||
+                name.startsWith("kotlin-test")
+        if (requested.group == "org.jetbrains.kotlin" && isRuntimeArtifact) {
             useVersion("2.0.21")
-            because("Align all org.jetbrains.kotlin:* artifacts with the project's Kotlin compiler version (2.0.21).")
+            because("Align Kotlin runtime artifacts with the project's Kotlin compiler version (2.0.21).")
         }
     }
 }

--- a/sdk/@launchdarkly/observability-android/lib/build.gradle.kts
+++ b/sdk/@launchdarkly/observability-android/lib/build.gradle.kts
@@ -38,11 +38,11 @@ dependencies {
     compileOnly("androidx.compose.ui:ui-tooling:1.7.5")
 
     // Coroutines
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.9.0")
 
     // Kotlinx serialization for JSON parsing
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.1")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3")
 
     // TODO: revise these versions to be as old as usable for compatibility
     implementation("io.opentelemetry:opentelemetry-api:1.51.0")
@@ -72,10 +72,10 @@ dependencies {
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 
     testImplementation("io.mockk:mockk:1.14.5")
-    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.9.0")
 
     testFixturesApi("io.opentelemetry:opentelemetry-sdk-testing:1.51.0")
-    testFixturesImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2")
+    testFixturesImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.9.0")
 }
 
 val releaseVersion = version.toString()
@@ -105,12 +105,12 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
     }
     kotlin {
         compilerOptions {
-            jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8)
+            jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11)
         }
     }
 

--- a/sdk/@launchdarkly/observability-android/lib/build.gradle.kts
+++ b/sdk/@launchdarkly/observability-android/lib/build.gradle.kts
@@ -24,14 +24,16 @@ val isIncludedByMaui = gradle.parent?.rootProject?.name == "LDObserve"
 
 // Pin all Kotlin artifacts (stdlib, reflect, etc.) on this build's classpath to the same
 // version as the configured Kotlin compiler. Without this, transitive deps such as the
-// io.opentelemetry.android:*:0.11.0-alpha modules drag in a newer kotlin-stdlib whose
+// io.opentelemetry.android:*:0.11.0-alpha modules drag in newer Kotlin artifacts whose
 // metadata version this compiler cannot read, producing
 // "Module was compiled with an incompatible version of Kotlin" errors at compileDebugKotlin.
+// All org.jetbrains.kotlin:* artifacts ship in lock-step with the compiler, so aligning the
+// whole group is the right scope here (covers kotlin-stdlib*, kotlin-reflect, etc.).
 configurations.all {
     resolutionStrategy.eachDependency {
-        if (requested.group == "org.jetbrains.kotlin" && requested.name.startsWith("kotlin-stdlib")) {
+        if (requested.group == "org.jetbrains.kotlin") {
             useVersion("2.0.21")
-            because("Align kotlin-stdlib with the project's Kotlin compiler version (2.0.21).")
+            because("Align all org.jetbrains.kotlin:* artifacts with the project's Kotlin compiler version (2.0.21).")
         }
     }
 }

--- a/sdk/@launchdarkly/observability-android/lib/build.gradle.kts
+++ b/sdk/@launchdarkly/observability-android/lib/build.gradle.kts
@@ -38,10 +38,10 @@ configurations.all {
 
 dependencies {
     if (isIncludedByMaui) {
-        compileOnly("com.launchdarkly:launchdarkly-android-client-sdk:5.11.1")
-        testImplementation("com.launchdarkly:launchdarkly-android-client-sdk:5.11.1")
+        compileOnly("com.launchdarkly:launchdarkly-android-client-sdk:5.12.0")
+        testImplementation("com.launchdarkly:launchdarkly-android-client-sdk:5.12.0")
     } else {
-        implementation("com.launchdarkly:launchdarkly-android-client-sdk:5.11.1")
+        implementation("com.launchdarkly:launchdarkly-android-client-sdk:5.12.0")
     }
 
     // AndroidX

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/network/GraphQLClient.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/network/GraphQLClient.kt
@@ -85,7 +85,7 @@ class GraphQLClient(
                 variables = variables
             )
 
-            val requestJson = json.encodeToString(request)
+            val requestJson = json.encodeToString(GraphQLRequest.serializer(), request)
             val requestBytes = requestJson.toByteArray(Charsets.UTF_8)
             val payloadBytes = if (compress) gzip(requestBytes) else requestBytes
             val connectionLocal = connectionProvider.openConnection(endpoint).also { connection = it }


### PR DESCRIPTION
## Summary

 - Increase compatibility and gives more Java features

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Build-toolchain and dependency version shifts (Kotlin/JVM targets plus coroutines/serialization downgrades) can cause compilation or runtime compatibility issues across consumers despite minimal code changes.
> 
> **Overview**
> Shifts the Android toolchain to **Kotlin 2.0.21** (plugin versions updated) while moving the `observability-android` library and the MAUI `LDObserve` native Android module to **Java/JVM 11** (`sourceCompatibility`/`jvmTarget`).
> 
> To keep Kotlin 2.0.21 compatible with transitive dependencies, the library build now **pins Kotlin runtime artifacts** (`kotlin-stdlib`/`reflect`/`test`) to 2.0.21 and **downgrades coroutines/serialization** versions accordingly; it also bumps `launchdarkly-android-client-sdk` to `5.12.0`. 
> 
> Fixes a Kotlinx serialization call-site by switching `GraphQLClient` request encoding to the explicit `encodeToString(serializer, value)` form, and updates the e2e app’s `noCompose` flavor to include `androidx.activity:activity-ktx:1.7.0` for `by viewModels()` support.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 730b3b8fed1a067966a77bb67b744193e809ab85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->