### PR TITLE
feat: Android SR options frameRate to match with iOS

### DIFF
--- a/e2e/android/app/src/main/java/com/example/androidobservability/BaseApplication.kt
+++ b/e2e/android/app/src/main/java/com/example/androidobservability/BaseApplication.kt
@@ -51,7 +51,8 @@ open class BaseApplication : Application() {
                     view(ImageView::class.java),
                 ),
                 maskXMLViewIds = listOf("smoothieTitle")
-            )
+            ),
+            frameRate = 1.0
         )
     )
 

--- a/sdk/@launchdarkly/flutter/packages/session_replay/android/src/main/kotlin/com/launchdarkly/launchdarkly_flutter_session_replay/FlutterImageCaptureService.kt
+++ b/sdk/@launchdarkly/flutter/packages/session_replay/android/src/main/kotlin/com/launchdarkly/launchdarkly_flutter_session_replay/FlutterImageCaptureService.kt
@@ -15,9 +15,12 @@ internal class FlutterImageCaptureService(
     private val maskTextInputs: Boolean,
 ) : ImageCaptureServicing {
 
-    override suspend fun captureRawFrame(): ImageCaptureService.RawFrame? =
-        withContext(Dispatchers.Main.immediate) {
-            val payload = requestCapture() ?: return@withContext null
+    override suspend fun captureRawFrame(): ImageCaptureService.RawFrame? {
+        val payload = withContext(Dispatchers.Main.immediate) {
+            requestCapture()
+        } ?: return null
+
+        return withContext(Dispatchers.Default) {
             val bytes = payload["bytes"] as? ByteArray ?: return@withContext null
             val bitmap = BitmapFactory.decodeByteArray(bytes, 0, bytes.size) ?: return@withContext null
             val timestamp = (payload["timestamp"] as? Number)?.toLong() ?: System.currentTimeMillis()
@@ -29,6 +32,7 @@ internal class FlutterImageCaptureService(
                 orientation = orientation,
             )
         }
+    }
 
     private suspend fun requestCapture(): Map<*, *>? =
         suspendCancellableCoroutine { continuation ->

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/ReplayOptions.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/ReplayOptions.kt
@@ -5,7 +5,7 @@ package com.launchdarkly.observability.replay
  *
  * @property debug enables verbose logging if true as well as other debug functionality. Defaults to false.
  * @property privacyProfile privacy profile that controls masking behavior
- * @property capturePeriodMillis period between captures
+ * @property frameRate target capture rate in frames per second
  * @property scale optional replay scale override. When null, no additional scaling is applied. Usually from 1-4. 1 = 160DPI
  * @property enabled controls whether session replay starts capturing immediately on initialization
  * @property compression compression strategy for frame export
@@ -14,7 +14,7 @@ data class ReplayOptions(
     val enabled: Boolean = true,
     val debug: Boolean = false,
     val privacyProfile: PrivacyProfile = PrivacyProfile(),
-    val capturePeriodMillis: Long = 1000, // defaults to ever 1 second
+    val frameRate: Double = 1.0,
     /** Optional replay scale. Null disables scaling override. */
     val scale: Float? = 1.0f,
     val compression: CompressionMethod = CompressionMethod.OverlayTiles(),

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/SessionReplayService.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/SessionReplayService.kt
@@ -223,6 +223,7 @@ class SessionReplayService(
     override var isEnabled: Boolean
         get() = _isEnabled.value
         set(value) {
+            if (_isEnabled.value == value) return
             _isEnabled.value = value
             if (value) flushPendingIdentify()
         }

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/SessionReplayService.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/SessionReplayService.kt
@@ -196,7 +196,7 @@ class SessionReplayService(
                 } catch (e: Exception) {
                     logger.error("Capture failed", e)
                 }
-                delay(options.capturePeriodMillis)
+                delay(captureManager?.captureDelayMillis ?: Long.MAX_VALUE)
             }
         }
     }

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/capture/CaptureManager.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/capture/CaptureManager.kt
@@ -26,6 +26,11 @@ class CaptureManager(
         compression = options.compression,
         scale = options.scale ?: 1f,
     )
+    val captureDelayMillis: Long = if (options.frameRate > 0) {
+        (1000.0 / options.frameRate).toLong().coerceAtLeast(1L)
+    } else {
+        Long.MAX_VALUE
+    }
 
     /**
      * Requests a [ExportFrame] be taken now.

--- a/sdk/@launchdarkly/observability-android/lib/src/test/kotlin/com/launchdarkly/observability/replay/ReplayOptionsTest.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/test/kotlin/com/launchdarkly/observability/replay/ReplayOptionsTest.kt
@@ -1,0 +1,17 @@
+package com.launchdarkly.observability.replay
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class ReplayOptionsTest {
+
+    @Test
+    fun `frameRate defaults to one frame per second`() {
+        assertEquals(1.0, ReplayOptions().frameRate)
+    }
+
+    @Test
+    fun `frameRate can be configured`() {
+        assertEquals(2.0, ReplayOptions(frameRate = 2.0).frameRate)
+    }
+}

--- a/sdk/@launchdarkly/observability-android/lib/src/test/kotlin/com/launchdarkly/observability/replay/capture/CaptureManagerTest.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/test/kotlin/com/launchdarkly/observability/replay/capture/CaptureManagerTest.kt
@@ -1,0 +1,32 @@
+package com.launchdarkly.observability.replay.capture
+
+import com.launchdarkly.observability.context.ObserveLogger
+import com.launchdarkly.observability.replay.ReplayOptions
+import io.mockk.mockk
+import io.opentelemetry.android.session.SessionManager
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class CaptureManagerTest {
+
+    @Test
+    fun `captureDelayMillis defaults to one second`() {
+        val manager = captureManager()
+
+        assertEquals(1000L, manager.captureDelayMillis)
+    }
+
+    @Test
+    fun `captureDelayMillis is derived from frameRate`() {
+        val manager = captureManager(ReplayOptions(frameRate = 2.0))
+
+        assertEquals(500L, manager.captureDelayMillis)
+    }
+
+    private fun captureManager(options: ReplayOptions = ReplayOptions()) = CaptureManager(
+        sessionManager = mockk<SessionManager>(relaxed = true),
+        options = options,
+        logger = mockk<ObserveLogger>(relaxed = true),
+        imageCaptureService = mockk<ImageCaptureServicing>(relaxed = true),
+    )
+}


### PR DESCRIPTION
## Summary

Android SR options frameRate to match with iOS

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking rename of a public `ReplayOptions` field for integrators; capture timing and replay volume behavior change only when callers set non-default `frameRate`.
> 
> **Overview**
> Android Session Replay now configures capture cadence with **`frameRate`** (frames per second, default **1.0**) instead of **`capturePeriodMillis`**, aligning the option with iOS. **`CaptureManager`** exposes **`captureDelayMillis`** derived from **`frameRate`** (including **`Long.MAX_VALUE`** when rate ≤ 0), and the capture loop in **`SessionReplayService`** sleeps on that value rather than a fixed period.
> 
> The e2e app sets **`frameRate = 1.0`** on **`ReplayOptions`**. **`SessionReplayService.isEnabled`** no-ops when the value is unchanged. Flutter bridge **`FlutterImageCaptureService`** still requests frames on the main thread but decodes bitmaps on **`Dispatchers.Default`**. Unit tests cover defaults and delay math.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3893e5b93968db09e838da62209d7ba0c3f32148. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->