### PR TITLE
fix(next): silence OpenTelemetry "Critical dependency" warnings in build

### DIFF
--- a/sdk/highlight-next/src/util/with-highlight-config.test.ts
+++ b/sdk/highlight-next/src/util/with-highlight-config.test.ts
@@ -117,4 +117,56 @@ describe('withHighlightConfig', () => {
 			).rewrites!(),
 		).toMatchObject(defaultRewrite)
 	})
+
+	it('adds OpenTelemetry packages to serverExternalPackages', async () => {
+		const result = await withHighlightConfig({})
+		expect(result.serverExternalPackages).toEqual(
+			expect.arrayContaining([
+				'@highlight-run/node',
+				'@opentelemetry/instrumentation',
+				'@prisma/instrumentation',
+				'require-in-the-middle',
+				'import-in-the-middle',
+			]),
+		)
+	})
+
+	it('preserves user-provided serverExternalPackages and deduplicates', async () => {
+		const result = await withHighlightConfig({
+			serverExternalPackages: ['pino', '@opentelemetry/instrumentation'],
+		})
+		expect(result.serverExternalPackages).toEqual(
+			expect.arrayContaining([
+				'pino',
+				'@opentelemetry/instrumentation',
+				'@highlight-run/node',
+			]),
+		)
+		expect(
+			(result.serverExternalPackages ?? []).filter(
+				(p) => p === '@opentelemetry/instrumentation',
+			),
+		).toHaveLength(1)
+	})
+
+	it('adds ignoreWarnings for OpenTelemetry on the server build', async () => {
+		const result = await withHighlightConfig({})
+		const webpack = result.webpack as (cfg: any, opts: any) => any
+		const cfg = webpack({ plugins: [] }, { isServer: true } as any)
+		expect(cfg.ignoreWarnings).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					message: expect.any(RegExp),
+					module: expect.any(RegExp),
+				}),
+			]),
+		)
+	})
+
+	it('does not add ignoreWarnings on the client build', async () => {
+		const result = await withHighlightConfig({})
+		const webpack = result.webpack as (cfg: any, opts: any) => any
+		const cfg = webpack({ plugins: [] }, { isServer: false } as any)
+		expect(cfg.ignoreWarnings).toBeUndefined()
+	})
 })

--- a/sdk/highlight-next/src/util/with-highlight-config.ts
+++ b/sdk/highlight-next/src/util/with-highlight-config.ts
@@ -3,6 +3,21 @@ import { Rewrite } from 'next/dist/lib/load-custom-routes'
 import { WebpackConfigContext } from 'next/dist/server/config-shared'
 import HighlightWebpackPlugin from './highlight-webpack-plugin.js'
 
+// Packages that use require-in-the-middle / import-in-the-middle, which
+// webpack cannot statically analyze. Marking them external tells Next to load
+// them via Node's runtime require instead of bundling them, which silences the
+// "Critical dependency" warnings during `next build`.
+const OTEL_SERVER_EXTERNAL_PACKAGES = [
+	'@highlight-run/node',
+	'@opentelemetry/api',
+	'@opentelemetry/auto-instrumentations-node',
+	'@opentelemetry/instrumentation',
+	'@opentelemetry/sdk-node',
+	'@prisma/instrumentation',
+	'import-in-the-middle',
+	'require-in-the-middle',
+]
+
 interface HighlightConfigOptionsDefault {
 	uploadSourceMaps: boolean
 	configureHighlightProxy: boolean
@@ -180,17 +195,39 @@ const getHighlightConfig = async (
 		}
 	}
 
