### PR TITLE
fix(deps): bump Django to 5.2.14 in e2e/python

### DIFF
--- a/e2e/python/poetry.lock
+++ b/e2e/python/poetry.lock
@@ -797,18 +797,18 @@ files = [
 
 [[package]]
 name = "django"
-version = "5.1.7"
+version = "5.2.14"
 description = "A high-level Python web framework that encourages rapid development and clean, pragmatic design."
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "Django-5.1.7-py3-none-any.whl", hash = "sha256:1323617cb624add820cb9611cdcc788312d250824f92ca6048fda8625514af2b"},
-    {file = "Django-5.1.7.tar.gz", hash = "sha256:30de4ee43a98e5d3da36a9002f287ff400b43ca51791920bfb35f6917bfe041c"},
+    {file = "django-5.2.14-py3-none-any.whl", hash = "sha256:6f712143bd3064310d1f50fac859c3e9a274bdcfc9595339853be7779297fc76"},
+    {file = "django-5.2.14.tar.gz", hash = "sha256:58a63ba841662e5c686b57ba1fec52ddd68c0b93bd96ac3029d55728f00bf8a2"},
 ]
 
 [package.dependencies]
-asgiref = ">=3.8.1,<4"
+asgiref = ">=3.8.1"
 sqlparse = ">=0.3.1"
 tzdata = {version = "*", markers = "sys_platform == \"win32\""}
 


### PR DESCRIPTION
## Summary

- Bumps Django from `5.1.7` to `5.2.14` (latest 5.2.x LTS) in `e2e/python/poetry.lock`.
- The pyproject constraint `django = "^5.0.8"` already allowed 5.2.x, so `pyproject.toml` is unchanged; only the lock moves.
- Addresses the launchdarkly-org dependency-insights flag on Django 5.1.7 (https://github.com/dependency-insights/pip/django/5.1.7/dependents?query=org%3Alaunchdarkly).

This affects e2e test fixtures only — no SDK runtime change.

## Test plan
- [ ] CI runs against e2e/python (poetry lock should resolve cleanly).
- [ ] Django-related e2e (`e2e/python/highlight_django`) still exercises instrumentation against 5.2.x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk since this only updates an e2e test fixture dependency (lockfile) and should not impact production/runtime code, though it may affect Django-based e2e test behavior.
> 
> **Overview**
> Updates the `e2e/python` Poetry lock to bump `django` from `5.1.7` to `5.2.14` (including updated artifact hashes).
> 
> Adjusts the locked `django` dependency constraint for `asgiref` (drops the `<4` upper bound) to match the new Django release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf2a65653ec7a099ddb80b1cdfb943857b4f412d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->