### PR TITLE
feat(react-native): drop accessibilityIdentifiers options; mark minimumAlpha iOS-only

### DIFF
--- a/sdk/@launchdarkly/react-native-ld-session-replay/ios/SessionReplayClientAdapter.swift
+++ b/sdk/@launchdarkly/react-native-ld-session-replay/ios/SessionReplayClientAdapter.swift
@@ -187,14 +187,8 @@ extension SessionReplayClientAdapter {
       )
     }
 
-    // testID-based mask/unmask accepts either the new `*TestIDs` keys or the deprecated
-    // `*AccessibilityIdentifiers` keys; if both are present, the lists are combined.
-    let maskTestIDs =
-      (dictionary["maskTestIDs"] as? [String] ?? [])
-      + (dictionary["maskAccessibilityIdentifiers"] as? [String] ?? [])
-    let unmaskTestIDs =
-      (dictionary["unmaskTestIDs"] as? [String] ?? [])
-      + (dictionary["unmaskAccessibilityIdentifiers"] as? [String] ?? [])
+    let maskTestIDs = dictionary["maskTestIDs"] as? [String] ?? []
+    let unmaskTestIDs = dictionary["unmaskTestIDs"] as? [String] ?? []
 
     // RN's <Text> renders to RCTTextView (Paper) or RCTParagraphComponentView (Fabric), neither
     // of which extends UILabel — so the iOS SDK's `maskLabels` (which matches UILabel) doesn't
@@ -214,8 +208,7 @@ extension SessionReplayClientAdapter {
       ignoreUIViews: [], /// Not supported, since AnyClass has type erased and it is very likely is not serializable
       maskAccessibilityIdentifiers: maskTestIDs,
       unmaskAccessibilityIdentifiers: unmaskTestIDs,
-      ignoreAccessibilityIdentifiers:
-        dictionary["ignoreAccessibilityIdentifiers"] as? [String] ?? [],
+      ignoreAccessibilityIdentifiers: [],
       minimumAlpha:
         CGFloat((dictionary["minimumAlpha"] as? NSNumber)?.doubleValue ?? 0.02)
     )

--- a/sdk/@launchdarkly/react-native-ld-session-replay/src/NativeSessionReplayReactNative.ts
+++ b/sdk/@launchdarkly/react-native-ld-session-replay/src/NativeSessionReplayReactNative.ts
@@ -20,16 +20,9 @@ export type SessionReplayOptions = {
   unmaskTestIDs?: string[];
 
   /**
-   * @deprecated Use `maskTestIDs` instead.
+   * iOS only. Mask views whose effective opacity is below this threshold (0.0–1.0).
+   * Defaults to `0.02`. Has no effect on Android.
    */
-  maskAccessibilityIdentifiers?: string[];
-
-  /**
-   * @deprecated Use `unmaskTestIDs` instead.
-   */
-  unmaskAccessibilityIdentifiers?: string[];
-
-  ignoreAccessibilityIdentifiers?: string[];
   minimumAlpha?: number;
 };
 


### PR DESCRIPTION
## Summary

* `maskAccessibilityIdentifiers` -- Removed in favor of cross-platform `maskTestIDs`.
* `unmaskAccessibilityIdentifiers` -- Removed in favor of cross-platform `unmaskTestIDs`.
* `ignoreAccessibilityIdentifiers` -- Removed.
* `minimumAlpha` -- Documented as iOS-only.

## How did you test this change?

Unit tests pass and example apps run.

## Are there any deployment considerations?

N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it removes previously accepted configuration keys; existing apps passing deprecated `*AccessibilityIdentifiers` or `ignoreAccessibilityIdentifiers` will silently stop applying those rules on iOS until migrated to `maskTestIDs`/`unmaskTestIDs`. No core recording/runtime logic changes beyond option parsing and typings.
> 
> **Overview**
> Simplifies session replay privacy configuration by **removing support for the deprecated `maskAccessibilityIdentifiers`/`unmaskAccessibilityIdentifiers` and `ignoreAccessibilityIdentifiers` options**, leaving `maskTestIDs`/`unmaskTestIDs` as the only testID-based masking inputs.
> 
> Updates the React Native TypeScript options surface to drop the deprecated fields and clarifies `minimumAlpha` as **iOS-only**, while the iOS adapter now reads only `maskTestIDs`/`unmaskTestIDs` and always uses an empty `ignoreAccessibilityIdentifiers` list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 925b4859ee7e0d7473ddcc2b2f520807c3bd42b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->