-	let newWebpack = config.webpack
-	if (defaultOpts.uploadSourceMaps) {
-		newWebpack = (webpackConfig: any, opts: WebpackConfigContext) => {
-			let originalConfig = webpackConfig
-			if (config.webpack) {
-				originalConfig = config.webpack(webpackConfig, opts)
-			}
-			if (opts.isServer) {
+	const newWebpack = (webpackConfig: any, opts: WebpackConfigContext) => {
+		let originalConfig = webpackConfig
+		if (config.webpack) {
+			originalConfig = config.webpack(webpackConfig, opts)
+		}
+
+		if (opts.isServer) {
+			if (defaultOpts.uploadSourceMaps) {
 				originalConfig.devtool = 'source-map'
 			}
 
+			// Defense-in-depth: even with serverExternalPackages set, some
+			// builds (custom resolvers, monorepo hoisting) can still pull
+			// these modules through webpack. Silence the known-noisy
+			// warnings rather than letting them spam the customer build.
+			const criticalDepMessage =
+				/Critical dependency: the request of a dependency is an expression/
+			originalConfig.ignoreWarnings = [
+				...(originalConfig.ignoreWarnings ?? []),
+				{
+					module: /node_modules\/(@opentelemetry\/instrumentation|require-in-the-middle|import-in-the-middle|@highlight-run\/node|@prisma\/instrumentation)/,
+					message: criticalDepMessage,
+				},
+				{
+					// Workspace / hoisted builds where @highlight-run/node
+					// is symlinked outside node_modules.
+					module: /highlight-node\/dist/,
+					message: criticalDepMessage,
+				},
+			]
+		}
+
+		if (defaultOpts.uploadSourceMaps) {
 			originalConfig.plugins.push(
 				new HighlightWebpackPlugin(
 					defaultOpts.apiKey,
@@ -200,10 +237,17 @@ const getHighlightConfig = async (
 					defaultOpts.sourceMapsBackendUrl,
 				),
 			)
-
-			return originalConfig
 		}
+
+		return originalConfig
 	}
+
+	const existingServerExternal = Array.isArray(config.serverExternalPackages)
+		? config.serverExternalPackages
+		: []
+	const serverExternalPackages = Array.from(
+		new Set([...existingServerExternal, ...OTEL_SERVER_EXTERNAL_PACKAGES]),
+	)
 
 	return {
 		...config,
@@ -217,6 +261,7 @@ const getHighlightConfig = async (
 			defaultOpts.uploadSourceMaps || config.productionBrowserSourceMaps,
 		rewrites: newRewrites,
 		webpack: newWebpack,
+		serverExternalPackages,
 	}
 }
 


### PR DESCRIPTION
## Summary

Backend Next.js apps using `@highlight-run/next/server` (typically via `instrumentation.ts`) currently emit a wall of `Critical dependency: the request of a dependency is an expression` warnings during `next build`. The root cause is that `@highlight-run/node` pulls `@opentelemetry/instrumentation` (via `@prisma/instrumentation`) and uses `require-in-the-middle` / `import-in-the-middle`, which webpack cannot statically analyze.

This PR teaches `withHighlightConfig` to suppress these warnings out of the box so customers don't need to know about the underlying webpack quirk:

- **Primary fix:** merge an OTel/RITM/ITM package list into Next 15's `serverExternalPackages`, so Next defers to Node's runtime `require` instead of bundling them. Preserves any existing user-provided entries and deduplicates.
- **Defense-in-depth:** add `ignoreWarnings` filters to the server webpack config covering both `node_modules/...` (typical install) and `highlight-node/dist/...` (workspace / hoisted) paths, scoped to the exact warning message.

Verified against the `e2e/nextjs` example: the `Critical dependency` warnings that were present before this change are gone after it. Existing `with-highlight-config` unit tests still pass; added four new tests covering `serverExternalPackages` merge/dedup and the server-only `ignoreWarnings` behavior.

## Test plan
- [x] `yarn workspace @highlight-run/next test` — 15/15 pass
- [x] `yarn turbo run lint --filter=@highlight-run/next` — clean
- [x] `yarn format-check` — clean
- [x] `e2e/nextjs` `next build` no longer emits `Critical dependency` warnings (pre-existing unrelated type error in the example is untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Next.js server build configuration by externalizing OpenTelemetry-related packages and suppressing specific webpack warnings, which could affect server bundling behavior in some deployments.
> 
> **Overview**
> Reduces noisy `next build` output for apps using Highlight + OpenTelemetry by automatically treating several OTel/Prisma and `*-in-the-middle` modules as server externals via `serverExternalPackages`, while preserving user entries and deduplicating.
> 
> Adds a server-only webpack `ignoreWarnings` filter for the known OpenTelemetry “Critical dependency” warning (including hoisted/workspace layouts), and extends unit tests to cover the externals merge/dedup behavior and the server-vs-client warning suppression.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 617f72147ee5ba1a53db7c6b1784571ae71f8dfc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->