### PR TITLE
feat: include LD context keys in metric event attributes

### DIFF
--- a/.changeset/swift-otters-roam.md
+++ b/.changeset/swift-otters-roam.md
@@ -1,0 +1,5 @@
+---
+'highlight.run': minor
+---
+
+include LaunchDarkly context keys as attributes on emitted metric events (recordCount, recordGauge, recordHistogram, recordUpDownCounter)

--- a/.changeset/swift-otters-roam.md
+++ b/.changeset/swift-otters-roam.md
@@ -1,5 +1,0 @@
----
-'highlight.run': minor
----
-
-include LaunchDarkly context keys as attributes on emitted metric events (recordCount, recordGauge, recordHistogram, recordUpDownCounter)

--- a/sdk/highlight-run/src/__tests__/sdk.test.ts
+++ b/sdk/highlight-run/src/__tests__/sdk.test.ts
@@ -7,6 +7,7 @@ import { ObserveSDK } from '../sdk/observe'
 import { RecordSDK } from '../sdk/record'
 import { globalStorage } from '../client/utils/storage'
 import { Record } from '../plugins/record'
+import * as otel from '../client/otel'
 
 describe('SDK', () => {
 	let observe: typeof LDObserve
@@ -135,6 +136,75 @@ describe('SDK', () => {
 			})
 			expect(mockRecordHistogram).toHaveBeenCalledWith(metric)
 			expect(mockRecordUpDownCounter).toHaveBeenCalledWith(metric)
+		})
+
+		it('should include LD context keys in metric attributes', () => {
+			const gauge = { record: vi.fn() }
+			const counter = { add: vi.fn() }
+			const histogram = { record: vi.fn() }
+			const upDownCounter = { add: vi.fn() }
+			vi.spyOn(otel, 'getMeter').mockReturnValue({
+				createGauge: vi.fn().mockReturnValue(gauge),
+				createCounter: vi.fn().mockReturnValue(counter),
+				createHistogram: vi.fn().mockReturnValue(histogram),
+				createUpDownCounter: vi.fn().mockReturnValue(upDownCounter),
+			} as any)
+
+			observeImpl.setLDContextKeyAttributes({ user: 'alice' })
+
+			observeImpl.recordGauge({
+				name: 'gauge.test',
+				value: 1,
+				attributes: { foo: 'bar' },
+			})
+			observeImpl.recordCount({
+				name: 'count.test',
+				value: 2,
+				attributes: { foo: 'bar' },
+			})
+			observeImpl.recordHistogram({
+				name: 'hist.test',
+				value: 3,
+				attributes: { foo: 'bar' },
+			})
+			observeImpl.recordUpDownCounter({
+				name: 'updown.test',
+				value: 4,
+				attributes: { foo: 'bar' },
+			})
+
+			const expected = expect.objectContaining({
+				'context.contextKeys.user': 'alice',
+				foo: 'bar',
+			})
+			expect(gauge.record).toHaveBeenCalledWith(1, expected)
+			expect(counter.add).toHaveBeenCalledWith(2, expected)
+			expect(histogram.record).toHaveBeenCalledWith(3, expected)
+			expect(upDownCounter.add).toHaveBeenCalledWith(4, expected)
+		})
+
+		it('caller attributes win over LD context keys with the same name', () => {
+			const gauge = { record: vi.fn() }
+			vi.spyOn(otel, 'getMeter').mockReturnValue({
+				createGauge: vi.fn().mockReturnValue(gauge),
+				createCounter: vi.fn(),
+				createHistogram: vi.fn(),
+				createUpDownCounter: vi.fn(),
+			} as any)
+
+			observeImpl.setLDContextKeyAttributes({ user: 'alice' })
+			observeImpl.recordGauge({
+				name: 'gauge.override',
+				value: 1,
+				attributes: { 'context.contextKeys.user': 'bob' },
+			})
+
+			expect(gauge.record).toHaveBeenCalledWith(
+				1,
+				expect.objectContaining({
+					'context.contextKeys.user': 'bob',
+				}),
+			)
 		})
 
 		it('should handle error recording', async () => {

--- a/sdk/highlight-run/src/sdk/observe.ts
+++ b/sdk/highlight-run/src/sdk/observe.ts
@@ -360,6 +360,7 @@ export class ObserveSDK implements Observe {
 			this._counters.set(metric.name, counter)
 		}
 		counter.add(metric.value, {
+			...(this._ldContextKeys ?? {}),
 			...metric.attributes,
 			'highlight.session_id': getPersistentSessionSecureID(),
 		})
@@ -372,21 +373,23 @@ export class ObserveSDK implements Observe {
 			if (!gauge) return
 			this._gauges.set(metric.name, gauge)
 		}
-		gauge.record(metric.value, {
+		const attributes: Attributes = {
+			...(this._ldContextKeys ?? {}),
 			...metric.attributes,
+		}
+		gauge.record(metric.value, {
+			...attributes,
 			'highlight.session_id': getPersistentSessionSecureID(),
 		})
 		const recordMetric: RecordMetric = {
 			name: metric.name,
 			value: metric.value,
-			category: metric.attributes?.['category'] as MetricCategory,
-			group: metric.attributes?.['group']?.toString(),
-			tags: metric.attributes
-				? Object.entries(metric.attributes).map(([key, value]) => ({
-						name: key ?? '',
-						value: value?.toString() ?? '',
-					}))
-				: [],
+			category: attributes['category'] as MetricCategory,
+			group: attributes['group']?.toString(),
+			tags: Object.entries(attributes).map(([key, value]) => ({
+				name: key ?? '',
+				value: value?.toString() ?? '',
+			})),
 		}
 		for (const integration of this._integrations) {
 			integration.recordGauge(
@@ -408,6 +411,7 @@ export class ObserveSDK implements Observe {
 			this._histograms.set(metric.name, histogram)
 		}
 		histogram.record(metric.value, {
+			...(this._ldContextKeys ?? {}),
 			...metric.attributes,
 			'highlight.session_id': getPersistentSessionSecureID(),
 		})
@@ -421,6 +425,7 @@ export class ObserveSDK implements Observe {
 			this._up_down_counters.set(metric.name, up_down_counter)
 		}
 		up_down_counter.add(metric.value, {
+			...(this._ldContextKeys ?? {}),
 			...metric.attributes,
 			'highlight.session_id': getPersistentSessionSecureID(),
 		})


### PR DESCRIPTION
## Summary

- Spread `_ldContextKeys` (set via `LDObserve.setLDContextKeyAttributes(...)`) into the OTel attribute bag for `recordCount`, `recordGauge`, `recordHistogram`, and `recordUpDownCounter` in `ObserveSDK`. Caller-provided `metric.attributes` still win; `highlight.session_id` stays last.
- Same change applied to the integration `recordMetric` tags in `recordGauge` so gauge data flowing to integrations carries the same dimensions.

## Why

Previously, `context.contextKeys.*` attrs only flowed to track/identify/spans, so gauge and histogram queries (e.g. web-vital LCP/CLS/INP) could not `groupBy` `pathTemplate`, `owner`, or `accountId`. Verified that `service_name=gonfalon-web` emits these metrics at high volume but `groupBy context.contextKeys.pathTemplate` returns empty groups today.

## Test plan

- [x] `yarn turbo run build --filter highlight.run`
- [x] `yarn turbo run lint --filter highlight.run`
- [x] `yarn turbo run test --filter highlight.run` (added two new unit tests in `sdk.test.ts`; 408 tests pass)
- [x] `yarn enforce-size` (166KB / 256KB brotli)
- [x] `yarn format-check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the attribute payload for all emitted metrics, which can affect metric cardinality/cost and downstream dashboards/integrations; logic is straightforward and covered by unit tests.
> 
> **Overview**
> **LaunchDarkly context key attributes are now attached to emitted metrics.** `ObserveSDK` spreads `_ldContextKeys` into the OpenTelemetry attribute bag for `recordCount`, `recordGauge`, `recordHistogram`, and `recordUpDownCounter`, while keeping caller-provided `metric.attributes` as the override source and preserving `highlight.session_id`.
> 
> For gauges, the same merged attributes are also used when building the integration `recordMetric` (`category`, `group`, and `tags`), so integrations receive the same dimensions. Adds unit tests to verify LD context keys are included and that caller attributes win on key collisions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37a350508c80d142893d45511041e0cd0c77cfad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->