### PR TITLE
feat: session replay control with sampling and state management

### DIFF
--- a/sdk/@launchdarkly/observability-android/README.md
+++ b/sdk/@launchdarkly/observability-android/README.md
@@ -202,6 +202,7 @@ Add the Session Replay plugin **after** Observability when configuring the Launc
 
 ```kotlin
 import com.launchdarkly.observability.plugin.Observability
+import com.launchdarkly.observability.replay.ReplayOptions
 import com.launchdarkly.observability.replay.plugin.SessionReplay
 
 val ldConfig = LDConfig.Builder(LDConfig.Builder.AutoEnvAttributes.Enabled)
@@ -210,7 +211,12 @@ val ldConfig = LDConfig.Builder(LDConfig.Builder.AutoEnvAttributes.Enabled)
         Components.plugins().setPlugins(
             listOf(
                 Observability(this@MyApplication, "your-mobile-key"),
-                SessionReplay() // depends on Observability being present first
+                SessionReplay(
+                    ReplayOptions(
+                        enabled = true,
+                        sampleRate = 1.0,
+                    )
+                ) // depends on Observability being present first
             )
         )
     )
@@ -223,12 +229,24 @@ Notes:
 
 #### Delay Start
 
+By default, Session Replay attempts to start recording during initialization if `ReplayOptions.enabled` is `true`. The `sampleRate` option controls whether that attempt actually starts recording. Use a value from `0.0` to `1.0`, where `0.0` never records and `1.0` always records.
+
+```kotlin
+val sessionReplay = SessionReplay(
+    ReplayOptions(
+        enabled = true,
+        sampleRate = 0.25,
+    )
+)
+```
+
 If you need to begin recording after login or later in the app lifecycle, disable automatic capture and start it later:
 
 ```kotlin
 import com.launchdarkly.observability.replay.ReplayOptions
 import com.launchdarkly.observability.replay.plugin.SessionReplay
 import com.launchdarkly.observability.sdk.LDReplay
