### PR TITLE
fix: parse JSON-string url.query_params in FormatAttributes

### DIFF
--- a/sdk/highlight-go/log/util.go
+++ b/sdk/highlight-go/log/util.go
@@ -238,6 +238,16 @@ func SubmitHTTPLog(ctx context.Context, tracer trace.Tracer, projectID int, lg L
 // parenKeySyntax matches a parenthesis pattern, i.e. `cs(Referrer)`
 var parenKeySyntax = regexp.MustCompile(`(.+)\((.+)\)`)
 
+// jsonExpansionAllowlist names attribute keys whose string values are expected
+// to be JSON-encoded objects/arrays and should be parsed and flattened, so the
+// resulting map keys (e.g. `url.query_params.foo`) round-trip through
+// flat.Unflatten on the read side. Keep this list small — every distinct
+// child key becomes a permanent entry in the ClickHouse
+// Map(LowCardinality(String), String) dictionary.
+var jsonExpansionAllowlist = map[string]bool{
+	"url.query_params": true,
+}
+
 func formatAttributes(k string, v interface{}, depth uint8) map[string]string {
 	if depth >= MaxLogAttributesDepth {
 		return nil
@@ -247,6 +257,14 @@ func formatAttributes(k string, v interface{}, depth uint8) map[string]string {
 	}
 	k = strings.ReplaceAll(k, " ", "_")
 	if vStr, ok := v.(string); ok {
+		if len(vStr) <= LogAttributeValueLengthLimit && jsonExpansionAllowlist[k] && looksLikeJSONObjectOrArray(vStr) {
+			var parsed interface{}
+			if err := json.Unmarshal([]byte(vStr), &parsed); err == nil {
+				if expanded := formatAttributes(k, parsed, depth+1); len(expanded) > 0 {
+					return expanded
+				}
+			}
+		}
 		if len(vStr) > LogAttributeValueLengthLimit {
 			vStr = vStr[:LogAttributeValueLengthLimit] + "..."
 		}
@@ -285,4 +303,18 @@ func formatAttributes(k string, v interface{}, depth uint8) map[string]string {
 
 func FormatAttributes(k string, v interface{}) map[string]string {
 	return formatAttributes(k, v, 0)
+}
+
+func looksLikeJSONObjectOrArray(s string) bool {
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case ' ', '\t', '\n', '\r':
+			continue
+		case '{', '[':
+			return true
+		default:
+			return false
+		}
+	}
+	return false
 }

--- a/sdk/highlight-go/log/util_test.go
+++ b/sdk/highlight-go/log/util_test.go
@@ -1,0 +1,60 @@
+package hlog
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFormatAttributes_JSONStringExpansionAllowlist(t *testing.T) {
+	got := FormatAttributes("url.query_params", `{"foo":"bar","baz":"qux"}`)
+	assert.Equal(t, map[string]string{
+		"url.query_params.foo": "bar",
+		"url.query_params.baz": "qux",
+	}, got)
+}
+
+func TestFormatAttributes_JSONStringNotInAllowlist(t *testing.T) {
+	raw := `{"foo":"bar"}`
+	got := FormatAttributes("http.request.body", raw)
+	assert.Equal(t, map[string]string{"http.request.body": raw}, got)
+}
+
+func TestFormatAttributes_NonJSONAllowlistedKey(t *testing.T) {
+	got := FormatAttributes("url.query_params", "not-json")
+	assert.Equal(t, map[string]string{"url.query_params": "not-json"}, got)
+}
+
+func TestFormatAttributes_InvalidJSONAllowlistedKey(t *testing.T) {
+	raw := `{"foo":`
+	got := FormatAttributes("url.query_params", raw)
+	assert.Equal(t, map[string]string{"url.query_params": raw}, got)
+}
+
+func TestFormatAttributes_LeadingWhitespaceJSON(t *testing.T) {
+	got := FormatAttributes("url.query_params", `   {"foo":"bar"}`)
+	assert.Equal(t, map[string]string{"url.query_params.foo": "bar"}, got)
+}
+
+func TestFormatAttributes_NestedJSONObjectInAllowlist(t *testing.T) {
+	got := FormatAttributes("url.query_params", `{"filter":{"id":"1"}}`)
+	assert.Equal(t, map[string]string{"url.query_params.filter.id": "1"}, got)
+}
+
+func TestFormatAttributes_PassesThroughForOtherTypes(t *testing.T) {
+	got := FormatAttributes("count", int64(7))
+	assert.Equal(t, map[string]string{"count": "7"}, got)
+
+	got = FormatAttributes("ratio", 1.5)
+	assert.Equal(t, map[string]string{"ratio": "1.5"}, got)
+
+	got = FormatAttributes("ok", true)
+	assert.Equal(t, map[string]string{"ok": "true"}, got)
+}
+
+func TestFormatAttributes_NestedMapStillFlattens(t *testing.T) {
+	got := FormatAttributes("a", map[string]interface{}{
+		"b": map[string]interface{}{"c": "d"},
+	})
+	assert.Equal(t, map[string]string{"a.b.c": "d"}, got)
+}


### PR DESCRIPTION
## Summary

- Backend-ingest complement to #517: when `hlog.FormatAttributes` sees a JSON-encoded string value for an allowlisted key, parse it and flatten into nested attributes (e.g. `url.query_params.foo`).
- Allowlist starts with just `url.query_params`. Every entry adds permanent keys to the ClickHouse `Map(LowCardinality(String), String)` dictionary, so it stays small.
- Older JS SDK versions in the wild and other SDKs (Node, Python, .NET, Android, Java) still send `url.query_params` as a JSON blob; this lets those clients also produce structured, queryable output without an SDK update.

## Test plan

- [x] `go test ./log/... -run TestFormatAttributes -v` (8 cases: allowlisted JSON expansion, allowlisted non-JSON pass-through, allowlisted malformed JSON pass-through, leading-whitespace tolerance, nested-object expansion, scalar types unaffected, non-allowlisted key not parsed)
- [x] `go vet ./log/...`
- [x] `gofmt -l` clean
- [x] Backend (`observability/backend`) builds clean against this branch via go.work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes log attribute normalization to parse and flatten JSON-encoded strings for allowlisted keys, which can alter emitted attribute keys and increase cardinality in storage. Scoped by an explicit allowlist and guarded parsing, but impacts ingestion/query behavior for those fields.
> 
> **Overview**
> `FormatAttributes` now detects JSON-looking *string* values for an explicit allowlist of keys (starting with `url.query_params`), parses them, and flattens the result into dotted child attributes (e.g. `url.query_params.foo`).
> 
> Adds `looksLikeJSONObjectOrArray` as a cheap pre-check and introduces tests covering allowlisted expansion, non-allowlisted pass-through, malformed/non-JSON handling, whitespace tolerance, nested objects, and unchanged behavior for other scalar/map types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 816822d468ef424914b99aeaef480a86017067c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->