### PR TITLE
fix: emit url.query_params as nested otel attributes

### DIFF
--- a/sdk/highlight-run/src/client/otel/index.ts
+++ b/sdk/highlight-run/src/client/otel/index.ts
@@ -727,16 +727,14 @@ const enhanceSpanWithHttpRequestAttributes = (
 		[SemanticAttributes.ATTR_URL_QUERY]: sanitizedUrlObject.search,
 	})
 
-	// Set sanitized query params as JSON object for easier querying
-	const searchParamsEntries = Array.from(
-		sanitizedUrlObject.searchParams.entries(),
-	)
-	if (searchParamsEntries.length > 0) {
-		span.setAttribute(
+	// Emit each query param as its own dotted attribute so the backend's
+	// hlog.FormatAttributes handles them as a nested attribute map natively.
+	span.setAttributes(
+		convertSearchParamsToOtelAttributes(
+			sanitizedUrlObject.searchParams,
 			'url.query_params',
-			JSON.stringify(Object.fromEntries(searchParamsEntries)),
-		)
-	}
+		),
+	)
 
 	if (networkRecordingOptions?.recordHeadersAndBody) {
 		const requestBody = getBodyThatShouldBeRecorded(
@@ -817,6 +815,36 @@ export const convertHeadersToOtelAttributes = (
 			attributes[attributeName] = values.length === 1 ? values[0] : values
 		}
 	})
+
+	return attributes
+}
+
+/**
+ * Converts URL query params to OpenTelemetry attributes with dotted keys.
+ * Each param becomes its own attribute (`<prefix>.<name>`), so the backend's
+ * `hlog.FormatAttributes` flattens them natively into a nested attribute map
+ * without needing to JSON-parse a stringified blob.
+ *
+ * Repeated keys (`?foo=1&foo=2`) become array-valued attributes — single
+ * values stay as strings to keep simple equality queries working.
+ */
+export const convertSearchParamsToOtelAttributes = (
+	searchParams: URLSearchParams,
+	prefix: string,
+): { [key: string]: string | string[] } => {
+	const attributes: { [key: string]: string | string[] } = {}
+
+	for (const [key, value] of searchParams.entries()) {
+		const attributeName = `${prefix}.${key}`
+		const existing = attributes[attributeName]
+		if (existing === undefined) {
+			attributes[attributeName] = value
+		} else if (Array.isArray(existing)) {
+			existing.push(value)
+		} else {
+			attributes[attributeName] = [existing, value]
+		}
+	}
 
 	return attributes
 }

--- a/sdk/highlight-run/src/client/otel/instrumentation.test.ts
+++ b/sdk/highlight-run/src/client/otel/instrumentation.test.ts
@@ -8,6 +8,7 @@ import {
 	parseXhrResponseHeaders,
 	splitHeaderValue,
 	convertHeadersToOtelAttributes,
+	convertSearchParamsToOtelAttributes,
 } from './index'
 
 describe('Network Instrumentation Custom Attributes', () => {
@@ -382,6 +383,93 @@ describe('Network Instrumentation Custom Attributes', () => {
 				'http.request.header',
 			)
 			expect(result).toEqual({})
+		})
+	})
+
+	describe('convertSearchParamsToOtelAttributes', () => {
+		it('should emit one dotted attribute per query param', () => {
+			const params = new URLSearchParams('foo=bar&baz=qux')
+
+			const result = convertSearchParamsToOtelAttributes(
+				params,
+				'url.query_params',
+			)
+
+			expect(result).toEqual({
+				'url.query_params.foo': 'bar',
+				'url.query_params.baz': 'qux',
+			})
+		})
+
+		it('should keep single-value params as strings', () => {
+			const params = new URLSearchParams('only=once')
+
+			const result = convertSearchParamsToOtelAttributes(
+				params,
+				'url.query_params',
+			)
+
+			expect(result['url.query_params.only']).toBe('once')
+			expect(result['url.query_params.only']).not.toBeInstanceOf(Array)
+		})
+
+		it('should collect repeated keys into an array preserving order', () => {
+			const params = new URLSearchParams('id=1&id=2&id=3')
+
+			const result = convertSearchParamsToOtelAttributes(
+				params,
+				'url.query_params',
+			)
+
+			expect(result['url.query_params.id']).toEqual(['1', '2', '3'])
+		})
+
+		it('should handle empty values', () => {
+			const params = new URLSearchParams('flag=&name=alice')
+
+			const result = convertSearchParamsToOtelAttributes(
+				params,
+				'url.query_params',
+			)
+
+			expect(result).toEqual({
+				'url.query_params.flag': '',
+				'url.query_params.name': 'alice',
+			})
+		})
+
+		it('should preserve URL-decoded values', () => {
+			const params = new URLSearchParams('q=hello%20world&filter=a%26b')
+
+			const result = convertSearchParamsToOtelAttributes(
+				params,
+				'url.query_params',
+			)
+
+			expect(result['url.query_params.q']).toBe('hello world')
+			expect(result['url.query_params.filter']).toBe('a&b')
+		})
+
+		it('should return an empty object when there are no params', () => {
+			const result = convertSearchParamsToOtelAttributes(
+				new URLSearchParams(),
+				'url.query_params',
+			)
+
+			expect(result).toEqual({})
+		})
+
+		it('should respect a custom prefix', () => {
+			const params = new URLSearchParams('utm_source=email')
+
+			const result = convertSearchParamsToOtelAttributes(
+				params,
+				'request.query',
+			)
+
+			expect(result).toEqual({
+				'request.query.utm_source': 'email',
+			})
 		})
 	})
 


### PR DESCRIPTION
## Summary

- Emit each URL query param as its own `url.query_params.<key>` OTel span attribute instead of one JSON-stringified blob, so the backend's `hlog.FormatAttributes` flattens them natively into a nested attribute map with no JSON parsing required.
- Repeated keys (`?id=1&id=2`) now become array-valued attributes; singletons stay as strings. The previous `Object.fromEntries` path silently dropped duplicates.
- New helper `convertSearchParamsToOtelAttributes` mirrors the existing `convertHeadersToOtelAttributes` pattern.

## Test plan

- [x] `yarn turbo run test --filter highlight.run` (413 tests pass; 7 new for the helper)
- [x] `yarn turbo run lint --filter highlight.run`
- [x] `yarn format-check`
- [x] `yarn turbo run build enforce-size --filter highlight.run --filter @launchdarkly/observability` (brotli: 166 kB, under 256 kB limit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only how URL query params are represented on OTEL spans, with added unit tests; primary risk is minor downstream query/attribute-shape expectations.
> 
> **Overview**
> Switches HTTP span query-param capture from a single JSON-stringified `url.query_params` attribute to **per-param dotted attributes** (e.g. `url.query_params.foo`), allowing backend attribute formatting to build nested maps without JSON parsing.
> 
> Adds `convertSearchParamsToOtelAttributes` to preserve repeated query keys as **ordered arrays** while keeping singletons as strings, and introduces a focused test suite covering duplicates, empty values, decoding, and custom prefixes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ddc1e02372c8540e8af71c6e855a3daad4f17703. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->