### PR TITLE
feat(android): add features needed for react native android session replay masking

### DIFF
--- a/sdk/@launchdarkly/observability-android/README.md
+++ b/sdk/@launchdarkly/observability-android/README.md
@@ -303,7 +303,7 @@ val sessionReplay = SessionReplay(
 Notes:
 - `maskViews` matches on `target.view.javaClass` equality (exact class only).
 - `maskWebViews` uses a default list of WebView class names for masking (and still allows subclasses), including AndroidView-hosted views inside Compose.
-- `maskXMLViewIds` applies only to Views with a non-`View.NO_ID` id that resolves to a resource entry name.
+- `maskXMLViewIds` and `unmaskXMLViewIds` apply to Views with a non-`View.NO_ID` id that resolves to a resource entry name. When the React Native library is on the runtime classpath, they also match the value of the `react_test_id` tag — i.e. the JS `testID` prop on RN-rendered views.
 
 ##### XML Views
 

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/PrivacyProfile.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/PrivacyProfile.kt
@@ -31,10 +31,13 @@ private fun List<String>.normalizeXmlIds(): Set<String> = map {
  * @param maskImageViews Set to true to mask [ImageView] targets by exact class match.
  * @param maskViews Additional Views to mask by exact class match (see [viewsMatcher]).
  * @param maskXMLViewIds Additional Views to mask by resource entry name (see [xmlViewIdsMatcher]).
- * accepts `"@+id/foo"`, `"@id/foo"`, or `"foo"`.
+ * accepts `"@+id/foo"`, `"@id/foo"`, or `"foo"`. When the React Native library is on the runtime
+ * classpath, this list is also matched against the React Native `testID` prop, which RN stores in
+ * `com.facebook.react.R.id.react_test_id` on each view.
  * @param unmaskXMLViewIds Views whose resource entry name appears in this list are explicitly
- * *unmasked* (see [unmaskXMLViewIdsMatcher]). Same id format as [maskXMLViewIds]. Takes precedence
- * over global masking rules — see `MaskCollector` for the full precedence rules.
+ * *unmasked* (see [unmaskXMLViewIdsMatcher]). Same id format and same React Native `testID`
+ * support as [maskXMLViewIds]. Takes precedence over global masking rules — see `MaskCollector`
+ * for the full precedence rules.
  * @param maskWebViews Set to true to mask known WebView types and their subclasses
  * (e.g., "android.webkit.WebView", "org.mozilla.geckoview.GeckoView", etc).
  * @param maskBySemanticsKeywords Set to true to enable masking of "sensitive" targets detected by
@@ -88,11 +91,28 @@ data class PrivacyProfile(
     }
 
     /**
-     * Builds a [MaskMatcher] that matches targets whose underlying Android View has a non-
-     * [View.NO_ID] id whose resource entry name (per `resources.getResourceEntryName(view.id)`)
-     * appears in [idSet].
+     * Matches targets whose underlying Android View has an id (or React Native `testID`) included
+     * in [maskXMLViewIds].
      *
-     * @param idSet set of normalized resource entry names to match against.
+     * Two lookups are performed against the same configured set:
+     *  - `resources.getResourceEntryName(view.id)` — applies to Views with a non-[View.NO_ID] id
+     *    that resolves to a resource entry.
+     *  - The value stored in `com.facebook.react.R.id.react_test_id` on the View, if React Native
+     *    is on the runtime classpath. RN's framework writes the JS `testID` prop into that tag.
+     */
+    internal val xmlViewIdsMatcher: MaskMatcher = xmlIdMatcher(maskXMLViewIdSet)
+
+    /**
+     * Matches targets whose underlying Android View has an id (or React Native `testID`) included
+     * in [unmaskXMLViewIds]. Counterpart to [xmlViewIdsMatcher] — same lookup, different set.
+     */
+    internal val unmaskXMLViewIdsMatcher: MaskMatcher = xmlIdMatcher(unmaskXMLViewIdSet)
+
+    /**
+     * Builds a [MaskMatcher] that checks whether a target view's XML resource entry name or
+     * React Native test id (when RN is on the runtime classpath) appears in [idSet].
+     *
+     * @param idSet the set of normalized identifiers to match against.
      */
     private fun xmlIdMatcher(idSet: Set<String>): MaskMatcher = object : MaskMatcher {
         fun View.idNameOrNull(): String? =
@@ -100,25 +120,16 @@ data class PrivacyProfile(
             else runCatching { resources.getResourceEntryName(id) }.getOrNull()
 
         override fun isMatch(target: MaskTarget): Boolean {
-            val id = target.view.idNameOrNull() ?: return false
-            return idSet.contains(id)
+            val view = target.view
+            view.idNameOrNull()?.let { if (idSet.contains(it)) return true }
+            reactTestIdResId?.let { resId ->
+                (view.getTag(resId) as? String)?.let { testId ->
+                    if (idSet.contains(testId)) return true
+                }
+            }
+            return false
         }
     }
-
-    /**
-     * Matches targets whose underlying Android View's resource entry name is included in
-     * [maskXMLViewIds].
-     *
-     * IDs are compared using `resources.getResourceEntryName(view.id)`, so this only applies to
-     * Views with a non-[View.NO_ID] id that resolves to a resource entry.
-     */
-    internal val xmlViewIdsMatcher: MaskMatcher = xmlIdMatcher(maskXMLViewIdSet)
-
-    /**
-     * Matches targets whose underlying Android View's resource entry name is included in
-     * [unmaskXMLViewIds]. Same id resolution as [xmlViewIdsMatcher].
-     */
-    internal val unmaskXMLViewIdsMatcher: MaskMatcher = xmlIdMatcher(unmaskXMLViewIdSet)
 
     /**
      * This matcher will match most text inputs, but there may be special cases where it will
@@ -272,5 +283,18 @@ data class PrivacyProfile(
             "com.tencent.smtt.sdk.WebView",
             "com.uc.webview.export.WebView",
         )
+
+        /**
+         * Resource id of the `react_test_id` tag, where React Native stores the JS `testID` prop on
+         * each view. Resolved reflectively to avoid a compile-time dependency on React Native;
+         * `null` when the RN library isn't on the classpath.
+         */
+        internal val reactTestIdResId: Int? by lazy {
+            runCatching {
+                Class.forName("com.facebook.react.R\$id")
+                    .getField("react_test_id")
+                    .getInt(null)
+            }.getOrNull()
+        }
     }
 }

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/PrivacyProfile.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/PrivacyProfile.kt
@@ -28,7 +28,7 @@ private fun List<String>.normalizeXmlIds(): Set<String> = map {
  *
  * @param maskTextInputs Set to false to disable masking text input targets.
  * @param maskText Set to false to disable masking text targets.
- * @param maskImageViews Set to true to mask [ImageView] targets by exact class match.
+ * @param maskImageViews Set to true to mask [ImageView] targets.
  * @param maskViews Additional Views to mask by exact class match (see [viewsMatcher]).
  * @param maskXMLViewIds Additional Views to mask by resource entry name (see [xmlViewIdsMatcher]).
  * accepts `"@+id/foo"`, `"@id/foo"`, or `"foo"`. When the React Native library is on the runtime
@@ -56,7 +56,6 @@ data class PrivacyProfile(
 ) {
     private val viewClassSet = buildSet {
         addAll(maskViews.map { it.clazz })
-        if (maskImageViews) add(ImageView::class.java)
     }
 
     private val webViewClassNameSet = if (maskWebViews) webViewClassNames.toSet() else emptySet()
@@ -72,6 +71,15 @@ data class PrivacyProfile(
     internal val viewsMatcher: MaskMatcher = object : MaskMatcher {
         override fun isMatch(target: MaskTarget): Boolean {
             return viewClassSet.contains(target.view.javaClass)
+        }
+    }
+
+    /**
+     * Matches targets whose underlying Android View is an [ImageView].
+     */
+    internal val imageViewMatcher: MaskMatcher = object : MaskMatcher {
+        override fun isMatch(target: MaskTarget): Boolean {
+            return target.view is ImageView
         }
     }
 
@@ -203,6 +211,7 @@ data class PrivacyProfile(
         // Prefer cheaper checks first; heavier checks should be later.
         if (maskTextInputs) add(textInputMatcher)
         if (maskText) add(textMatcher)
+        if (maskImageViews) add(imageViewMatcher)
         if (viewClassSet.isNotEmpty()) add(viewsMatcher)
         if (maskBySemanticsKeywords) add(sensitiveMatcher)
         if (webViewClassNameSet.isNotEmpty()) add(webViewClassHierarchyMatcher)

--- a/sdk/@launchdarkly/observability-android/lib/src/test/kotlin/com/launchdarkly/observability/replay/PrivacyProfileTest.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/test/kotlin/com/launchdarkly/observability/replay/PrivacyProfileTest.kt
@@ -1,6 +1,5 @@
 package com.launchdarkly.observability.replay
 
-import android.widget.ImageView
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -84,23 +83,17 @@ class PrivacyProfileTest {
     }
 
     @Test
-    fun `maskImageViews adds ImageView to viewClassSet and includes viewsMatcher even when maskViews is empty`() {
+    fun `maskImageViews true adds imageViewMatcher to global matchers`() {
         val profile = PrivacyProfile(maskImageViews = true, maskViews = emptyList())
 
-        assertTrue(profile.globalMaskMatchers.contains(profile.viewsMatcher))
-
-        val viewClassSet = profile.getPrivateSet("viewClassSet")
-        assertTrue(viewClassSet.contains(ImageView::class.java))
+        assertTrue(profile.globalMaskMatchers.contains(profile.imageViewMatcher))
     }
 
     @Test
-    fun `maskImageViews false does not add ImageView to viewClassSet and does not include viewsMatcher when maskViews is empty`() {
+    fun `maskImageViews false does not include imageViewMatcher in global matchers`() {
         val profile = PrivacyProfile(maskImageViews = false, maskViews = emptyList())
 
-        assertFalse(profile.globalMaskMatchers.contains(profile.viewsMatcher))
-
-        val viewClassSet = profile.getPrivateSet("viewClassSet")
-        assertFalse(viewClassSet.contains(ImageView::class.java))
+        assertFalse(profile.globalMaskMatchers.contains(profile.imageViewMatcher))
     }
 
     @Test


### PR DESCRIPTION
## Summary

Two related fixes to the Android session replay SDK to make masking work correctly with React Native views:
1. `maskXMLViewIds` and `unmaskXMLViewIds` now also match the value of the `react_test_id` tag (RN's `testID` prop) when the React Native library is on the runtime classpath. Resolved reflectively so the SDK has no compile-time RN dependency.
3. `maskImageViews` now catches ImageView subclasses (notably RN's `ReactImageView`) instead of only the exact `android.widget.ImageView` class.

## How did you test this change?

Tested with PR #528 using the example app and capturing a session replay.

## Are there any deployment considerations?

N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates session replay masking matchers, which can change what UI is captured vs masked (privacy-sensitive) and could cause over/under-masking in apps, especially with mixed native/RN view hierarchies.
> 
> **Overview**
> Improves `PrivacyProfile` masking to work with React Native-rendered views by having `maskXMLViewIds`/`unmaskXMLViewIds` also match RN’s `testID` via the `react_test_id` view tag (resolved reflectively to avoid an RN dependency).
> 
> Updates `maskImageViews` to mask *all* `ImageView` instances (including subclasses) by introducing an `imageViewMatcher` instead of relying on exact-class matching, and refreshes docs/tests to reflect the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65f2af5f70c90103f192b96c230030bd6a5f3c8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->