### PR TITLE
feat(react-native): add <LDMask> and <LDUnmask> wrapper components

### DIFF
--- a/sdk/@launchdarkly/react-native-ld-session-replay/README.md
+++ b/sdk/@launchdarkly/react-native-ld-session-replay/README.md
@@ -4,18 +4,19 @@ session replay for react native
 
 ## Installation
 
-
 ```sh
 npm install session-replay-react-native
 ```
-
 
 ## Usage
 
 Use the session replay plugin with the LaunchDarkly React Native client:
 
 ```js
-import { ReactNativeLDClient, AutoEnvAttributes } from '@launchdarkly/react-native-client-sdk';
+import {
+  ReactNativeLDClient,
+  AutoEnvAttributes,
+} from '@launchdarkly/react-native-client-sdk';
 import { createSessionReplayPlugin } from 'session-replay-react-native';
 
 const plugin = createSessionReplayPlugin({
@@ -42,11 +43,69 @@ import {
   stopSessionReplay,
 } from 'session-replay-react-native';
 
-await configureSessionReplay('YOUR_LAUNCHDARKLY_MOBILE_KEY', { isEnabled: true });
+await configureSessionReplay('YOUR_LAUNCHDARKLY_MOBILE_KEY', {
+  isEnabled: true,
+});
 await startSessionReplay();
 // later: await stopSessionReplay();
 ```
 
+## Masking sensitive content
+
+### How the SDK decides what to mask
+
+For each view, the SDK evaluates these rules in order and stops at the first that applies:
+
+1. **Explicit masking (highest priority)**: is this view — or any of its ancestors — explicitly masked (wrapped in `<LDMask>`, or `testID` matched by `maskTestIDs`)?
+   - **Yes**: the view is **masked**. This overrides everything below.
+2. **Explicit unmasking**: is this view — or any of its ancestors — explicitly unmasked (wrapped in `<LDUnmask>`, or `testID` matched by `unmaskTestIDs`)?
+   - **Yes**: the view is **unmasked**.
+3. **Global configuration**: does the global privacy config (`maskTextInputs`, `maskLabels`, `maskImages`, `maskWebViews`) apply to this view?
+   - **Yes**: the view follows the global config.
+
+When two rules conflict at the same level, **masking wins over unmasking**.
+
+### Global toggles by component type
+
+Set on the plugin config; each affects every instance of that RN component across the app.
+
+```ts
+createSessionReplayPlugin({
+  maskTextInputs: true, // default — masks every <TextInput>
+  maskLabels: false, // when true, masks every <Text>
+  maskImages: false, // when true, masks every <Image>
+  maskWebViews: false, // when true, masks every <WebView>
+});
+```
+
+### By `testID`
+
+Name specific views to mask or unmask. Match is exact string equality — `'password'` matches `<View testID="password" />` but not `<View testID="password_field" />`.
+
+```ts
+createSessionReplayPlugin({
+  maskTestIDs: ['password', 'ssn'],
+  unmaskTestIDs: ['greeting'],
+});
+```
+
+### Wrapper components
+
+Redact a subtree without giving it a `testID`.
+
+```tsx
+import { LDMask, LDUnmask } from '@launchdarkly/session-replay-react-native';
+
+<LDMask>
+  <Text>account balance: $1,234</Text>
+</LDMask>;
+
+<LDUnmask>
+  <Text>safe even when maskLabels is on</Text>
+</LDUnmask>;
+```
+
+`<LDMask>` propagates to descendants and beats any `<LDUnmask>` further down the tree — once a subtree is wrapped in `<LDMask>`, nothing inside it can opt back in.
 
 ## Contributing
 