+import com.launchdarkly.observability.sdk.SessionReplayStartResult
 
 val sessionReplay = SessionReplay(
     ReplayOptions(enabled = false)
@@ -236,6 +254,33 @@ val sessionReplay = SessionReplay(
 
 // After login:
 LDReplay.start()
+```
+
+Setting `LDReplay.isEnabled = true` or calling `LDReplay.start()` still applies sampling. Use `LDReplay.isRunning` to check whether Session Replay is actually recording, or inspect the result returned by `start()`:
+
+```kotlin
+val result = LDReplay.start()
+
+when (result) {
+    SessionReplayStartResult.STARTED,
+    SessionReplayStartResult.ALREADY_STARTED -> {
+        // Session Replay is running.
+    }
+    SessionReplayStartResult.SAMPLED_OUT -> {
+        // Session Replay is enabled, but this session was not selected by sampleRate.
+    }
+    SessionReplayStartResult.UNAVAILABLE -> {
+        // Session Replay has not been registered.
+    }
+}
+
+val isRecording = LDReplay.isRunning
+```
+
+For debugging, you can bypass sampling for a manual start:
+
+```kotlin
+LDReplay.start(ignoreSampling = true)
 ```
 
 Call `LDReplay.stop()` to pause recording.

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/ReplayOptions.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/ReplayOptions.kt
@@ -8,10 +8,12 @@ package com.launchdarkly.observability.replay
  * @property capturePeriodMillis period between captures
  * @property scale optional replay scale override. When null, no additional scaling is applied. Usually from 1-4. 1 = 160DPI
  * @property enabled controls whether session replay starts capturing immediately on initialization
+ * @property sampleRate probability from 0.0 to 1.0 that session replay starts when enabled
  * @property compression compression strategy for frame export
  */
 data class ReplayOptions(
     val enabled: Boolean = true,
+    val sampleRate: Double = 1.0,
     val debug: Boolean = false,
     val privacyProfile: PrivacyProfile = PrivacyProfile(),
     val capturePeriodMillis: Long = 1000, // defaults to ever 1 second

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/SessionReplaySampling.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/SessionReplaySampling.kt
@@ -1,0 +1,12 @@
+package com.launchdarkly.observability.replay
+
+import kotlin.random.Random
+
+internal object SessionReplaySampling {
+    fun shouldSample(sampleRate: Double, randomValue: () -> Double = { Random.nextDouble() }): Boolean {
+        if (sampleRate <= 0.0) return false
+        if (sampleRate >= 1.0) return true
+
+        return randomValue() < sampleRate
+    }
+}

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/SessionReplayService.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/SessionReplayService.kt
@@ -17,6 +17,7 @@ import com.launchdarkly.observability.replay.transport.BatchWorker
 import com.launchdarkly.observability.replay.transport.EventQueue
 import com.launchdarkly.observability.context.LDObserveContext
 import com.launchdarkly.observability.sdk.SessionReplayServicing
+import com.launchdarkly.observability.sdk.SessionReplayStartResult
 import com.launchdarkly.observability.util.requireMainThread
 import io.opentelemetry.android.session.SessionManager
 import kotlinx.coroutines.CoroutineScope
@@ -74,6 +75,7 @@ class SessionReplayService(
     private var captureJob: Job? = null
     private val shouldCapture = MutableStateFlow(false)
     private val _isEnabled = MutableStateFlow(options.enabled)
+    private val _isRunning = MutableStateFlow(false)
     private var processLifecycleObserver: DefaultLifecycleObserver? = null
     private var isInstalled: Boolean = false
     private var exporter: SessionReplayExporter? = null
@@ -138,6 +140,9 @@ class SessionReplayService(
         interactionSource?.attachToApplication(application)
 
         isInstalled = true
+        if (options.enabled) {
+            start()
+        }
         return true
     }
 
@@ -145,7 +150,7 @@ class SessionReplayService(
         // Images collector
         instrumentationScope.launch {
             captureManager?.captureFlow?.collect { capture ->
-                if (!_isEnabled.value) return@collect
+                if (!_isRunning.value) return@collect
                 eventQueue.send(ImageItemPayload(capture))
             }
         }
@@ -153,7 +158,7 @@ class SessionReplayService(
         // Interactions collector
         instrumentationScope.launch {
             interactionSource?.captureFlow?.collect { interaction ->
-                if (!_isEnabled.value) return@collect
+                if (!_isRunning.value) return@collect
                 eventQueue.send(InteractionItemPayload(interaction))
             }
         }
@@ -165,7 +170,7 @@ class SessionReplayService(
      */
     private fun startCaptureStateObserver() {
         instrumentationScope.launch {
-            combine(shouldCapture, _isEnabled) { shouldRun, enabled -> shouldRun && enabled }
+            combine(shouldCapture, _isRunning) { shouldRun, running -> shouldRun && running }
                 .collect { shouldRun ->
                     val running = captureJob?.isActive == true
                     if (shouldRun == running) return@collect
@@ -218,8 +223,34 @@ class SessionReplayService(
         get() = _isEnabled.value
         set(value) {
             _isEnabled.value = value
-            if (value) flushPendingIdentify()
+            if (value) {
+                start()
+            } else {
+                stop()
+            }
         }
+
+    override val isRunning: Boolean
+        get() = _isRunning.value
+
+    override fun start(ignoreSampling: Boolean): SessionReplayStartResult {
+        _isEnabled.value = true
+        if (_isRunning.value) return SessionReplayStartResult.ALREADY_STARTED
+
+        if (!ignoreSampling && !SessionReplaySampling.shouldSample(options.sampleRate)) {
+            logger.info("LaunchDarkly Session Replay skipped by sampling.")
+            return SessionReplayStartResult.SAMPLED_OUT
+        }
+
+        _isRunning.value = true
+        flushPendingIdentify()
+        return SessionReplayStartResult.STARTED
+    }
+
+    private fun stop() {
+        _isEnabled.value = false
+        _isRunning.value = false
+    }
 
     override fun flush() {
         batchWorker.flush()
@@ -314,7 +345,7 @@ class SessionReplayService(
         )
 
         // When replay is disabled, cache the identify payload for later session init without sending it now.
-        if (!_isEnabled.value) {
+        if (!_isRunning.value) {
             synchronized(pendingIdentifyLock) {
                 pendingIdentify = event
             }

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/SessionReplayService.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/SessionReplayService.kt
@@ -78,6 +78,8 @@ class SessionReplayService(
     private val _isRunning = MutableStateFlow(false)
     private var processLifecycleObserver: DefaultLifecycleObserver? = null
     private var isInstalled: Boolean = false
+    /** Whether [start] has already applied sampling for this enable cycle (until [stop]). */
+    private var samplingDecisionMade = false
     private var exporter: SessionReplayExporter? = null
     private val pendingIdentifyLock = Any()
     private var pendingIdentify: IdentifyItemPayload? = null
@@ -237,9 +239,15 @@ class SessionReplayService(
         _isEnabled.value = true
         if (_isRunning.value) return SessionReplayStartResult.ALREADY_STARTED
 
-        if (!ignoreSampling && !SessionReplaySampling.shouldSample(options.sampleRate)) {
-            logger.info("LaunchDarkly Session Replay skipped by sampling.")
-            return SessionReplayStartResult.SAMPLED_OUT
+        if (!ignoreSampling) {
+            if (samplingDecisionMade) {
+                return SessionReplayStartResult.SAMPLED_OUT
+            }
+            samplingDecisionMade = true
+            if (!SessionReplaySampling.shouldSample(options.sampleRate)) {
+                logger.info("LaunchDarkly Session Replay skipped by sampling.")
+                return SessionReplayStartResult.SAMPLED_OUT
+            }
         }
 
         _isRunning.value = true
@@ -250,6 +258,7 @@ class SessionReplayService(
     private fun stop() {
         _isEnabled.value = false
         _isRunning.value = false
+        samplingDecisionMade = false
     }
 
     override fun flush() {

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/sdk/LDReplay.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/sdk/LDReplay.kt
@@ -39,9 +39,20 @@ object LDReplay {
             state.setEnabled(value)
         }
 
-    /** Starts session replay capture. */
-    fun start() {
-        isEnabled = true
+    /**
+     * Whether session replay capture is currently running after sampling.
+     */
+    val isRunning: Boolean
+        get() = state.isRunning
+
+    /**
+     * Starts session replay capture.
+     *
+     * @param ignoreSampling set to true to force start for debugging
+     */
+    @JvmOverloads
+    fun start(ignoreSampling: Boolean = false): SessionReplayStartResult {
+        return state.start(ignoreSampling)
     }
 
     /** Pauses session replay capture. */
@@ -119,6 +130,9 @@ internal interface SessionReplayServicing {
      * forward it to a live replay service during initialization.
      */
     var isEnabled: Boolean
+    val isRunning: Boolean
+
+    fun start(ignoreSampling: Boolean = false): SessionReplayStartResult
 
     fun flush()
     fun afterIdentify(contextKeys: Map<String, String>, canonicalKey: String, completed: Boolean)

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/sdk/PreInitReplayBuffer.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/sdk/PreInitReplayBuffer.kt
@@ -134,11 +134,16 @@ internal class PreInitReplayBuffer {
             // Drain buffered state into the live replay service in a deterministic order:
             // enable first (so subsequent operations see the right gate), then activities,
             // then the latest identify.
-            pendingEnabled?.let {
-                if (it && pendingStartIgnoresSampling) {
-                    replayService.start(ignoreSampling = true)
-                } else {
-                    replayService.isEnabled = it
+            pendingEnabled?.let { desired ->
+                when {
+                    desired && pendingStartIgnoresSampling -> {
+                        replayService.start(ignoreSampling = true)
+                    }
+                    replayService.isEnabled == desired -> {
+                        // Options-based initialize() may have already applied this intent
+                        // (including a sampled-out start). Do not call start() again.
+                    }
+                    else -> replayService.isEnabled = desired
                 }
             }
             pendingActivities.forEach { replayService.registerActivity(it) }

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/sdk/PreInitReplayBuffer.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/sdk/PreInitReplayBuffer.kt
@@ -14,6 +14,7 @@ import com.launchdarkly.observability.util.runOnMainThread
  *    "pre-init" flag.
  *  - `pendingEnabled`: latest pre-init `isEnabled` write. `null` means "no buffered value",
  *    so [bind] won't clobber the replay service's `ReplayOptions.enabled` default.
+ *  - `pendingStartIgnoresSampling`: whether a buffered start should bypass sampling.
  *  - `pendingActivities`: every pre-init [registerActivity], in submission order.
  *  - `pendingIdentify`: most recent pre-init [afterIdentify] only — older identifies are stale.
  *
@@ -39,6 +40,7 @@ internal class PreInitReplayBuffer {
 
     @Volatile
     private var pendingEnabled: Boolean? = null
+    private var pendingStartIgnoresSampling: Boolean = false
 
     private val pendingActivities = mutableListOf<Activity>()
     private var pendingIdentify: PendingIdentify? = null
@@ -55,17 +57,42 @@ internal class PreInitReplayBuffer {
             return service.isEnabled
         }
 
+    val isRunning: Boolean
+        get() = liveReplayService?.isRunning ?: false
+
     fun setEnabled(value: Boolean) {
         val target: SessionReplayServicing? = synchronized(this) {
             val current = liveReplayService
             if (current == null) {
                 pendingEnabled = value
+                pendingStartIgnoresSampling = false
                 null
             } else {
                 current
             }
         }
         target?.let { runOnMainThread { it.isEnabled = value } }
+    }
+
+    fun start(ignoreSampling: Boolean): SessionReplayStartResult {
+        val target: SessionReplayServicing? = synchronized(this) {
+            val current = liveReplayService
+            if (current == null) {
+                pendingEnabled = true
+                pendingStartIgnoresSampling = ignoreSampling
+                null
+            } else {
+                current
+            }
+        }
+
+        var result = SessionReplayStartResult.UNAVAILABLE
+        target?.let {
+            runOnMainThread {
+                result = it.start(ignoreSampling)
+            }
+        }
+        return result
     }
 
     fun registerActivity(activity: Activity) {
@@ -107,7 +134,13 @@ internal class PreInitReplayBuffer {
             // Drain buffered state into the live replay service in a deterministic order:
             // enable first (so subsequent operations see the right gate), then activities,
             // then the latest identify.
-            pendingEnabled?.let { replayService.isEnabled = it }
+            pendingEnabled?.let {
+                if (it && pendingStartIgnoresSampling) {
+                    replayService.start(ignoreSampling = true)
+                } else {
+                    replayService.isEnabled = it
+                }
+            }
             pendingActivities.forEach { replayService.registerActivity(it) }
             pendingIdentify?.let { replayService.afterIdentify(it.contextKeys, it.canonicalKey, it.completed) }
 
@@ -116,6 +149,7 @@ internal class PreInitReplayBuffer {
             // ordering).
             liveReplayService = replayService
             pendingEnabled = null
+            pendingStartIgnoresSampling = false
             pendingActivities.clear()
             pendingIdentify = null
         }
@@ -125,6 +159,7 @@ internal class PreInitReplayBuffer {
         synchronized(this) {
             liveReplayService = null
             pendingEnabled = null
+            pendingStartIgnoresSampling = false
             pendingActivities.clear()
             pendingIdentify = null
         }

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/sdk/SessionReplayStartResult.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/sdk/SessionReplayStartResult.kt
@@ -1,0 +1,15 @@
+package com.launchdarkly.observability.sdk
+
+enum class SessionReplayStartResult(val isRunning: Boolean) {
+    /** Session Replay was not installed or has not finished registering. */
+    UNAVAILABLE(false),
+
+    /** Session Replay is now running because this call started it. */
+    STARTED(true),
+
+    /** Session Replay was already running before this call. */
+    ALREADY_STARTED(true),
+
+    /** Session Replay stayed stopped because the session was sampled out. */
+    SAMPLED_OUT(false),
+}

--- a/sdk/@launchdarkly/observability-android/lib/src/test/kotlin/com/launchdarkly/observability/replay/SessionReplaySamplingTest.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/test/kotlin/com/launchdarkly/observability/replay/SessionReplaySamplingTest.kt
@@ -1,0 +1,33 @@
+package com.launchdarkly.observability.replay
+
+import com.launchdarkly.observability.sdk.SessionReplayStartResult
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class SessionReplaySamplingTest {
+    @Test
+    fun `sampleRate defaults to always sample`() {
+        assertTrue(ReplayOptions().sampleRate == 1.0)
+        assertTrue(SessionReplaySampling.shouldSample(sampleRate = 1.0) { 0.99 })
+    }
+
+    @Test
+    fun `sampleRate zero disables session replay`() {
+        assertFalse(SessionReplaySampling.shouldSample(sampleRate = 0.0) { 0.0 })
+    }
+
+    @Test
+    fun `sampleRate samples when random value is below rate`() {
+        assertTrue(SessionReplaySampling.shouldSample(sampleRate = 0.5) { 0.49 })
+        assertFalse(SessionReplaySampling.shouldSample(sampleRate = 0.5) { 0.5 })
+    }
+
+    @Test
+    fun `start result indicates whether session replay is running`() {
+        assertTrue(SessionReplayStartResult.STARTED.isRunning)
+        assertTrue(SessionReplayStartResult.ALREADY_STARTED.isRunning)
+        assertFalse(SessionReplayStartResult.SAMPLED_OUT.isRunning)
+        assertFalse(SessionReplayStartResult.UNAVAILABLE.isRunning)
+    }
+}

--- a/sdk/@launchdarkly/observability-android/lib/src/test/kotlin/com/launchdarkly/observability/sdk/LDReplayTest.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/test/kotlin/com/launchdarkly/observability/sdk/LDReplayTest.kt
@@ -12,14 +12,25 @@ import org.junit.jupiter.api.Test
 
 class LDReplayTest {
 
-    private class TestReplayService(initialIsEnabled: Boolean = false) : SessionReplayServicing {
+    private class TestReplayService(
+        initialIsEnabled: Boolean = false,
+        private val startResult: SessionReplayStartResult = SessionReplayStartResult.STARTED,
+    ) : SessionReplayServicing {
         override var isEnabled: Boolean = initialIsEnabled
+        override var isRunning: Boolean = false
+            private set
         var flushCalls = 0
         val registeredActivities = mutableListOf<Activity>()
         val identifyCalls = mutableListOf<IdentifyCall>()
 
         val registerActivityCalls: Int get() = registeredActivities.size
         val afterIdentifyCalls: Int get() = identifyCalls.size
+
+        override fun start(ignoreSampling: Boolean): SessionReplayStartResult {
+            isEnabled = true
+            isRunning = startResult.isRunning
+            return startResult
+        }
 
         override fun flush() {
             flushCalls++
@@ -70,13 +81,40 @@ class LDReplayTest {
     }
 
     @Test
-    fun `start sets isEnabled to true on active replay service`() {
+    fun `start returns result from active replay service`() {
         val replayService = TestReplayService()
         LDReplay.init(replayService)
 
-        LDReplay.start()
+        val result = LDReplay.start()
 
+        assertEquals(SessionReplayStartResult.STARTED, result)
         assertTrue(replayService.isEnabled)
+        assertTrue(replayService.isRunning)
+        assertTrue(LDReplay.isRunning)
+    }
+
+    @Test
+    fun `start before init buffers enabled intent and returns unavailable`() {
+        val result = LDReplay.start()
+        val replayService = TestReplayService()
+
+        LDReplay.init(replayService)
+
+        assertEquals(SessionReplayStartResult.UNAVAILABLE, result)
+        assertTrue(replayService.isEnabled)
+        assertTrue(LDReplay.isEnabled)
+    }
+
+    @Test
+    fun `start can enable replay without running when sampled out`() {
+        val replayService = TestReplayService(startResult = SessionReplayStartResult.SAMPLED_OUT)
+        LDReplay.init(replayService)
+
+        val result = LDReplay.start()
+
+        assertEquals(SessionReplayStartResult.SAMPLED_OUT, result)
+        assertTrue(LDReplay.isEnabled)
+        assertFalse(LDReplay.isRunning)
     }
 
     @Test
@@ -87,6 +125,11 @@ class LDReplayTest {
         LDReplay.stop()
 
         assertFalse(replayService.isEnabled)
+    }
+
+    @Test
+    fun `isRunning getter defaults to false before init`() {
+        assertFalse(LDReplay.isRunning)
     }
 
     @Test

--- a/sdk/@launchdarkly/observability-android/lib/src/test/kotlin/com/launchdarkly/observability/sdk/PreInitReplayBufferTest.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/test/kotlin/com/launchdarkly/observability/sdk/PreInitReplayBufferTest.kt
@@ -1,0 +1,110 @@
+package com.launchdarkly.observability.sdk
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class PreInitReplayBufferTest {
+
+    private class CountingReplayService(
+        isEnabled: Boolean,
+    ) : SessionReplayServicing {
+        private var enabled = isEnabled
+
+        override var isEnabled: Boolean
+            get() = enabled
+            set(value) {
+                enabled = value
+                if (value) {
+                    start(ignoreSampling = false)
+                } else {
+                    isRunning = false
+                }
+            }
+
+        override var isRunning: Boolean = false
+        var startCalls = 0
+
+        override fun start(ignoreSampling: Boolean): SessionReplayStartResult {
+            startCalls++
+            enabled = true
+            isRunning = true
+            return SessionReplayStartResult.STARTED
+        }
+
+        override fun flush() {}
+
+        override fun afterIdentify(
+            contextKeys: Map<String, String>,
+            canonicalKey: String,
+            completed: Boolean
+        ) {
+        }
+    }
+
+    @Test
+    fun `bind does not re-enable when service already enabled`() {
+        val buffer = PreInitReplayBuffer()
+        buffer.setEnabled(true)
+
+        val replayService = CountingReplayService(isEnabled = true)
+        buffer.bind(replayService)
+
+        assertEquals(0, replayService.startCalls)
+        assertTrue(replayService.isEnabled)
+    }
+
+    @Test
+    fun `bind applies buffered enable when service is still disabled`() {
+        val buffer = PreInitReplayBuffer()
+        buffer.setEnabled(true)
+
+        val replayService = CountingReplayService(isEnabled = false)
+        buffer.bind(replayService)
+
+        assertEquals(1, replayService.startCalls)
+        assertTrue(replayService.isEnabled)
+    }
+
+    /**
+     * Models [SessionReplayService.initialize] with [ReplayOptions.enabled] after a sampled-out
+     * [start]: enabled intent is set but capture is not running.
+     */
+    private class SampledOutReplayService : SessionReplayServicing {
+        override var isEnabled: Boolean = true
+        override var isRunning: Boolean = false
+        var startCalls = 0
+
+        override fun start(ignoreSampling: Boolean): SessionReplayStartResult {
+            startCalls++
+            isEnabled = true
+            if (ignoreSampling) {
+                isRunning = true
+                return SessionReplayStartResult.STARTED
+            }
+            isRunning = false
+            return SessionReplayStartResult.SAMPLED_OUT
+        }
+
+        override fun flush() {}
+
+        override fun afterIdentify(
+            contextKeys: Map<String, String>,
+            canonicalKey: String,
+            completed: Boolean
+        ) {
+        }
+    }
+
+    @Test
+    fun `bind does not re-roll sampling after options-based sampled-out start`() {
+        val buffer = PreInitReplayBuffer()
+        buffer.start(ignoreSampling = false)
+
+        val replayService = SampledOutReplayService()
+        buffer.bind(replayService)
+
+        assertEquals(0, replayService.startCalls)
+        assertTrue(replayService.isEnabled)
+    }
+}


### PR DESCRIPTION
## Summary
- Add Session Replay launch sampling for Android via `ReplayOptions.sampleRate`.
- Add `LDReplay.start(ignoreSampling)` with `SessionReplayStartResult` so callers can tell whether replay started, was already running, was sampled out, or is unavailable.
- Split replay intent from runtime state: `LDReplay.isEnabled` remains the sampled enable/disable control, while `LDReplay.isRunning` reports whether replay is actually recording.
- Preserve pre-init buffering behavior for `LDReplay` calls, including sampled starts and debug starts that bypass sampling.
- Update Android README docs and unit coverage for sampling and enabled-but-not-running behavior.

## Test Plan
- `./gradlew :lib:testDebugUnitTest`
- `./gradlew :lib:testDebugUnitTest --tests "com.launchdarkly.observability.sdk.LDReplayTest" --tests "com.launchdarkly.observability.replay.SessionReplaySamplingTest"`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes public Session Replay control APIs and capture gating; behavior shifts for apps that assumed `isEnabled` implied recording, though defaults preserve full sampling.
> 
> **Overview**
> Adds **launch-time sampling** for Android Session Replay via `ReplayOptions.sampleRate` (0.0–1.0), applied when replay is enabled at init or through `LDReplay.start()` / `isEnabled = true`.
> 
> Introduces **`SessionReplayStartResult`** and **`LDReplay.start(ignoreSampling)`** so apps can see whether capture started, was already running, was sampled out, or is unavailable pre-init. **`LDReplay.isRunning`** reflects actual recording, separate from **`isEnabled`** (intent after sampling).
> 
> **`SessionReplayService`** gates frame/interaction export on running state, rolls sampling once per enable cycle until `stop()`, and supports debug bypass. **`PreInitReplayBuffer`** bind logic avoids a second `start()` when options-based init already applied enable (including sampled-out). README and unit tests cover the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf09aec8d8e8ee9d011c4d37fdc36e5f772cd808. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->