### PR TITLE
fix(deps): bump rack-session to ≥2.1.2 in e2e Ruby demos

### DIFF
--- a/e2e/ruby/rails/api-only/Gemfile.lock
+++ b/e2e/ruby/rails/api-only/Gemfile.lock
@@ -410,7 +410,7 @@ GEM
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.1.12)
-    rack-session (2.1.0)
+    rack-session (2.1.2)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
     rack-test (2.2.0)

--- a/e2e/ruby/rails/demo/Gemfile.lock
+++ b/e2e/ruby/rails/demo/Gemfile.lock
@@ -428,7 +428,7 @@ GEM
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.1.12)
-    rack-session (2.1.0)
+    rack-session (2.1.2)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
     rack-test (2.2.0)

--- a/e2e/ruby/sinatra/demo/Gemfile.lock
+++ b/e2e/ruby/sinatra/demo/Gemfile.lock
@@ -256,7 +256,7 @@ GEM
       base64 (>= 0.1.0)
       logger (>= 1.6.0)
       rack (>= 3.0.0, < 4)
-    rack-session (2.1.1)
+    rack-session (2.1.2)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
     rackup (2.3.1)


### PR DESCRIPTION
## Summary

Bumps `rack-session` to `2.1.2` in all three e2e Ruby Gemfile.lock files to address critical Dependabot alerts.

- `e2e/ruby/sinatra/demo/Gemfile.lock`: 2.1.1 → 2.1.2
- `e2e/ruby/rails/demo/Gemfile.lock`: 2.1.0 → 2.1.2
- `e2e/ruby/rails/api-only/Gemfile.lock`: 2.1.0 → 2.1.2

Addresses Dependabot alerts #656, #657, #658 (CVE-2026-39324: `Rack::Session::Cookie` secrets fallback enables session forgery).

## Test plan

- [ ] CI passes on the three updated demo apps

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low code risk since this only updates `Gemfile.lock` in demo/test apps, but it does change session middleware behavior via a `rack-session` patch release to address a session-forgery CVE.
> 
> **Overview**
> Bumps `rack-session` to `2.1.2` in the three Ruby e2e app lockfiles (`rails/api-only`, `rails/demo`, and `sinatra/demo`) to pick up the latest security fix.
> 
> No application code changes; this PR only adjusts the resolved dependency versions recorded in `Gemfile.lock`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38bcbd11ee03465d0dc5630339b4068e711532cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->