--- a/sdk/@launchdarkly/react-native-ld-session-replay/example/src/MaskingScreen.tsx
+++ b/sdk/@launchdarkly/react-native-ld-session-replay/example/src/MaskingScreen.tsx
@@ -1,11 +1,12 @@
 import { Image, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { LDMask, LDUnmask } from '@launchdarkly/session-replay-react-native';
 
 /**
- * Manual test screen for `maskTestIDs` / `unmaskTestIDs`. The plugin in `App.tsx` is configured
- * with `maskTestIDs: ['password', 'ssn']` and `unmaskTestIDs: ['safe']`. Each row's testID is
- * picked to exercise a specific case; the inline comment on each row explains the expected
- * behavior under whatever values of `maskLabels` / `maskImages` are currently set in the plugin
- * config.
+ * Manual test screen for `maskTestIDs` / `unmaskTestIDs` and the `<LDMask>` / `<LDUnmask>`
+ * wrappers. The plugin in `App.tsx` is configured with `maskTestIDs: ['password', 'ssn']` and
+ * `unmaskTestIDs: ['safe']`. Each row's testID (or wrapper) is picked to exercise a specific
+ * case; the inline comment on each row explains the expected behavior under whatever values of
+ * `maskLabels` / `maskImages` are currently set in the plugin config.
  *
  * Section headers use `testID="safe"` so they remain readable in the recording regardless of
  * `maskLabels`.
@@ -75,6 +76,31 @@ export default function MaskingScreen() {
           testID="other"
         </Text>
       </View>
+
+      <Text testID="safe" style={styles.sectionHeader}>
+        LDMask / LDUnmask
+      </Text>
+
+      {/* Always masked: <LDMask> applies explicit-mask to its subtree. */}
+      <LDMask>
+        <Text style={styles.row}>LDMask wrapping Text — always masked</Text>
+      </LDMask>
+
+      {/* Always unmasked: <LDUnmask> overrides maskLabels for its subtree. */}
+      <LDUnmask>
+        <Text style={styles.row}>
+          LDUnmask wrapping Text — always visible (overrides maskLabels)
+        </Text>
+      </LDUnmask>
+
+      {/* Masked: ancestor LDMask wins over descendant LDUnmask. */}
+      <LDMask>
+        <LDUnmask>
+          <Text style={styles.row}>
+            LDMask &gt; LDUnmask &gt; Text — masked (mask wins over unmask)
+          </Text>
+        </LDUnmask>
+      </LDMask>
     </ScrollView>
   );
 }

