### PR TITLE
feat: RN decrease Kotlin to 2.0.21 and increase JVM to 11

### DIFF
--- a/sdk/@launchdarkly/react-native-ld-session-replay/android/build.gradle
+++ b/sdk/@launchdarkly/react-native-ld-session-replay/android/build.gradle
@@ -83,8 +83,8 @@ def kotlin_version = getExtOrDefault("kotlinVersion")
 dependencies {
   implementation "com.facebook.react:react-android"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  implementation "com.launchdarkly:launchdarkly-observability-android:0.39.0"
-  implementation "com.launchdarkly:launchdarkly-android-client-sdk:5.11.0"
+  implementation "com.launchdarkly:launchdarkly-observability-android:0.42.0"
+  implementation "com.launchdarkly:launchdarkly-android-client-sdk:5.12.0"
   // compileOnly: OTel Attributes appears in ObservabilityOptions parameter types; provided at
   // runtime transitively through launchdarkly-observability-android.
   compileOnly "io.opentelemetry:opentelemetry-api:1.51.0"


### PR DESCRIPTION
## Summary

decrease Kotlin to 2.0.21 to make RN more usable

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only version bumps in the Android build; risk is limited to potential behavior/regression changes introduced by upstream SDK updates.
> 
> **Overview**
> Updates the React Native session replay Android module to use newer LaunchDarkly dependencies by bumping `launchdarkly-observability-android` from `0.39.0` to `0.42.0` and `launchdarkly-android-client-sdk` from `5.11.0` to `5.12.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30636e8b7b92855969130e8e3e68f653dd2a803e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->