### PR TITLE
fix: MAUI Android deploy on .net10 windows

### DIFF
--- a/sdk/@launchdarkly/mobile-dotnet/android/native/LDObserve/build.gradle.kts
+++ b/sdk/@launchdarkly/mobile-dotnet/android/native/LDObserve/build.gradle.kts
@@ -96,22 +96,46 @@ dependencies {
     "copyDependencies"("io.opentelemetry.android:android-agent:0.11.0-alpha")
 }
 
-// Custom task: merges all transitive JARs (OTel + okhttp + okio + ...) into one
-// fat JAR with META-INF/services concatenated per service name.
+// Custom task: merges all transitive JARs (OTel + okhttp + okio + ...) into a
+// single fat JAR containing class files, code resources, and a deduplicated
+// set of META-INF/services/* SPI registrations. The same merged services
+// are also emitted as standalone files on disk so the consumer-side MSBuild
+// target can re-inject them via @(FilesToAddToArchive) for .NET 10 builds.
 //
-// Why: .NET-for-Android 10 ships a new System.IO.Compression-based BuildArchive
+// Why a single fat JAR (rather than ~15 individual ones):
+// .NET-for-Android 10 ships a new System.IO.Compression-based BuildArchive
 // task (dotnet/android#9623) that, when collecting Java resources from
-// `<AndroidJavaLibrary>` items, silently skips any JAR entry whose `ArchivePath`
+// <AndroidJavaLibrary> items, silently skips any JAR entry whose ArchivePath
 // already exists in the APK. With ~15 OTel JARs shipped individually, several
-// `META-INF/services/*` paths overlap (e.g. ComponentProvider exists in
+// META-INF/services/* paths overlap (e.g. ComponentProvider exists in
 // opentelemetry-exporter-otlp, -exporter-logging, -exporter-logging-otlp), and
 // the unique HttpSenderProvider in opentelemetry-exporter-sender-okhttp gets
 // dropped along with them, breaking ServiceLoader at runtime with
 // "No HttpSenderProvider found on classpath".
 //