--- a/sdk/@launchdarkly/react-native-ld-session-replay/src/__tests__/index.test.tsx
+++ b/sdk/@launchdarkly/react-native-ld-session-replay/src/__tests__/index.test.tsx
@@ -22,12 +22,12 @@ describe('configureSessionReplay', () => {
   });
 
   it('prepends LDMask / LDUnmask sentinels to the user lists', async () => {
-    // act
+    // configure with user-supplied testID lists
     await configureSessionReplay('mob-key-123', {
       maskTestIDs: ['password'],
       unmaskTestIDs: ['safe'],
     });
-    // assert: sentinels come first; user-supplied entries are preserved in order
+    // sentinels are prepended; user entries follow in their original order
     expect(NativeSessionReplayReactNative.configure).toHaveBeenCalledWith(
       'mob-key-123',
       expect.objectContaining({

--- a/sdk/@launchdarkly/react-native-ld-session-replay/src/__tests__/index.test.tsx
+++ b/sdk/@launchdarkly/react-native-ld-session-replay/src/__tests__/index.test.tsx
@@ -20,6 +20,22 @@ describe('configureSessionReplay', () => {
   it('rejects if key is whitespace', async () => {
     await expect(configureSessionReplay('   ')).rejects.toThrow();
   });
+
+  it('prepends LDMask / LDUnmask sentinels to the user lists', async () => {
+    // act
+    await configureSessionReplay('mob-key-123', {
+      maskTestIDs: ['password'],
+      unmaskTestIDs: ['safe'],
+    });
+    // assert: sentinels come first; user-supplied entries are preserved in order
+    expect(NativeSessionReplayReactNative.configure).toHaveBeenCalledWith(
+      'mob-key-123',
+      expect.objectContaining({
+        maskTestIDs: ['__LD_INTERNAL_MASK__', 'password'],
+        unmaskTestIDs: ['__LD_INTERNAL_UNMASK__', 'safe'],
+      })
+    );
+  });
 });
 
 describe('afterIdentify', () => {
@@ -165,9 +181,14 @@ describe('SessionReplayPluginAdapter', () => {
 
     await new Promise(process.nextTick);
 
+    // configure receives the user options plus the LDMask / LDUnmask sentinel testIDs
+    // that withInternalSentinels prepends.
     expect(NativeSessionReplayReactNative.configure).toHaveBeenCalledWith(
       'mob-key-123',
-      {}
+      {
+        maskTestIDs: ['__LD_INTERNAL_MASK__'],
+        unmaskTestIDs: ['__LD_INTERNAL_UNMASK__'],
+      }
     );
     expect(
       NativeSessionReplayReactNative.startSessionReplay

--- a/sdk/@launchdarkly/react-native-ld-session-replay/src/index.tsx
+++ b/sdk/@launchdarkly/react-native-ld-session-replay/src/index.tsx
@@ -1,3 +1,5 @@
+import { View, type StyleProp, type ViewStyle } from 'react-native';
+import type { ReactNode } from 'react';
 import SessionReplayReactNative from './NativeSessionReplayReactNative';
 import type { SessionReplayOptions } from './NativeSessionReplayReactNative';
 import type {
@@ -19,6 +21,24 @@ import type {
 
 const MOBILE_KEY_REQUIRED_MESSAGE =
   'Session replay requires a non-empty mobile key. Provide metadata.sdkKey or metadata.mobileKey when initializing the LaunchDarkly client.';
+
+// testIDs reserved for <LDMask> / <LDUnmask>. Prepended to maskTestIDs / unmaskTestIDs
+// in withInternalSentinels before options are forwarded to native.
+const LD_INTERNAL_MASK_TEST_ID = '__LD_INTERNAL_MASK__';
+const LD_INTERNAL_UNMASK_TEST_ID = '__LD_INTERNAL_UNMASK__';
+
+function withInternalSentinels(
+  options: SessionReplayOptions
+): SessionReplayOptions {
+  return {
+    ...options,
+    maskTestIDs: [LD_INTERNAL_MASK_TEST_ID, ...(options.maskTestIDs ?? [])],
+    unmaskTestIDs: [
+      LD_INTERNAL_UNMASK_TEST_ID,
+      ...(options.unmaskTestIDs ?? []),
+    ],
+  };
+}
 
 // Mirrors escapeKey() in LDObserveContext.kt (observability-android)
 function escapeContextKey(key: string): string {
@@ -89,7 +109,10 @@ export function configureSessionReplay(
   if (!key) {
     return Promise.reject(new Error(MOBILE_KEY_REQUIRED_MESSAGE));
   }
-  return SessionReplayReactNative.configure(key, options);
+  return SessionReplayReactNative.configure(
+    key,
+    withInternalSentinels(options)
+  );
 }
 
 export function startSessionReplay(): Promise<void> {
@@ -98,6 +121,38 @@ export function startSessionReplay(): Promise<void> {
 
 export function stopSessionReplay(): Promise<void> {
   return SessionReplayReactNative.stopSessionReplay();
+}
+
+export type LDMaskProps = {
+  children?: ReactNode;
+  style?: StyleProp<ViewStyle>;
+};
+
+/**
+ * Marks its children as sensitive in the session replay recording. Everything inside
+ * is rendered as a mask, regardless of `maskLabels`, `maskImages`, or other global
+ * rules. An ancestor `<LDMask>` overrides any `<LDUnmask>` further down the tree —
+ * once a subtree is masked, nothing inside it can opt back in.
+ */
+export function LDMask({ children, style }: LDMaskProps) {
+  return (
+    <View collapsable={false} testID={LD_INTERNAL_MASK_TEST_ID} style={style}>
+      {children}
+    </View>
+  );
+}
+
+/**
+ * Marks its children as explicitly *not* sensitive in the session replay recording.
+ * Overrides global rules like `maskLabels: true` for the wrapped subtree. An ancestor
+ * `<LDMask>` still wins.
+ */
+export function LDUnmask({ children, style }: LDMaskProps) {
+  return (
+    <View collapsable={false} testID={LD_INTERNAL_UNMASK_TEST_ID} style={style}>
+      {children}
+    </View>
+  );
 }
 
 class SessionReplayHook implements Hook {


### PR DESCRIPTION
## Summary

Implements `<LDMask>` and `<LDUnmask>` wrapper components for views. The names were chosen to be consistent with existing LD APIs in RN. The implementation piggybacks on the TestID implementation. While I considered other ways of implementing it (such as walking the tree and marking individual controls), this was the only design that didn't have a small window at render time where masked controls could be visible.

## How did you test this change?

Added a new section to the example app to exercise the new features. Everything is correct on Android. On iOS, there is only the known issue that will have to be fixed in the iOS repo separately.

## Are there any deployment considerations?

N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how masking configuration is sent to native by prepending internal `testID` sentinels, which could affect apps relying on `maskTestIDs`/`unmaskTestIDs` ordering or using the reserved IDs. It also introduces new privacy-related behavior that should be validated across platforms.
> 
> **Overview**
> Adds new `<LDMask>` and `<LDUnmask>` wrapper components that mark a React Native subtree as explicitly masked/unmasked in session replay via reserved internal `testID` values.
> 
> Updates `configureSessionReplay` (and plugin registration) to always prepend those internal sentinel IDs to `maskTestIDs`/`unmaskTestIDs` before forwarding options to native, and extends tests, the example app, and the README with the new masking precedence rules and usage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a04e12cb62b66c9216c87f677272f1485375f575. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->