### PR TITLE
feat: forward LD context keys to errors, logs, and custom spans

### DIFF
--- a/sdk/highlight-run/src/__tests__/sdk.test.ts
+++ b/sdk/highlight-run/src/__tests__/sdk.test.ts
@@ -223,5 +223,155 @@ describe('SDK', () => {
 				undefined,
 			)
 		})
+
+		describe('LD context keys propagation', () => {
+			const mockTracer = (span: any) => {
+				const tracer = {
+					startActiveSpan: vi.fn((_name: string, ...args: any[]) => {
+						const callback = args[args.length - 1]
+						return callback(span)
+					}),
+				}
+				vi.spyOn(otel, 'getTracer').mockReturnValue(tracer as any)
+				return tracer
+			}
+
+			const makeSpan = () => ({
+				setAttributes: vi.fn(),
+				setAttribute: vi.fn(),
+				addEvent: vi.fn(),
+				recordException: vi.fn(),
+				setStatus: vi.fn(),
+				end: vi.fn(),
+				spanContext: vi.fn(() => ({
+					traceId: 'trace',
+					spanId: 'span',
+					traceFlags: 1,
+				})),
+				updateName: vi.fn(),
+				isRecording: vi.fn(() => true),
+			})
+
+			it('attaches context keys to error span attributes', () => {
+				const span = makeSpan()
+				mockTracer(span)
+
+				observeImpl.setLDContextKeyAttributes({
+					pathTemplate: '/projects/:projectKey/flags',
+					owner: 'team-fm-foundations',
+				})
+
+				observeImpl.recordError(new Error('boom'), 'oops', {
+					errorCode: 'E123',
+				})
+
+				// First call: contextKeys injected by the startSpan wrapper.
+				expect(span.setAttributes).toHaveBeenNthCalledWith(1, {
+					'context.contextKeys.pathTemplate':
+						'/projects/:projectKey/flags',
+					'context.contextKeys.owner': 'team-fm-foundations',
+				})
+				// Second call: error-specific attributes from _recordErrorMessage.
+				expect(span.setAttributes).toHaveBeenNthCalledWith(
+					2,
+					expect.objectContaining({
+						event: expect.stringContaining('oops'),
+						errorCode: 'E123',
+					}),
+				)
+			})
+
+			it('caller payload wins over context keys with the same name', () => {
+				const span = makeSpan()
+				mockTracer(span)
+
+				observeImpl.setLDContextKeyAttributes({ owner: 'team-a' })
+
+				observeImpl.recordError(new Error('boom'), 'oops', {
+					'context.contextKeys.owner': 'team-override',
+				})
+
+				// Second setAttributes call wins on the wire because OTel
+				// merges with last-write-wins semantics for matching keys.
+				expect(span.setAttributes).toHaveBeenLastCalledWith(
+					expect.objectContaining({
+						'context.contextKeys.owner': 'team-override',
+					}),
+				)
+			})
+
+			it('attaches context keys to log addEvent attributes', () => {
+				const span = makeSpan()
+				mockTracer(span)
+
+				observeImpl.setLDContextKeyAttributes({
+					pathTemplate: '/login',
+				})
+
+				observeImpl.recordLog('hello world', 'info', {
+					traceId: 'tid',
+				})
+
+				expect(span.addEvent).toHaveBeenCalledWith(
+					'log',
+					expect.objectContaining({
+						'context.contextKeys.pathTemplate': '/login',
+						traceId: 'tid',
+					}),
+				)
+			})
+
+			it('caller metadata wins over context keys on logs', () => {
+				const span = makeSpan()
+				mockTracer(span)
+
+				observeImpl.setLDContextKeyAttributes({
+					pathTemplate: '/login',
+				})
+
+				observeImpl.recordLog('hello', 'info', {
+					'context.contextKeys.pathTemplate': '/override',
+				})
+
+				expect(span.addEvent).toHaveBeenCalledWith(
+					'log',
+					expect.objectContaining({
+						'context.contextKeys.pathTemplate': '/override',
+					}),
+				)
+			})
+
+			it('attaches context keys to user-created spans via startSpan', () => {
+				const span = makeSpan()
+				mockTracer(span)
+
+				observeImpl.setLDContextKeyAttributes({
+					pathTemplate: '/projects/:projectKey/flags',
+					accountId: 'acct-123',
+				})
+
+				observeImpl.startSpan('user.custom.span', (s) => {
+					s?.setAttribute('foo', 'bar')
+				})
+
+				expect(span.setAttributes).toHaveBeenCalledWith({
+					'context.contextKeys.pathTemplate':
+						'/projects/:projectKey/flags',
+					'context.contextKeys.accountId': 'acct-123',
+				})
+				// Caller's setAttribute call is also issued.
+				expect(span.setAttribute).toHaveBeenCalledWith('foo', 'bar')
+			})
+
+			it('does not call setAttributes when no context keys are set', () => {
+				const span = makeSpan()
+				mockTracer(span)
+
+				observeImpl.startSpan('user.custom.span', () => {})
+
+				// startSpan should not inject anything when contextKeys are unset.
+				expect(span.setAttributes).not.toHaveBeenCalled()
+			})
+		})
 	})
 })