-// By collapsing every JAR into one, no two FilesToAddToArchive items share an
-// ArchivePath, and the merged services file is the single source of truth for
-// every SPI we ship. .NET 9 consumers behave identically (one JAR vs many).
+// By collapsing every JAR into one, the merged services file is the single
+// source of truth for every SPI we ship: each ArchivePath is unique within
+// the bundle JAR, so neither .NET 9's BuildApk nor .NET 10's BuildArchive
+// drops entries. .NET 9 consumers behave identically (one JAR vs many).
+//
+// Why META-INF/services/* IS kept inside the bundle JAR (and ALSO emitted
+// as standalone files on disk):
+// .NET-for-Android 9 ships the older BuildApk task, which extracts JAR
+// contents into the APK directly via its JavaLibraries parameter and does
+// NOT consume @(FilesToAddToArchive). The MSBuild-side _LDInjectMetaInfServices
+// target therefore is a no-op on .NET 9, and stripping services from the
+// bundle JAR meant ServiceLoader could not find HttpSenderProvider at
+// runtime. Putting the merged services back into the JAR restores the .NET 9
+// path while staying compatible with .NET 10:
+//   - .NET 9 BuildApk: extracts JAR services into META-INF/services/*.
+//   - .NET 10 CollectJarContentFilesForArchive: emits the same JAR services
+//     into @(FilesToAddToArchive) (auto-prefixing with `root/` for AAB so
+//     bundletool's XABAB0000 module-dir check is satisfied). The standalone
+//     injection contributes the same paths; BuildArchive silently dedupes
+//     by ArchivePath, so the two mechanisms coexist without error.
+// All OTHER META-INF/* entries (MANIFEST.MF, LICENSE, NOTICE, maven/*,
+// signature files, etc.) are stripped: they are not needed at runtime and
+// have historically caused noise/errors across .NET-for-Android versions.
 abstract class BundleOtelJarsTask : DefaultTask() {
     @get:org.gradle.api.tasks.InputFiles
     abstract val inputJars: org.gradle.api.file.ConfigurableFileCollection
@@ -119,15 +143,14 @@ abstract class BundleOtelJarsTask : DefaultTask() {
     @get:org.gradle.api.tasks.OutputFile
     abstract val outputJar: org.gradle.api.file.RegularFileProperty
 
-    // Directory that mirrors META-INF/services/* from the bundle JAR as plain
-    // files on disk. The .NET-for-Android packaging task hardcodes "META-INF"
-    // as a stripped folder when collecting JAR resources for the APK
-    // (PackagingUtils.CheckEntryForPackaging), so the merged service files
-    // inside the JAR never reach the final APK and ServiceLoader fails at
-    // runtime. By emitting them as standalone files we can re-add them to
-    // @(FilesToAddToArchive) in MSBuild *after* the strip-aware
-    // CollectJarContentFilesForArchive task runs, so BuildArchive (which does
-    // not filter on path) places them at META-INF/services/* in the APK.
+    // Directory containing the merged META-INF/services/* registrations as
+    // plain files on disk. These are emitted IN ADDITION to the same merged
+    // entries inside the bundle JAR (see the @TaskAction body). The
+    // standalone files exist to drive consumer-side MSBuild targets that
+    // inject them into @(FilesToAddToArchive) with the correct ArchivePath
+    // (META-INF/services/* for APK, root/META-INF/services/* for AAB) on
+    // .NET 10 builds. .NET 9 ignores @(FilesToAddToArchive) entirely and
+    // relies on the JAR-embedded copies instead.
     @get:org.gradle.api.tasks.OutputDirectory
     abstract val outputServicesDir: org.gradle.api.file.DirectoryProperty
 
@@ -150,16 +173,27 @@ abstract class BundleOtelJarsTask : DefaultTask() {
                     val entry = entries.nextElement()
                     if (entry.isDirectory) continue
                     val name = entry.name
-                    if (name == "META-INF/MANIFEST.MF") continue
-                    if (name.startsWith("META-INF/") &&
-                        (name.endsWith(".SF") || name.endsWith(".DSA") || name.endsWith(".RSA"))) continue
 
-                    if (name.startsWith("META-INF/services/")) {
-                        zip.getInputStream(entry).use { input ->
-                            val content = input.bufferedReader().readText()
-                            serviceFiles.getOrPut(name) { mutableListOf() }.add(content)
+                    // Capture META-INF/services/* contents so we can both
+                    // (a) re-emit a single merged copy back into the bundle
+                    // JAR (so .NET 9's BuildApk extracts SPI registrations
+                    // into the APK) and (b) write standalone files for the
+                    // .NET 10 MSBuild injection path. Strip every other
+                    // META-INF/* entry (MANIFEST.MF, LICENSE, NOTICE,
+                    // maven/*, signature files): they're not needed at
+                    // runtime and have historically caused noise/errors
+                    // across .NET-for-Android versions.
+                    if (name.startsWith("META-INF/")) {
+                        if (name.startsWith("META-INF/services/")) {
+                            zip.getInputStream(entry).use { input ->
+                                val content = input.bufferedReader().readText()
+                                serviceFiles.getOrPut(name) { mutableListOf() }.add(content)
+                            }
                         }
-                    } else if (!classOrResourceEntries.containsKey(name)) {
+                        continue
+                    }
+
+                    if (!classOrResourceEntries.containsKey(name)) {
                         zip.getInputStream(entry).use { input ->
                             classOrResourceEntries[name] = input.readBytes()
                         }
@@ -168,47 +202,78 @@ abstract class BundleOtelJarsTask : DefaultTask() {
             }
         }
 
+        // Merge once, write twice: the same content goes into both the
+        // bundle JAR and the standalone files on disk.
+        val mergedServiceFiles = serviceFiles.mapValues { (_, contents) ->
+            contents
+                .flatMap { it.lineSequence() }
+                .map { it.trim() }
+                .filter { it.isNotEmpty() && !it.startsWith("#") }
+                .distinct()
+                .joinToString("\n") + "\n"
+        }
+
+        // Standalone files: consumed by the .NET 10 _LDInjectMetaInfServices
+        // MSBuild target which re-adds them via @(FilesToAddToArchive) with
+        // the correct ArchivePath (META-INF/services/* for APK,
+        // root/META-INF/services/* for AAB).
+        mergedServiceFiles.forEach { (path, merged) ->
+            val serviceName = path.removePrefix("META-INF/services/")
+            File(servicesDir, serviceName).writeText(merged)
+        }
+
         ZipOutputStream(out.outputStream().buffered()).use { zout ->
             zout.putNextEntry(ZipEntry("META-INF/MANIFEST.MF"))
             zout.write("Manifest-Version: 1.0\nCreated-By: ldobserve-otel-bundle\n".toByteArray())
             zout.closeEntry()
-
-            serviceFiles.forEach { (path, contents) ->
-                val merged = contents
-                    .flatMap { it.lineSequence() }
-                    .map { it.trim() }
-                    .filter { it.isNotEmpty() && !it.startsWith("#") }
-                    .distinct()
-                    .joinToString("\n") + "\n"
-                zout.putNextEntry(ZipEntry(path))
-                zout.write(merged.toByteArray())
-                zout.closeEntry()
-
-                // Also write the merged service file as a standalone file so
-                // MSBuild can pick it up and inject it into the APK directly.
-                // Strip the "META-INF/services/" prefix; the consumer-side
-                // target re-applies it as ArchivePath.
-                val serviceName = path.removePrefix("META-INF/services/")
-                File(servicesDir, serviceName).writeText(merged)
-            }
 
             classOrResourceEntries.forEach { (name, data) ->
                 zout.putNextEntry(ZipEntry(name))
                 zout.write(data)
                 zout.closeEntry()
             }
+
+            // Embed the same merged services inside the JAR. .NET 9's
+            // BuildApk task extracts JAR contents directly into the APK
+            // (it ignores @(FilesToAddToArchive)), so without these
+            // entries ServiceLoader fails at runtime with
+            // "No HttpSenderProvider found on classpath" on .NET 9 builds.
+            // Each path is unique within the bundle JAR (see the per-path
+            // dedup above), so .NET 10's BuildArchive does not lose any
+            // SPI registrations either; if its CollectJarContentFilesForArchive
+            // also produces an entry at the same ArchivePath as the standalone
+            // injection, BuildArchive silently skips the duplicate.
+            mergedServiceFiles.forEach { (path, merged) ->
+                zout.putNextEntry(ZipEntry(path))
+                zout.write(merged.toByteArray())
+                zout.closeEntry()
+            }
         }
 
         logger.lifecycle(
             "ldobserve-otel-bundle: ${classOrResourceEntries.size} class/resource entries, " +
-                "${serviceFiles.size} merged service files, ${inputJars.files.size} input JARs"
+                "${mergedServiceFiles.size} merged service files (in-JAR + standalone), " +
+                "${inputJars.files.size} input JARs"
         )
     }
 }
 
 project.afterEvaluate {
     val observabilityBuild = gradle.includedBuild("observability-android")
-    val observabilityAarDir = File(observabilityBuild.projectDir, "lib/build/outputs/aar")
+    // Mirror this project's buildDir relative path onto the included build's
+    // `lib` module. The .NET-for-Android NLI BuildTasks invoke gradle with
+    // `-Dorg.gradle.project.buildDir=bin/<Configuration>/<TFM>`, a system
+    // property that Gradle applies to *every* project in the build — both
+    // LDObserve and the included observability-android build. Hardcoding
+    // `lib/build/outputs/aar` would miss the relocated AAR (e.g.
+    // `lib/bin/Release/net9.0-android/outputs/aar/lib-release.aar`) under
+    // MSBuild/NLI, so the Sync below would silently produce zero matches and
+    // MSBuild later fails MSB3030 copying the missing `lib-release.aar`.
+    // Direct `./gradlew` invocations keep the default `build` value and the
+    // path collapses to `lib/build/outputs/aar` as before.
+    val relativeBuildDir = layout.buildDirectory.get().asFile
+        .relativeTo(projectDir).invariantSeparatorsPath
+    val observabilityAarDir = File(observabilityBuild.projectDir, "lib/$relativeBuildDir/outputs/aar")
     val depsDir = layout.buildDirectory.dir("outputs/deps").get().asFile
     val bundleStaging = layout.buildDirectory.dir("tmp/ldobserve-otel-bundle").get().asFile
 

--- a/sdk/@launchdarkly/mobile-dotnet/android/native/build.gradle.kts
+++ b/sdk/@launchdarkly/mobile-dotnet/android/native/build.gradle.kts
@@ -1,5 +1,5 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     id("com.android.library") apply false
-    id("org.jetbrains.kotlin.android") version "2.2.0" apply false
+    id("org.jetbrains.kotlin.android") version "2.0.21" apply false
 }

--- a/sdk/@launchdarkly/mobile-dotnet/observability/Directory.Build.props
+++ b/sdk/@launchdarkly/mobile-dotnet/observability/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 	<PropertyGroup>
 		<PackageId>LaunchDarkly.SessionReplay</PackageId>
-		<Version>0.9.14</Version>
+		<Version>0.9.17</Version>
 		<UseLocalClientSdk>false</UseLocalClientSdk>
 		<Authors>LaunchDarkly</Authors>
 		<Owners>LaunchDarkly</Owners>

--- a/sdk/@launchdarkly/mobile-dotnet/observability/NativeAndroidDeps.props
+++ b/sdk/@launchdarkly/mobile-dotnet/observability/NativeAndroidDeps.props
@@ -41,33 +41,47 @@
 
 		<!--
 			Single fat JAR produced by the LDObserve native module's `bundleOtelJars`
-			Gradle task. It bundles every transitive OTel + okhttp + okio JAR with
-			META-INF/services entries merged per service name.
+			Gradle task. It bundles every transitive OTel + okhttp + okio JAR's
+			class files and code resources, plus a deduplicated, merged copy of
+			`META-INF/services/*` SPI registrations. All other `META-INF/*`
+			entries (MANIFEST.MF, LICENSE, NOTICE, maven/*, signature files)
+			are stripped.
 
-			One JAR (instead of ~15 individual ones) avoids two .NET-for-Android 10
-			packaging hazards:
-			  1. `BuildArchive` drops jar-extracted entries whose `ArchivePath` is
-			     already present in the APK, so overlapping `META-INF/services/*`
-			     paths from sibling JARs would race and lose entries.
-			  2. `CollectJarContentFilesForArchive` calls
-			     `PackagingUtils.CheckEntryForPackaging`, which hardcodes the
-			     entire `META-INF/` folder as stripped — so even with a single
-			     bundle JAR, services files inside the JAR never reach the APK.
-			     We work around (2) below with `_LDNativeMetaInfService`.
+			One JAR (instead of ~15 individual ones) avoids the .NET-for-Android
+			10 hazard where `BuildArchive` drops jar-extracted entries whose
+			`ArchivePath` is already present in the APK: overlapping
+			`META-INF/services/*` paths across sibling JARs would race and lose
+			entries (including the unique HttpSenderProvider in
+			opentelemetry-exporter-sender-okhttp).
+
+			`META-INF/services/*` IS kept inside the JAR — once merged,
+			each path is unique within the bundle, so neither .NET 9's BuildApk
+			nor .NET 10's BuildArchive drops entries:
+			  - .NET 9: BuildApk extracts JAR contents directly into the APK
+			    (it does NOT consume `@(FilesToAddToArchive)`), so the JAR
+			    copy is the only way `ServiceLoader` can find the SPI
+			    registrations on this version.
+			  - .NET 10: `CollectJarContentFilesForArchive` extracts the JAR
+			    services into `@(FilesToAddToArchive)`, auto-prefixing with
+			    `root/` for AAB so bundletool's XABAB0000 module-dir check
+			    is satisfied. If the standalone-file injection (see
+			    `_LDNativeMetaInfService` below) produces the same path,
+			    BuildArchive silently dedupes.
 		-->
 		<_LDNativeJAR Include="$(_LDNativeDepsDir)ldobserve-otel-bundle.jar" />
 
 		<!--
 			Standalone copies of the merged `META-INF/services/*` files produced
-			by the same `bundleOtelJars` task. We can't rely on
-			`<AndroidJavaLibrary>` to surface these because
-			`PackagingUtils.CheckEntryForPackaging` strips every JAR entry whose
-			path begins with `META-INF/`. Instead, the consumer-side targets
-			inject these files directly into `@(FilesToAddToArchive)` after
-			`CollectJarContentFilesForArchive` runs, so `BuildArchive` (which
-			does not filter on path) places them at `META-INF/services/*` in
-			the APK and ServiceLoader can find e.g.
-			`io.opentelemetry.exporter.sender.okhttp.internal.OkHttpHttpSenderProvider`.
+			by the same `bundleOtelJars` task. Used by the consumer-side
+			`_LDInjectMetaInfServices` MSBuild target on .NET 10 builds to add
+			the registrations to `@(FilesToAddToArchive)` with the correct
+			`ArchivePath` (`META-INF/services/*` for APK,
+			`root/META-INF/services/*` for AAB). This injection is a no-op on
+			.NET 9 (the older `BuildApk` task ignores `@(FilesToAddToArchive)`)
+			and is redundant on current .NET 10 builds because the same
+			services are also embedded in the bundle JAR; it remains as a
+			defensive fallback for older .NET 10 SDKs whose BuildArchive
+			stripped `META-INF/` from extracted JARs.
 		-->
 		<_LDNativeMetaInfService Include="$(_LDNativeDepsDir)META-INF\services\*" />
 	</ItemGroup>

--- a/sdk/@launchdarkly/mobile-dotnet/observability/buildTransitive/LDObservability.Fat.targets
+++ b/sdk/@launchdarkly/mobile-dotnet/observability/buildTransitive/LDObservability.Fat.targets
@@ -11,23 +11,23 @@
 	</ItemGroup>
 
 	<!--
-		Re-inject the OTel `META-INF/services/*` registrations into the APK / AAB.
+		Re-inject the OTel `META-INF/services/*` registrations into the APK / AAB
+		on .NET 10 builds. This is a no-op on .NET 9 (the older `BuildApk` task
+		does not consume `@(FilesToAddToArchive)`); .NET 9 instead relies on
+		the same merged registrations being embedded inside the bundle JAR,
+		which `BuildApk` extracts directly into the APK.
 
-		.NET-for-Android's `CollectJarContentFilesForArchive` task calls
-		`PackagingUtils.CheckEntryForPackaging`, which hardcodes the entire
-		`META-INF/` folder as a stripped path when extracting JAR resources for
-		the APK (alongside `.svn`, `SCCS`, `picasa.ini`, etc.). As a result,
-		the merged service registrations inside `ldobserve-otel-bundle.jar`
-		never reach the final APK and `java.util.ServiceLoader` cannot find
-		`io.opentelemetry.exporter.sender.okhttp.internal.OkHttpHttpSenderProvider`,
-		causing `OtlpHttpSpanExporterBuilder.build()` to throw
-		`No HttpSenderProvider found on classpath`.
-
-		`BuildArchive` itself does not filter on path — it just copies every
+		`BuildArchive` (.NET 10) does not filter on path — it just copies every
 		`@(FilesToAddToArchive)` item to its `ArchivePath`. We append the
 		standalone service files (shipped alongside the bundle JAR in
 		runtimes/android/native/META-INF/services/) to that item group before
-		`_BuildApkEmbed` runs, sidestepping the strip.
+		`_BuildApkEmbed` runs, so `ServiceLoader` can find
+		`io.opentelemetry.exporter.sender.okhttp.internal.OkHttpHttpSenderProvider`
+		at runtime and `OtlpHttpSpanExporterBuilder.build()` doesn't throw
+		`No HttpSenderProvider found on classpath` even when an older .NET 10
+		BuildArchive variant strips `META-INF/` from extracted JARs. When the
+		same paths are produced by both this injection and the JAR's own
+		entries, BuildArchive silently dedupes by ArchivePath.
 
 		Important: the destination prefix differs by `$(AndroidPackageFormat)`.
 		  - APK ('apk'): files go straight to `META-INF/services/*`.
@@ -39,13 +39,19 @@
 		    place the files at `root/META-INF/services/*`; bundletool relocates
 		    everything under `root/` back to the APK root at install time, so
 		    the runtime ServiceLoader still sees `META-INF/services/*`.
+
+		The `AndroidPackageFormat` comparison is normalized via
+		`ToLowerInvariant()` so the `root/` prefix is applied for AAB builds
+		regardless of how the property is cased (mirrors the
+		`StringComparison.InvariantCultureIgnoreCase` check used by
+		`CollectJarContentFilesForArchive`).
 	-->
 	<Target Name="_LDInjectMetaInfServices"
 	        BeforeTargets="_BuildApkEmbed;_BuildApkFastDev"
 	        Condition="$(TargetFramework.Contains('android'))">
 		<PropertyGroup>
-			<_LDArchiveMetaInfPrefix Condition="'$(AndroidPackageFormat)' == 'aab'">root/META-INF/services</_LDArchiveMetaInfPrefix>
-			<_LDArchiveMetaInfPrefix Condition="'$(AndroidPackageFormat)' != 'aab'">META-INF/services</_LDArchiveMetaInfPrefix>
+			<_LDArchiveMetaInfPrefix Condition="'$(AndroidPackageFormat.ToLowerInvariant())' == 'aab'">root/META-INF/services</_LDArchiveMetaInfPrefix>
+			<_LDArchiveMetaInfPrefix Condition="'$(AndroidPackageFormat.ToLowerInvariant())' != 'aab'">META-INF/services</_LDArchiveMetaInfPrefix>
 		</PropertyGroup>
 		<ItemGroup>
 			<_LDInjectedMetaInfService Include="$(MSBuildThisFileDirectory)../runtimes/android/native/META-INF/services/*" />


### PR DESCRIPTION
## Summary

Repackaging META-INF/services/ files in combined JAR to keep compatibility with .net9 and .net10 on Windows

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Gradle/MSBuild packaging logic for Android (fat-JAR bundling, META-INF handling, and included-build output paths), which can easily break build/deploy if paths or resource dedupe behavior differ across .NET/Gradle versions.
> 
> **Overview**
> Fixes Android MAUI deploy issues by changing the OTel fat-JAR bundling to **merge and keep** `META-INF/services/*` inside `ldobserve-otel-bundle.jar` *and* also emit the merged files as standalone disk artifacts for the .NET 10 `@(FilesToAddToArchive)` injection path, while stripping all other `META-INF/*` entries.
> 
> Updates the Gradle sync logic to locate the included `observability-android` `lib-release.aar` under relocated `buildDir` paths used by MSBuild/NLI, and hardens the .NET packaging targets by making the AAB/APK `AndroidPackageFormat` check case-insensitive. Also downgrades the Android Kotlin Gradle plugin version and bumps the NuGet package version to `0.9.17`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2df6316a78c4907963fb43262a4b9f8237a0565. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->