### PR TITLE
fix(ruby): observability plugin compatibility — require server-sdk >= 8.11.0 and fix Rails Railtie load order

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -54,7 +54,10 @@ jobs:
             - name: Setup Node.js environment
               uses: actions/setup-node@v4
               with:
-                  node-version: lts/*
+                  # Pinned: lts/* floated to Node 24.16.0, which hangs the rrvideo
+                  # Playwright browser download during `yarn install` until the job
+                  # times out. 24.15.0 is the last known-good. See PR #575.
+                  node-version: 24.15.0
                   cache: 'yarn'
 
             - name: Install js dependencies

--- a/e2e/ruby/rails/api-only/Gemfile.lock
+++ b/e2e/ruby/rails/api-only/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ../../../../sdk/@launchdarkly/observability-ruby
   specs:
     launchdarkly-observability (0.2.0)
-      launchdarkly-server-sdk (>= 8.0)
+      launchdarkly-server-sdk (>= 8.11.0)
       opentelemetry-exporter-otlp (~> 0.28)
       opentelemetry-exporter-otlp-logs (~> 0.1)
       opentelemetry-instrumentation-all (~> 0.62)

--- a/e2e/ruby/rails/demo/Gemfile.lock
+++ b/e2e/ruby/rails/demo/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ../../../../sdk/@launchdarkly/observability-ruby
   specs:
     launchdarkly-observability (0.2.0)
-      launchdarkly-server-sdk (>= 8.0)
+      launchdarkly-server-sdk (>= 8.11.0)
       opentelemetry-exporter-otlp (~> 0.28)
       opentelemetry-exporter-otlp-logs (~> 0.1)
       opentelemetry-instrumentation-all (~> 0.62)

--- a/sdk/@launchdarkly/observability-ruby/README.md
+++ b/sdk/@launchdarkly/observability-ruby/README.md
@@ -35,7 +35,7 @@ gem install launchdarkly-observability
 ### Dependencies
 
 The gem includes everything needed for traces and logs out of the box:
-- `launchdarkly-server-sdk` >= 8.0
+- `launchdarkly-server-sdk` >= 8.11.0 (plugin support was added in 8.11.0)
 - `opentelemetry-sdk` ~> 1.4
 - `opentelemetry-exporter-otlp` ~> 0.28
 - `opentelemetry-instrumentation-all` ~> 0.62

--- a/sdk/@launchdarkly/observability-ruby/launchdarkly-observability.gemspec
+++ b/sdk/@launchdarkly/observability-ruby/launchdarkly-observability.gemspec
@@ -28,7 +28,9 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   # Runtime dependencies
-  spec.add_dependency 'launchdarkly-server-sdk', '>= 8.0'
+  # Plugin support (LaunchDarkly::Interfaces::Plugins) was added in 8.11.0; earlier
+  # versions raise "uninitialized constant LaunchDarkly::Interfaces::Plugins" on require.
+  spec.add_dependency 'launchdarkly-server-sdk', '>= 8.11.0'
   spec.add_dependency 'opentelemetry-exporter-otlp', '~> 0.28'
   spec.add_dependency 'opentelemetry-instrumentation-all', '~> 0.62'
   spec.add_dependency 'opentelemetry-sdk', '~> 1.4'

--- a/sdk/@launchdarkly/observability-ruby/lib/launchdarkly_observability/plugin.rb
+++ b/sdk/@launchdarkly/observability-ruby/lib/launchdarkly_observability/plugin.rb
@@ -2,6 +2,15 @@
 
 require 'launchdarkly-server-sdk'
 
+# Plugin support (LaunchDarkly::Interfaces::Plugins) was added in launchdarkly-server-sdk 8.11.0.
+# Surface an actionable error instead of a bare "uninitialized constant" if an older SDK is loaded.
+unless defined?(LaunchDarkly::Interfaces::Plugins::Plugin)
+  raise LoadError, 'launchdarkly-observability requires launchdarkly-server-sdk >= 8.11.0 ' \
+                   '(plugin support was added in 8.11.0). Your installed launchdarkly-server-sdk ' \
+                   "version is #{defined?(LaunchDarkly::VERSION) ? LaunchDarkly::VERSION : 'unknown'}. " \
+                   'Please upgrade: bundle update launchdarkly-server-sdk'
+end
+
 module LaunchDarklyObservability
   # LaunchDarkly SDK Plugin that provides observability instrumentation.
   #

--- a/sdk/@launchdarkly/observability-ruby/lib/launchdarkly_observability/rails.rb
+++ b/sdk/@launchdarkly/observability-ruby/lib/launchdarkly_observability/rails.rb
@@ -4,56 +4,16 @@ require_relative 'middleware'
 
 module LaunchDarklyObservability
   if defined?(::Rails::Railtie)
-    # Rails Railtie for automatic integration
+    # Controller and view helper modules are defined BEFORE the Railtie on purpose.
     #
-    # This Railtie automatically:
-    # - Inserts the LaunchDarkly middleware into the Rails middleware stack
-    # - Bridges Rails.logger to the OpenTelemetry Logs pipeline (if logger provider is available)
-    # - Provides helper methods for controllers and views
-    #
-    # @example The Railtie is automatically loaded when Rails is detected
-    #   # In config/initializers/launchdarkly.rb
-    #   LaunchDarklyObservability.init(project_id: ENV['LD_PROJECT_ID'])
-    #
-    class Railtie < ::Rails::Railtie
-      initializer 'launchdarkly_observability.configure_rails' do |app|
-        app.middleware.insert_before(0, LaunchDarklyObservability::Middleware)
-      end
-
-      config.after_initialize do
-        if defined?(ActionController::Base)
-          ActionController::Base.include(LaunchDarklyObservability::ControllerHelpers)
-        end
-
-        if defined?(ActionController::API)
-          ActionController::API.include(LaunchDarklyObservability::ControllerHelpers)
-        end
-
-        attach_otel_log_bridge
-      end
-
-      class << self
-        private
-
-        def attach_otel_log_bridge
-          return unless otel_logger_provider_available?
-
-          bridge = LaunchDarklyObservability::OtelLogBridge.new(OpenTelemetry.logger_provider)
-
-          if ::Rails.logger.respond_to?(:broadcast_to)
-            ::Rails.logger.broadcast_to(bridge)
-          elsif defined?(ActiveSupport::Logger) && ActiveSupport::Logger.respond_to?(:broadcast)
-            ::Rails.logger.extend(ActiveSupport::Logger.broadcast(bridge))
-          end
-        rescue StandardError => e
-          warn "[LaunchDarklyObservability] Could not attach log bridge to Rails.logger: #{e.message}"
-        end
-
-        def otel_logger_provider_available?
-          LaunchDarklyObservability.send(:otel_logger_provider_available?)
-        end
-      end
-    end
+    # The Railtie's `config.after_initialize` hook references ControllerHelpers. That
+    # hook is registered via ActiveSupport's lazy load hooks, which run immediately if
+    # the :after_initialize event has already fired. When the gem is required lazily
+    # *after* Rails has booted (e.g. from an autoloaded model during a request), the
+    # block executes synchronously while this file is still loading. If the helper
+    # modules were defined further down the file, they would not exist yet and the
+    # require would raise "uninitialized constant LaunchDarklyObservability::ControllerHelpers".
+    # Defining them first makes the require order-independent.
 
     # Controller helper methods for Rails
     #
@@ -131,6 +91,61 @@ module LaunchDarklyObservability
         trace_flags = span.context.trace_flags.sampled? ? '01' : '00'
 
         "00-#{trace_id}-#{span_id}-#{trace_flags}"
+      end
+    end
+
+    # Rails Railtie for automatic integration
+    #
+    # This Railtie automatically:
+    # - Inserts the LaunchDarkly middleware into the Rails middleware stack
+    # - Bridges Rails.logger to the OpenTelemetry Logs pipeline (if logger provider is available)
+    # - Provides helper methods for controllers and views
+    #
+    # @example The Railtie is automatically loaded when Rails is detected
+    #   # In config/initializers/launchdarkly.rb
+    #   LaunchDarklyObservability.init(project_id: ENV['LD_PROJECT_ID'])
+    #
+    class Railtie < ::Rails::Railtie
+      # Private helpers are defined before `config.after_initialize` references them.
+      # The after_initialize hook can run synchronously while this class body is still
+      # evaluating (lazy require after Rails has booted — see the note above), so any
+      # method it calls must already be defined at that point.
+      class << self
+        private
+
+        def attach_otel_log_bridge
+          return unless otel_logger_provider_available?
+
+          bridge = LaunchDarklyObservability::OtelLogBridge.new(OpenTelemetry.logger_provider)
+
+          if ::Rails.logger.respond_to?(:broadcast_to)
+            ::Rails.logger.broadcast_to(bridge)
+          elsif defined?(ActiveSupport::Logger) && ActiveSupport::Logger.respond_to?(:broadcast)
+            ::Rails.logger.extend(ActiveSupport::Logger.broadcast(bridge))
+          end
+        rescue StandardError => e
+          warn "[LaunchDarklyObservability] Could not attach log bridge to Rails.logger: #{e.message}"
+        end
+
+        def otel_logger_provider_available?
+          LaunchDarklyObservability.send(:otel_logger_provider_available?)
+        end
+      end
+
+      initializer 'launchdarkly_observability.configure_rails' do |app|
+        app.middleware.insert_before(0, LaunchDarklyObservability::Middleware)
+      end
+
+      config.after_initialize do
+        if defined?(ActionController::Base)
+          ActionController::Base.include(LaunchDarklyObservability::ControllerHelpers)
+        end
+
+        if defined?(ActionController::API)
+          ActionController::API.include(LaunchDarklyObservability::ControllerHelpers)
+        end
+
+        attach_otel_log_bridge
       end
     end
 

--- a/sdk/@launchdarkly/observability-ruby/test/rails_railtie_test.rb
+++ b/sdk/@launchdarkly/observability-ruby/test/rails_railtie_test.rb
@@ -15,52 +15,85 @@ require_relative 'test_helper'
 #
 # This test simulates that "already booted" condition and asserts rails.rb loads clean.
 class RailsRailtieTest < Minitest::Test
+  # Minimal stubs of the Rails surface rails.rb touches. The key behavior is that
+  # `config.after_initialize` invokes its block immediately, mimicking a post-boot
+  # lazy require where the :after_initialize hook has already run.
+  #
+  # Everything we introduce is tracked so teardown can undo ALL of it — some transitive
+  # dependency may already define a partial `::Rails` (without Railtie), and anything we
+  # leak (especially a bogus `Rails.logger`) pollutes other tests: the LD SDK's
+  # Config.default_logger returns `Rails.logger` whenever `Rails.respond_to?(:logger)`.
   def setup
-    # Minimal stubs of the Rails surface rails.rb touches. The key behavior is that
-    # `config.after_initialize` invokes its block immediately, mimicking a post-boot
-    # lazy require where the :after_initialize hook has already run.
-    #
-    # Track exactly what we introduce so teardown only removes our additions — some
-    # transitive dependency may already define a partial `::Rails` (without Railtie).
-    @added = []
+    @added_consts = [] # [owner, const_name] pairs to remove
+    @added_rails_logger = false
 
-    Object.const_set(:Rails, Module.new) unless defined?(::Rails)
-
-    unless defined?(::Rails::Railtie)
-      railtie_config = Class.new do
-        def after_initialize(&block)
-          block.call # already-booted: run synchronously
-        end
-      end
-      railtie = Class.new do
-        def self.initializer(*); end
-      end
-      railtie.const_set(:RAILTIE_CONFIG, railtie_config)
-      railtie.define_singleton_method(:config) { @config ||= self::RAILTIE_CONFIG.new }
-      ::Rails.const_set(:Railtie, railtie)
-      @added << [::Rails, :Railtie]
-    end
-
-    ::Rails.define_singleton_method(:logger) { @logger ||= Object.new } unless ::Rails.respond_to?(:logger)
-
-    unless defined?(::ActionController)
-      action_controller = Module.new
-      action_controller.const_set(:Base, Class.new { def self.include(_mod); end })
-      action_controller.const_set(:API, Class.new { def self.include(_mod); end })
-      Object.const_set(:ActionController, action_controller)
-      @added << [Object, :ActionController]
-    end
-
-    return if defined?(::ActionView)
-    action_view = Module.new
-    action_view.const_set(:Base, Class.new { def self.include(_mod); end })
-    Object.const_set(:ActionView, action_view)
-    @added << [Object, :ActionView]
+    stub_rails
+    stub_rails_logger
+    stub_action_controller
+    stub_action_view
   end
 
   def teardown
-    @added.reverse_each { |mod, const| mod.send(:remove_const, const) if mod.const_defined?(const, false) }
+    # Remove the logger singleton method first (only relevant when we didn't create ::Rails
+    # ourselves; if we did, removing the constant below drops it along with everything else).
+    if @added_rails_logger && defined?(::Rails) && ::Rails.singleton_class.method_defined?(:logger)
+      ::Rails.singleton_class.send(:remove_method, :logger)
+    end
+    @added_consts.reverse_each { |owner, const| owner.send(:remove_const, const) if owner.const_defined?(const, false) }
   end
+
+  private
+
+  def stub_rails
+    unless defined?(::Rails)
+      Object.const_set(:Rails, Module.new)
+      @added_consts << [Object, :Rails]
+    end
+
+    return if defined?(::Rails::Railtie)
+
+    railtie_config = Class.new do
+      def after_initialize(&block)
+        block.call # already-booted: run synchronously
+      end
+    end
+    railtie = Class.new { def self.initializer(*); end }
+    railtie.const_set(:RAILTIE_CONFIG, railtie_config)
+    railtie.define_singleton_method(:config) { @config ||= self::RAILTIE_CONFIG.new }
+    ::Rails.const_set(:Railtie, railtie)
+    @added_consts << [::Rails, :Railtie]
+  end
+
+  # Provide a real (null) logger if Rails doesn't already have one, so attach_otel_log_bridge
+  # works if exercised. Defined only when missing, and removed in teardown to avoid leaking.
+  def stub_rails_logger
+    return if ::Rails.respond_to?(:logger)
+
+    null_logger = ::Logger.new(File::NULL)
+    ::Rails.define_singleton_method(:logger) { null_logger }
+    @added_rails_logger = true
+  end
+
+  def stub_action_controller
+    return if defined?(::ActionController)
+
+    action_controller = Module.new
+    action_controller.const_set(:Base, Class.new { def self.include(_mod); end })
+    action_controller.const_set(:API, Class.new { def self.include(_mod); end })
+    Object.const_set(:ActionController, action_controller)
+    @added_consts << [Object, :ActionController]
+  end
+
+  def stub_action_view
+    return if defined?(::ActionView)
+
+    action_view = Module.new
+    action_view.const_set(:Base, Class.new { def self.include(_mod); end })
+    Object.const_set(:ActionView, action_view)
+    @added_consts << [Object, :ActionView]
+  end
+
+  public
 
   def test_rails_file_loads_when_after_initialize_runs_immediately
     rails_rb = File.expand_path('../lib/launchdarkly_observability/rails.rb', __dir__)

--- a/sdk/@launchdarkly/observability-ruby/test/rails_railtie_test.rb
+++ b/sdk/@launchdarkly/observability-ruby/test/rails_railtie_test.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require_relative 'test_helper'
+
+# Regression test for the Rails Railtie load order.
+#
+# When the gem is required lazily *after* Rails has finished booting (e.g. from an
+# autoloaded model during a request), ActiveSupport's `:after_initialize` load hook
+# has already fired, so `config.after_initialize` runs its block synchronously while
+# rails.rb is still being evaluated. Any constant/method that block references
+# (ControllerHelpers, attach_otel_log_bridge) must therefore be defined *before* the
+# Railtie. Previously they were defined after it, which raised:
+#
+#   uninitialized constant LaunchDarklyObservability::ControllerHelpers
+#
+# This test simulates that "already booted" condition and asserts rails.rb loads clean.
+class RailsRailtieTest < Minitest::Test
+  def setup
+    # Minimal stubs of the Rails surface rails.rb touches. The key behavior is that
+    # `config.after_initialize` invokes its block immediately, mimicking a post-boot
+    # lazy require where the :after_initialize hook has already run.
+    #
+    # Track exactly what we introduce so teardown only removes our additions — some
+    # transitive dependency may already define a partial `::Rails` (without Railtie).
+    @added = []
+
+    Object.const_set(:Rails, Module.new) unless defined?(::Rails)
+
+    unless defined?(::Rails::Railtie)
+      railtie_config = Class.new do
+        def after_initialize(&block)
+          block.call # already-booted: run synchronously
+        end
+      end
+      railtie = Class.new do
+        def self.initializer(*); end
+      end
+      railtie.const_set(:RAILTIE_CONFIG, railtie_config)
+      railtie.define_singleton_method(:config) { @config ||= self::RAILTIE_CONFIG.new }
+      ::Rails.const_set(:Railtie, railtie)
+      @added << [::Rails, :Railtie]
+    end
+
+    ::Rails.define_singleton_method(:logger) { @logger ||= Object.new } unless ::Rails.respond_to?(:logger)
+
+    unless defined?(::ActionController)
+      action_controller = Module.new
+      action_controller.const_set(:Base, Class.new { def self.include(_mod); end })
+      action_controller.const_set(:API, Class.new { def self.include(_mod); end })
+      Object.const_set(:ActionController, action_controller)
+      @added << [Object, :ActionController]
+    end
+
+    return if defined?(::ActionView)
+    action_view = Module.new
+    action_view.const_set(:Base, Class.new { def self.include(_mod); end })
+    Object.const_set(:ActionView, action_view)
+    @added << [Object, :ActionView]
+  end
+
+  def teardown
+    @added.reverse_each { |mod, const| mod.send(:remove_const, const) if mod.const_defined?(const, false) }
+  end
+
+  def test_rails_file_loads_when_after_initialize_runs_immediately
+    rails_rb = File.expand_path('../lib/launchdarkly_observability/rails.rb', __dir__)
+
+    # The bug manifested as a NameError raised during load of this file.
+    load rails_rb
+
+    assert defined?(LaunchDarklyObservability::ControllerHelpers),
+           'ControllerHelpers should be defined after loading rails.rb'
+    assert defined?(LaunchDarklyObservability::ViewHelpers),
+           'ViewHelpers should be defined after loading rails.rb'
+    assert defined?(LaunchDarklyObservability::Railtie),
+           'Railtie should be defined after loading rails.rb'
+  end
+end

--- a/sdk/@launchdarkly/observability-ruby/test/rails_railtie_test.rb
+++ b/sdk/@launchdarkly/observability-ruby/test/rails_railtie_test.rb
@@ -74,12 +74,19 @@ class RailsRailtieTest < Minitest::Test
     @added_rails_logger = true
   end
 
+  # A bare class whose `.include` is a no-op, standing in for ActionController::Base etc.
+  # Built via a helper so the no-op `include` is defined only once (avoids a false-positive
+  # Lint/DuplicateMethods when the same block is inlined for multiple constants).
+  def noop_includable_class
+    Class.new { def self.include(_mod); end }
+  end
+
   def stub_action_controller
     return if defined?(::ActionController)
 
     action_controller = Module.new
-    action_controller.const_set(:Base, Class.new { def self.include(_mod); end })
-    action_controller.const_set(:API, Class.new { def self.include(_mod); end })
+    action_controller.const_set(:Base, noop_includable_class)
+    action_controller.const_set(:API, noop_includable_class)
     Object.const_set(:ActionController, action_controller)
     @added_consts << [Object, :ActionController]
   end
@@ -88,7 +95,7 @@ class RailsRailtieTest < Minitest::Test
     return if defined?(::ActionView)
 
     action_view = Module.new
-    action_view.const_set(:Base, Class.new { def self.include(_mod); end })
+    action_view.const_set(:Base, noop_includable_class)
     Object.const_set(:ActionView, action_view)
     @added_consts << [Object, :ActionView]
   end


### PR DESCRIPTION
## Summary

Two compatibility fixes for the Ruby observability plugin, both surfaced by a customer trying to get `launchdarkly-observability` working in a Rails app ([Slack thread](https://launchdarkly.slack.com/archives/C0B1YHKPAGZ/p1780070472703819?thread_ts=1780069035.521779&cid=C0B1YHKPAGZ)).

### 1. Require `launchdarkly-server-sdk >= 8.11.0`

The plugin includes `LaunchDarkly::Interfaces::Plugins::Plugin` at load time, but that interface was only added in **server-sdk 8.11.0** ("Add experimental plugin support"). The gemspec allowed `>= 8.0`, so bundler could resolve an older, incompatible SDK and `require 'launchdarkly_observability'` would blow up with:

> uninitialized constant LaunchDarkly::Interfaces::Plugins

- Bump the gemspec dependency from `>= 8.0` to `>= 8.11.0`.
- Add a load-time guard that raises an actionable `LoadError` (naming the installed SDK version and the `bundle update` command) instead of the bare constant error, for anyone already sitting on an old SDK.
- Update the README dependency note.

### 2. Fix Rails Railtie load-order crash on lazy require

After upgrading the SDK, the customer hit a second error:

> NameError: uninitialized constant LaunchDarklyObservability::ControllerHelpers

The Railtie's `config.after_initialize` block registers via ActiveSupport's lazy load hooks, which **run immediately if the `:after_initialize` event has already fired**. The customer required the gem lazily from an autoloaded model (`app/models/feature.rb`) *during a request* — i.e. after Rails had booted — so the block executed synchronously while `rails.rb` was still loading. It referenced `ControllerHelpers` and the private `attach_otel_log_bridge`, both defined *below* the Railtie, so the require crashed. In a normal boot the block is deferred until the file finishes loading, which is why standard setups (and our existing tests) never hit it.

- Move `ControllerHelpers` / `ViewHelpers` above the `Railtie`.
- Move the Railtie's private class methods above `config.after_initialize`.
- The require is now order-independent regardless of where/when the gem is loaded.

## How did you test this change?

- Reproduced the customer's exact `ControllerHelpers` crash with a regression test that simulates the already-booted condition (immediate `after_initialize`); it fails on the old ordering and passes on the new one.
- Verified the min-version guard: `require` succeeds on server-sdk 8.12.2/8.13.0; a simulated 8.8.3 (no `Plugins` interface) raises the clear `LoadError`.
- Confirmed default registration paths (explicit `project_id` and auto-extracted SDK key) work on server-sdk 8.13.0.
- `bundle exec rake test` → 114 runs, 0 failures, 0 errors.
- `bundle exec rubocop` on changed files → no offenses.

## Are there any deployment considerations?

None — no migrations or data changes. The next `launchdarkly-observability` release will require server-sdk `>= 8.11.0`; users on older SDKs were already broken at require time and now get a clear upgrade message. The Railtie reordering is behavior-preserving for normal boots and only fixes the lazy-require case.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Ruby gem dependency and Rails boot-path changes affect customer integrations; behavior is intended to fix existing breakages. CI Node pin is low-risk infrastructure.
> 
> **Overview**
> Fixes **launchdarkly-observability** compatibility for Rails apps and tightens the **launchdarkly-server-sdk** floor to **>= 8.11.0** (plugin APIs). A load-time guard in `plugin.rb` raises a clear `LoadError` with upgrade guidance when an older SDK is present; README, gemspec, and e2e `Gemfile.lock` files reflect the new minimum.
> 
> **Rails Railtie load order** is reordered so `ControllerHelpers`, `ViewHelpers`, and Railtie private methods exist before `config.after_initialize` runs—fixing crashes when the gem is required lazily after boot. A new **`rails_railtie_test.rb`** regression test simulates immediate `after_initialize` execution.
> 
> **CI:** `.github/workflows/turbo.yml` pins Node to **24.15.0** instead of `lts/*` to avoid Playwright/rrvideo install hangs on Node 24.16.0.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e24e0f8dd8a5f8afe9fa5a9c9e293ba0f6342d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->