--- a/sdk/highlight-run/src/sdk/observe.ts
+++ b/sdk/highlight-run/src/sdk/observe.ts
@@ -247,6 +247,7 @@ export class ObserveSDK implements Observe {
 				[ATTR_LOG_SEVERITY]: level,
 				[ATTR_LOG_MESSAGE]: msg,
 				'code.stacktrace': stackTrace,
+				...(this._ldContextKeys ?? {}),
 				...metadata,
 			})
 			if (this._options.reportConsoleErrors && level === 'error') {
@@ -299,6 +300,8 @@ export class ObserveSDK implements Observe {
 			recordException(span, errorMsg.error ?? new Error(errorMsg.event), {
 				[ATTR_EXCEPTION_ID]: errorMsg.id,
 			})
+			// LD context keys are applied to the span by the startSpan
+			// wrapper above; only the error-specific attributes are added here.
 			span?.setAttributes({
 				event: errorMsg.event,
 				type: errorMsg.type,
@@ -451,6 +454,11 @@ export class ObserveSDK implements Observe {
 		}
 
 		const wrapCallback = (span: Span, callback: (span: Span) => any) => {
+			// Apply LD context keys before invoking the caller so any
+			// span.setAttributes the caller makes wins on key collisions.
+			if (this._ldContextKeys) {
+				span.setAttributes(this._ldContextKeys)
+			}
 			const result = callback(span)
 			if (result instanceof Promise) {
 				return result.finally(() => span.end())


### PR DESCRIPTION
## Summary

- Spread `_ldContextKeys` (set via `LDObserve.setLDContextKeyAttributes`) into all OTel data types where it makes semantic sense, not just metrics.
- `startSpan` wrapper now applies contextKeys to every span before invoking the caller, so user-created custom spans inherit `pathTemplate` / `owner` / `account` / route attributes automatically. Caller `setAttributes` calls win on key collisions (OTel merges with last-write-wins).
- `_recordLog` spreads contextKeys into the `addEvent('log', …)` payload so log events carry the same dimensions as their containing span.
- `_recordErrorMessage` no longer needs an explicit spread because the `startSpan` wrapper handles it; comment added at the call site.

## Why

Previously `_ldContextKeys` only flowed into `recordCount` / `recordGauge` / `recordHistogram` / `recordUpDownCounter` (#510 / commit `e49d4812f`), so error, log, and custom-span queries could not group by team or route. This meant LD Observability dashboards couldn't replicate Datadog RUM's per-team and per-route error and log breakdowns. After this change, queries like `errors group_by context.contextKeys.pathTemplate` and `logs group_by context.contextKeys.owner` produce real values, closing the last big gap relative to the Datadog frontend-errors dashboard.

## Coverage matrix

| Data type | Before | After |
|---|---|---|
| Counter / Gauge / Histogram / UpDownCounter metric | ✅ | ✅ |
| Click / page-view / user-interaction spans | ✅ | ✅ |
| Errors (`recordError` / `_recordErrorMessage`) | ❌ | ✅ (via `startSpan` wrapper) |
| Logs (`_recordLog` `addEvent`) | ❌ | ✅ |
| Custom spans created via `startSpan` | ❌ | ✅ |

## Test plan

- [x] `yarn vitest run src/__tests__/sdk.test.ts` — 14/14 passing locally
  - new tests cover: error span attrs, log addEvent attrs, custom span attrs, override semantics, no-context-keys no-op
- [x] `yarn turbo run build --filter '@launchdarkly/observability'` — clean build
- [x] `yarn format-check` — passes
- [ ] Verify in catfood: queries on `errors` / `logs` grouped by `context.contextKeys.pathTemplate` / `owner` / `accountId` populate after a gonfalon SDK bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core tracing/logging/error instrumentation by injecting `_ldContextKeys` into `startSpan` and log events, which could change span attributes and override behavior across all spans.
> 
> **Overview**
> LD context keys set via `setLDContextKeyAttributes` are now forwarded beyond metrics: `startSpan` injects them onto every created span (including user custom spans), and `_recordLog` includes them in `addEvent('log', ...)` attributes.
> 
> Error recording relies on the `startSpan` wrapper for context key attachment (instead of explicitly spreading them in `_recordErrorMessage`), and new Vitest coverage asserts propagation plus *last-write-wins* override semantics and the no-context-keys no-op case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 642f16d13c127ac39fa05e220028e2e01c43752f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->