### PR TITLE
chore: allows development with local dotnet client sdk

### DIFF
--- a/sdk/@launchdarkly/mobile-dotnet/Directory.Build.props
+++ b/sdk/@launchdarkly/mobile-dotnet/Directory.Build.props
@@ -1,0 +1,8 @@
+<Project>
+	<PropertyGroup>
+		<!-- Single source of truth for whether subprojects (observability, sample,
+		     bindings) consume the LaunchDarkly.ClientSdk from local source or from
+		     NuGet. Flip this in one place to switch the whole tree. -->
+		<UseLocalClientSdk>true</UseLocalClientSdk>
+	</PropertyGroup>
+</Project>

--- a/sdk/@launchdarkly/mobile-dotnet/Directory.Build.props
+++ b/sdk/@launchdarkly/mobile-dotnet/Directory.Build.props
@@ -3,6 +3,6 @@
 		<!-- Single source of truth for whether subprojects (observability, sample,
 		     bindings) consume the LaunchDarkly.ClientSdk from local source or from
 		     NuGet. Flip this in one place to switch the whole tree. -->
-		<UseLocalClientSdk>true</UseLocalClientSdk>
+		<UseLocalClientSdk>false</UseLocalClientSdk>
 	</PropertyGroup>
 </Project>

--- a/sdk/@launchdarkly/mobile-dotnet/observability/Directory.Build.props
+++ b/sdk/@launchdarkly/mobile-dotnet/observability/Directory.Build.props
@@ -1,8 +1,11 @@
 <Project>
+	<!-- Inherit shared properties (e.g. UseLocalClientSdk) from the parent
+	     mobile-dotnet/Directory.Build.props. Without this Import, MSBuild stops at
+	     this file and never sees the parent. -->
+	<Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
 	<PropertyGroup>
 		<PackageId>LaunchDarkly.SessionReplay</PackageId>
 		<Version>0.10.2</Version>
-		<UseLocalClientSdk>false</UseLocalClientSdk>
 		<Authors>LaunchDarkly</Authors>
 		<Owners>LaunchDarkly</Owners>
 		<Company>LaunchDarkly</Company>

--- a/sdk/@launchdarkly/mobile-dotnet/observability/Directory.Build.props
+++ b/sdk/@launchdarkly/mobile-dotnet/observability/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 	<PropertyGroup>
 		<PackageId>LaunchDarkly.SessionReplay</PackageId>
-		<Version>0.10.1</Version>
+		<Version>0.10.2</Version>
 		<UseLocalClientSdk>false</UseLocalClientSdk>
 		<Authors>LaunchDarkly</Authors>
 		<Owners>LaunchDarkly</Owners>

--- a/sdk/@launchdarkly/mobile-dotnet/observability/LDObservability.Fat.csproj
+++ b/sdk/@launchdarkly/mobile-dotnet/observability/LDObservability.Fat.csproj
@@ -104,4 +104,13 @@
 	<ItemGroup>
 		<None Include="..\README.md" Pack="true" PackagePath="README.md" />
 	</ItemGroup>
+
+	<!--
+		This is a packaging-only project (NoBuild=true). The .NET SDK's default
+		`Build` target asserts NETSDK1085 when invoked with NoBuild=true, which
+		breaks `dotnet build` at the solution level. Override `Build` as a no-op
+		in that case so solution builds succeed; `dotnet pack` still works
+		because it invokes the `Pack` target directly.
+	-->
+	<Target Name="Build" Condition="'$(NoBuild)' == 'true'" />
 </Project>

--- a/sdk/@launchdarkly/mobile-dotnet/sample/Directory.Build.props
+++ b/sdk/@launchdarkly/mobile-dotnet/sample/Directory.Build.props
@@ -1,4 +1,0 @@
-<Project>
-  <PropertyGroup>
-  </PropertyGroup>
-</Project>

--- a/sdk/@launchdarkly/mobile-dotnet/sample/MauiProgram.cs
+++ b/sdk/@launchdarkly/mobile-dotnet/sample/MauiProgram.cs
@@ -122,7 +122,6 @@ public static class MauiProgram
             try
             {
                 var client = await LdClient.InitAsync(ldConfig, context, TimeSpan.FromSeconds(5));
-
                 var feature1 = client.BoolVariation("feature1", false);
                 Console.WriteLine($"feature1 sync value ={feature1}");
 

--- a/sdk/@launchdarkly/mobile-dotnet/sample/MauiProgram.cs
+++ b/sdk/@launchdarkly/mobile-dotnet/sample/MauiProgram.cs
@@ -115,24 +115,38 @@ public static class MauiProgram
         ).Build();
 
         var context = LaunchDarkly.Sdk.Context.New("maui-user-key");
-        var client = Task.Run(() => LdClient.InitAsync(ldConfig, context)).GetAwaiter().GetResult();
+        
+		//async variant:
+		_ = Task.Run(async () =>
+        {
+            try
+            {
+                var client = await LdClient.InitAsync(ldConfig, context, TimeSpan.FromSeconds(5));
 
-        //var client = LdClient.Init(ldConfig, context, TimeSpan.FromSeconds(0));
-        var feature1 = client.BoolVariation("feature1", false);
-        	Console.WriteLine($"feature1 sync value ={feature1}");
+                var feature1 = client.BoolVariation("feature1", false);
+                Console.WriteLine($"feature1 sync value ={feature1}");
 
-        	client.FlagTracker.FlagValueChanged += (sender, eventArgs) =>
-        	{
-        		if (eventArgs.Key == "feature1")
-        		{
-        			Console.WriteLine($"feature1 changed from {eventArgs.OldValue} to {eventArgs.NewValue}");
-        		}
-        	};
+                client.FlagTracker.FlagValueChanged += (sender, eventArgs) =>
+                {
+                    if (eventArgs.Key == "feature1")
+                    {
+                        Console.WriteLine($"feature1 changed from {eventArgs.OldValue} to {eventArgs.NewValue}");
+                    }
+                };
 
-        LDObserve.RecordMetric("maui-app-start", 1.0);
-		LDObserve.RecordLog("maui-app-start", Severity.Info, new Dictionary<string, object?> { { "event", "app_start" } });
-		var span = LDObserve.StartActiveSpan("maui-app-start");
-		span?.End();
+                LDObserve.RecordMetric("maui-app-start", 1.0);
+                LDObserve.RecordLog("maui-app-start", Severity.Info, new Dictionary<string, object?> { { "event", "app_start" } });
+                var span = LDObserve.StartActiveSpan("maui-app-start");
+                span?.End();
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"LD init/startup failed: {ex}");
+            }
+        });
+
+        //sync variant: var client = LdClient.Init(ldConfig, context, TimeSpan.FromSeconds(0));
+
 
         return app;
     }


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared MSBuild props and overrides `Build` for a packaging-only project, which could affect solution builds/packing behavior across the tree. Runtime behavior changes are limited to the sample app’s initialization flow.
> 
> **Overview**
> Centralizes the `UseLocalClientSdk` toggle by adding a top-level `Directory.Build.props` and updating the observability `Directory.Build.props` to import it, so switching between local source and NuGet for `LaunchDarkly.ClientSdk` is controlled in one place.
> 
> Fixes solution-level `dotnet build` failures for the packaging-only `LDObservability.Fat.csproj` by making `Build` a no-op when `NoBuild=true`, and bumps the observability package version to `0.10.2`.
> 
> Updates the MAUI sample to initialize `LdClient` asynchronously with a timeout and startup error handling (instead of blocking synchronously), and removes an empty sample `Directory.Build.props`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4448104f94a45e22440992f867c3ce87d0caf52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->