### PR TITLE
[O11Y-1524] feat(rn,android,flutter): add LDObserve.track + afterTrack hook

### DIFF
--- a/sdk/@launchdarkly/flutter/packages/observability/lib/launchdarkly_flutter_observability.dart
+++ b/sdk/@launchdarkly/flutter/packages/observability/lib/launchdarkly_flutter_observability.dart
@@ -1,6 +1,6 @@
 export 'src/plugin/observability_plugin.dart' show ObservabilityPlugin;
 export 'src/plugin/observability_config.dart'
-    show InstrumentationConfig, DebugPrintSetting;
+    show InstrumentationConfig, DebugPrintSetting, ProductAnalyticsConfig;
 export 'src/observe.dart' show Observe;
 export 'src/api/attribute.dart'
     show

--- a/sdk/@launchdarkly/flutter/packages/observability/lib/src/observe.dart
+++ b/sdk/@launchdarkly/flutter/packages/observability/lib/src/observe.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:launchdarkly_flutter_client_sdk/launchdarkly_flutter_client_sdk.dart';
 import 'package:opentelemetry/api.dart' as otel;
 
 import 'api/attribute.dart';
@@ -13,12 +14,109 @@ import 'plugin/observability_config.dart';
 
 const _launchDarklyTracerName = 'launchdarkly-observability';
 const _launchDarklyErrorSpanName = 'launchdarkly.error';
+const _launchDarklyTrackSpanName = 'launchdarkly.track';
 const _defaultLogLevel = 'info';
+
+const _trackKeyAttr = 'key';
+const _trackValueAttr = 'value';
+
+/// Coerce a dynamic value (typically pulled out of `LDValue.toDynamic()`) into
+/// an attribute. Returns `null` for types that cannot be represented as an
+/// OpenTelemetry attribute (which the caller should skip rather than emit as
+/// an [InvalidAttribute]).
+Attribute? _attributeFromDynamic(dynamic value) {
+  if (value is bool) {
+    return BooleanAttribute(value);
+  }
+  if (value is int) {
+    return IntAttribute(value);
+  }
+  if (value is double) {
+    return DoubleAttribute(value);
+  }
+  if (value is String) {
+    return StringAttribute(value);
+  }
+  // Typed-list checks first. In practice `LDValue.toDynamic()` always returns
+  // `List<dynamic>` for arrays so these branches almost never match in
+  // production, but keep them for direct callers that may pass typed lists.
+  if (value is List<String>) {
+    return StringListAttribute(value);
+  }
+  if (value is List<double>) {
+    return DoubleListAttribute(value);
+  }
+  if (value is List<int>) {
+    return IntListAttribute(value);
+  }
+  if (value is List<bool>) {
+    return BooleanListAttribute(value);
+  }
+  // `LDValue.toDynamic()` always returns `List<dynamic>` for arrays. Inspect
+  // element types to pick the appropriate typed-list attribute.
+  if (value is List<dynamic>) {
+    if (value.isEmpty) {
+      // Can't infer element type from an empty list; skip rather than emit a
+      // potentially mistyped attribute.
+      return null;
+    }
+    if (value.every((e) => e is String)) {
+      return StringListAttribute(value.cast<String>());
+    }
+    if (value.every((e) => e is bool)) {
+      return BooleanListAttribute(value.cast<bool>());
+    }
+    if (value.every((e) => e is int)) {
+      return IntListAttribute(value.cast<int>());
+    }
+    if (value.every((e) => e is double)) {
+      return DoubleListAttribute(value.cast<double>());
+    }
+    // Mixed-numeric (int + double): coerce all to double.
+    if (value.every((e) => e is num)) {
+      return DoubleListAttribute(
+        value.map((e) => (e as num).toDouble()).toList(),
+      );
+    }
+    // Mixed or unsupported element types — skip.
+    return null;
+  }
+  return null;
+}
 
 /// Singleton used to access observability features.
 final class Observe {
   static bool _shutdown = false;
   static final List<ObservabilityPlugin> _pluginInstances = [];
+
+  // ---------------------------------------------------------------------------
+  // Process-wide mutable state shared between the observability hook's
+  // `afterIdentify`/`afterTrack` callbacks and direct callers of
+  // [Observe.track]. Lives here (rather than on a per-plugin instance) so that
+  // both code paths see the same context-key + SDK-metadata attribute bags
+  // without threading the plugin handle through every call site. A single LD
+  // plugin instance per process is the expected use; if multiple plugins
+  // register, the last writer wins. [Observe.shutdown] resets these caches to
+  // empty, after which subsequent `track` calls emit minimal spans (just the
+  // track key and any provided data/numericValue, with no context/SDK
+  // metadata).
+  // ---------------------------------------------------------------------------
+
+  /// Cached bare context-key attributes (e.g. `{user: 'alice', org: 'team-a'}`)
+  /// populated by the observability hook's `afterIdentify`. Used as a base
+  /// attribute set on every `launchdarkly.track` span emitted via
+  /// [Observe.track].
+  static Map<String, Attribute> _contextKeyAttributes = <String, Attribute>{};
+
+  /// Cached LaunchDarkly SDK metadata attributes (telemetry.sdk.*,
+  /// launchdarkly.application.*, feature_flag.set.id,
+  /// feature_flag.provider.name). Populated when the observability plugin is
+  /// registered with the LD client.
+  static Map<String, Attribute> _sdkMetadataAttributes = <String, Attribute>{};
+
+  /// Whether product analytics track-event emission is enabled. Populated
+  /// during plugin registration from [ProductAnalyticsConfig.trackEvents].
+  static bool _productAnalyticsTrackEvents = true;
 
   /// Start a span with the given name and optional attributes.
   static Span startSpan(
@@ -98,6 +196,68 @@ final class Observe {
     span.end();
   }
 
+  /// Emit a `launchdarkly.track` span describing a custom track event.
+  ///
+  /// This is the public surface invoked by the observability plugin's
+  /// `afterTrack` hook each time `ldClient.track(...)` is called. It may also
+  /// be called directly for ad-hoc track-event telemetry without going
+  /// through the LD client.
+  ///
+  /// The span's attributes are the union of:
+  ///   - cached LD context-key attributes from the most recent `afterIdentify`
+  ///     (e.g. `{user: 'alice', org: 'team-a'}`),
+  ///   - cached SDK/application metadata (telemetry.sdk.*,
+  ///     launchdarkly.application.*, feature_flag.set.id,
+  ///     feature_flag.provider.name),
+  ///   - the track event `key`,
+  ///   - `value` when [numericValue] is non-null,
+  ///   - any string/int/double/bool entries from [data] when
+  ///     `data.toDynamic()` resolves to a `Map<String, dynamic>`.
+  ///
+  /// If the configured [ProductAnalyticsConfig.trackEvents] is `false`, this
+  /// method is a no-op. All other failure modes (tracer not initialized,
+  /// throw during span construction) are caught internally and swallowed,
+  /// so this method never throws.
+  static void track(String key, {LDValue? data, num? numericValue}) {
+    if (!_productAnalyticsTrackEvents) {
+      return;
+    }
+
+    try {
+      final attributes = <String, Attribute>{
+        ..._contextKeyAttributes,
+        ..._sdkMetadataAttributes,
+        _trackKeyAttr: StringAttribute(key),
+      };
+
+      if (numericValue != null) {
+        attributes[_trackValueAttr] = DoubleAttribute(numericValue.toDouble());
+      }
+
+      if (data != null) {
+        final dynamicValue = data.toDynamic();
+        if (dynamicValue is Map<String, dynamic>) {
+          dynamicValue.forEach((dataKey, dataValue) {
+            final attribute = _attributeFromDynamic(dataValue);
+            if (attribute != null) {
+              attributes[dataKey] = attribute;
+            }
+          });
+        }
+      }
+
+      final span = startSpan(
+        _launchDarklyTrackSpanName,
+        attributes: attributes,
+      );
+      span.end();
+    } catch (_) {
+      // Hook safety: `ldClient.track(...)` must always return normally.
+      // Swallow any internal failure (tracer not initialized, exporter
+      // misconfigured, etc.) so the hook can be a trivial pass-through.
+    }
+  }
+
   /// Shutdown observability. Once shutdown observability cannot be restarted.
   static void shutdown() {
     if (!_shutdown) {
@@ -105,6 +265,9 @@ final class Observe {
       for (final plugin in _pluginInstances) {
         plugin.dispose();
       }
+      _contextKeyAttributes = <String, Attribute>{};
+      _sdkMetadataAttributes = <String, Attribute>{};
+      _productAnalyticsTrackEvents = true;
       _shutdown = true;
     }
   }
@@ -129,4 +292,40 @@ registerPlugin(
 ) {
   Otel.setup(credential, config);
   Observe._pluginInstances.add(plugin);
+  Observe._productAnalyticsTrackEvents =
+      config.productAnalyticsConfig.trackEvents;
+}
+
+/// Not for export.
+/// Populate the cached bare context-key attributes used by [Observe.track].
+/// Called by the observability hook's `afterIdentify`.
+void setLDContextKeyAttributes(Map<String, Attribute> attributes) {
+  Observe._contextKeyAttributes = Map<String, Attribute>.unmodifiable(
+    attributes,
+  );
+}
+
+/// Not for export.
+/// Populate the cached SDK metadata attributes used by [Observe.track].
+/// Called when the observability plugin is registered with the LD client.
+void setLDSdkMetadataAttributes(Map<String, Attribute> attributes) {
+  Observe._sdkMetadataAttributes = Map<String, Attribute>.unmodifiable(
+    attributes,
+  );
+}
+
+/// Not for export.
+/// Helper exposed for testing — coerce a dynamic value (typically pulled out
+/// of `LDValue.toDynamic()`) into an attribute, returning `null` for types
+/// that cannot be represented.
+Attribute? attributeFromDynamicForTest(dynamic value) =>
+    _attributeFromDynamic(value);
+
+/// Not for export.
+/// Helper exposed for testing — directly set the product-analytics gate
+/// without spinning up a full LD client + plugin registration. Production
+/// callers should use [registerPlugin] which seeds this from
+/// [ProductAnalyticsConfig.trackEvents].
+void setProductAnalyticsTrackEventsForTest(bool enabled) {
+  Observe._productAnalyticsTrackEvents = enabled;
 }

--- a/sdk/@launchdarkly/flutter/packages/observability/lib/src/plugin/observability_config.dart
+++ b/sdk/@launchdarkly/flutter/packages/observability/lib/src/plugin/observability_config.dart
@@ -85,6 +85,27 @@ final class InstrumentationConfig {
   InstrumentationConfig({this.debugPrint = const DebugPrintReleaseOnly()});
 }
 
+/// Configuration for product analytics behaviors.
+///
+/// Currently this controls whether the observability plugin emits a
+/// `launchdarkly.track` span for each `ldClient.track(...)` call. When
+/// disabled, both the `afterTrack` hook and any direct calls to
+/// [Observe.track] become no-ops.
+final class ProductAnalyticsConfig {
+  /// Whether `launchdarkly.track` spans should be emitted for track events.
+  ///
+  /// Defaults to `true`.
+  final bool trackEvents;
+
+  /// Construct a product analytics configuration.
+  ///
+  /// [trackEvents] When `true` (the default) the observability plugin emits
+  /// a `launchdarkly.track` span for every track event seen via the LD
+  /// client's `afterTrack` hook and for every direct call to
+  /// `Observe.track`. When `false`, both code paths are no-ops.
+  const ProductAnalyticsConfig({this.trackEvents = true});
+}
+
 final class ObservabilityConfig {
   /// The configured OTLP endpoint.
   final String otlpEndpoint;
@@ -107,12 +128,16 @@ final class ObservabilityConfig {
   /// Configuration of instrumentations.
   final InstrumentationConfig instrumentationConfig;
 
+  /// Configuration of product analytics behaviors.
+  final ProductAnalyticsConfig productAnalyticsConfig;
+
   ObservabilityConfig({
     this.applicationName,
     this.applicationVersion,
     required this.otlpEndpoint,
     required this.backendUrl,
     required this.instrumentationConfig,
+    required this.productAnalyticsConfig,
     this.contextFriendlyName,
   });
 }
@@ -124,6 +149,7 @@ ObservabilityConfig configWithDefaults({
   String? backendUrl,
   String? Function(LDContext context)? contextFriendlyName,
   InstrumentationConfig? instrumentationConfig,
+  ProductAnalyticsConfig? productAnalyticsConfig,
 }) {
   return ObservabilityConfig(
     applicationName: applicationName,
@@ -132,5 +158,7 @@ ObservabilityConfig configWithDefaults({
     backendUrl: backendUrl ?? _defaultBackendUrl,
     contextFriendlyName: contextFriendlyName,
     instrumentationConfig: instrumentationConfig ?? InstrumentationConfig(),
+    productAnalyticsConfig:
+        productAnalyticsConfig ?? const ProductAnalyticsConfig(),
   );
 }

--- a/sdk/@launchdarkly/flutter/packages/observability/lib/src/plugin/observability_plugin.dart
+++ b/sdk/@launchdarkly/flutter/packages/observability/lib/src/plugin/observability_plugin.dart
@@ -1,6 +1,7 @@
 import 'dart:collection';
 
 import 'package:launchdarkly_flutter_client_sdk/launchdarkly_flutter_client_sdk.dart';
+import 'package:launchdarkly_flutter_observability/src/api/attribute.dart';
 import 'package:launchdarkly_flutter_observability/src/api/span_status_code.dart';
 import 'package:launchdarkly_flutter_observability/src/instrumentation/debug_print.dart';
 import 'package:launchdarkly_flutter_observability/src/instrumentation/instrumentation.dart';
@@ -14,6 +15,65 @@ import '../observe.dart';
 const _launchDarklyObservabilityName = 'launchdarkly-observability';
 const _launchDarklyObservabilityPluginName =
     '$_launchDarklyObservabilityName-plugin';
+
+// SDK-metadata attribute keys mirrored from the JS reference plugin
+// (`sdk/highlight-run/src/integrations/launchdarkly/index.ts`).
+const _telemetrySdkNameAttr = 'telemetry.sdk.name';
+const _telemetrySdkVersionAttr = 'telemetry.sdk.version';
+const _featureFlagSetIdAttr = 'feature_flag.set.id';
+const _featureFlagProviderNameAttr = 'feature_flag.provider.name';
+const _launchDarklyApplicationIdAttr = 'launchdarkly.application.id';
+const _launchDarklyApplicationVersionAttr = 'launchdarkly.application.version';
+const _launchDarklyProviderName = 'LaunchDarkly';
+
+/// Build the SDK-metadata attribute bag for `launchdarkly.track` spans from the
+/// plugin's [PluginEnvironmentMetadata]. Exported as `package-private` so the
+/// observability plugin's `register` can cache it onto [Observe] and so unit
+/// tests can verify the mapping directly.
+Map<String, Attribute> buildSdkMetadataAttributes(
+  PluginEnvironmentMetadata environmentMetadata,
+) {
+  final attributes = <String, Attribute>{
+    _telemetrySdkNameAttr: StringAttribute(environmentMetadata.sdk.name),
+    _telemetrySdkVersionAttr: StringAttribute(environmentMetadata.sdk.version),
+    _featureFlagSetIdAttr: StringAttribute(
+      environmentMetadata.credential.value,
+    ),
+    _featureFlagProviderNameAttr: StringAttribute(_launchDarklyProviderName),
+  };
+
+  final application = environmentMetadata.application;
+  if (application != null) {
+    // `ApplicationInfo.applicationId` is non-required at the storage layer
+    // (sanitization can null it out even though the constructor takes a
+    // required String). Only emit attributes when the values are present.
+    final applicationId = application.applicationId;
+    if (applicationId != null) {
+      attributes[_launchDarklyApplicationIdAttr] = StringAttribute(
+        applicationId,
+      );
+    }
+    final applicationVersion = application.applicationVersion;
+    if (applicationVersion != null) {
+      attributes[_launchDarklyApplicationVersionAttr] = StringAttribute(
+        applicationVersion,
+      );
+    }
+  }
+
+  return attributes;
+}
+
+/// Build the bare LaunchDarkly context-key attribute bag (e.g.
+/// `{user: 'alice', org: 'team-a'}`) from an [LDContext]. Mirrors the JS
+/// `getContextKeys` helper but emits typed [StringAttribute] values directly.
+Map<String, Attribute> buildContextKeyAttributes(LDContext context) {
+  final attributes = <String, Attribute>{};
+  context.keys.forEach((kind, key) {
+    attributes[kind] = StringAttribute(key);
+  });
+  return attributes;
+}
 
 final class _ObservabilityHook extends Hook {
   static const _evalSpanDataName = 'eval-span';
@@ -65,6 +125,43 @@ final class _ObservabilityHook extends Hook {
     }
     return data;
   }
+
+  @override
+  UnmodifiableMapView<String, dynamic> afterIdentify(
+    IdentifySeriesContext hookContext,
+    UnmodifiableMapView<String, dynamic> data,
+    IdentifyResult result,
+  ) {
+    // Cache the bare LD context-key attributes so subsequent
+    // `Observe.track(...)` (or `afterTrack`) calls can spread them onto the
+    // `launchdarkly.track` span without re-deriving them from the context.
+    try {
+      setLDContextKeyAttributes(buildContextKeyAttributes(hookContext.context));
+    } catch (_) {
+      // Hook safety: identify must always return normally.
+    }
+    return data;
+  }
+
+  @override
+  void afterTrack(TrackSeriesContext hookContext) {
+    // Thin pass-through to the public `Observe.track`. All gating, attribute
+    // assembly, and exception handling lives there. The defensive try/catch
+    // here is belt-and-suspenders: `Observe.track` already swallows internal
+    // failures, but wrapping the call site guarantees that the hook continues
+    // to satisfy the `ldClient.track(...)` "must always return normally"
+    // contract even if a future refactor moves work into `Observe.track`'s
+    // prologue (before its own try/catch).
+    try {
+      Observe.track(
+        hookContext.key,
+        data: hookContext.data,
+        numericValue: hookContext.numericValue,
+      );
+    } catch (_) {
+      // Hook safety: LDClient.track() must always return normally.
+    }
+  }
 }
 
 /// LaunchDarkly Observability plugin.
@@ -106,6 +203,7 @@ final class ObservabilityPlugin extends Plugin {
     String? backendUrl,
     String? Function(LDContext context)? contextFriendlyName,
     InstrumentationConfig? instrumentation,
+    ProductAnalyticsConfig? productAnalytics,
   }) : _config = configWithDefaults(
          applicationName: applicationName,
          applicationVersion: applicationVersion,
@@ -113,6 +211,7 @@ final class ObservabilityPlugin extends Plugin {
          backendUrl: backendUrl,
          contextFriendlyName: contextFriendlyName,
          instrumentationConfig: instrumentation,
+         productAnalyticsConfig: productAnalytics,
        ) {
     _instrumentations.add(LifecycleInstrumentation());
     _instrumentations.add(
@@ -126,6 +225,7 @@ final class ObservabilityPlugin extends Plugin {
     PluginEnvironmentMetadata environmentMetadata,
   ) {
     registerPlugin(this, environmentMetadata.credential.value, _config);
+    setLDSdkMetadataAttributes(buildSdkMetadataAttributes(environmentMetadata));
     super.register(client, environmentMetadata);
   }
 

--- a/sdk/@launchdarkly/flutter/packages/observability/test/observability_plugin_test.dart
+++ b/sdk/@launchdarkly/flutter/packages/observability/test/observability_plugin_test.dart
@@ -1,0 +1,349 @@
+import 'dart:collection';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:launchdarkly_flutter_client_sdk/launchdarkly_flutter_client_sdk.dart';
+import 'package:launchdarkly_flutter_observability/launchdarkly_flutter_observability.dart';
+import 'package:launchdarkly_flutter_observability/src/observe.dart';
+import 'package:launchdarkly_flutter_observability/src/plugin/observability_plugin.dart';
+import 'package:opentelemetry/api.dart' as otel_api;
+import 'package:opentelemetry/sdk.dart' as otel_sdk;
+
+/// Test-only span processor that captures every finished span.
+class _RecordingSpanProcessor implements otel_sdk.SpanProcessor {
+  final List<otel_sdk.ReadOnlySpan> recorded = <otel_sdk.ReadOnlySpan>[];
+
+  @override
+  void onStart(otel_sdk.ReadWriteSpan span, otel_api.Context parentContext) {}
+
+  @override
+  void onEnd(otel_sdk.ReadOnlySpan span) {
+    recorded.add(span);
+  }
+
+  @override
+  void forceFlush() {}
+
+  @override
+  void shutdown() {}
+}
+
+/// Tracer provider whose inner delegate is swappable. See observe_test.dart
+/// for the rationale — opentelemetry-dart's `registerGlobalTracerProvider`
+/// only permits one call per isolate, so we install this wrapper once and
+/// swap its inner between tests.
+class _SwappableTracerProvider implements otel_api.TracerProvider {
+  otel_api.TracerProvider _inner;
+
+  _SwappableTracerProvider(this._inner);
+
+  void setInner(otel_api.TracerProvider inner) {
+    _inner = inner;
+  }
+
+  @override
+  otel_api.Tracer getTracer(
+    String name, {
+    String? version,
+    String? schemaUrl,
+    List<otel_api.Attribute>? attributes,
+  }) {
+    return _inner.getTracer(
+      name,
+      version: version ?? '',
+      schemaUrl: schemaUrl ?? '',
+      attributes: attributes ?? const [],
+    );
+  }
+
+  @override
+  void forceFlush() => _inner.forceFlush();
+
+  @override
+  void shutdown() => _inner.shutdown();
+}
+
+final _SwappableTracerProvider _globalProvider = () {
+  final initial = otel_sdk.TracerProviderBase();
+  final wrapper = _SwappableTracerProvider(initial);
+  otel_api.registerGlobalTracerProvider(wrapper);
+  return wrapper;
+}();
+
+_RecordingSpanProcessor _installRecorder() {
+  final processor = _RecordingSpanProcessor();
+  final provider = otel_sdk.TracerProviderBase(processors: [processor]);
+  _globalProvider.setInner(provider);
+  return processor;
+}
+
+void _resetCaches() {
+  setLDContextKeyAttributes(<String, Attribute>{});
+  setLDSdkMetadataAttributes(<String, Attribute>{});
+  setProductAnalyticsTrackEventsForTest(true);
+}
+
+void main() {
+  // `ObservabilityPlugin()` constructs a `LifecycleInstrumentation`, which
+  // touches `SchedulerBinding.instance`; the test framework requires the
+  // binding to be initialized before any such access.
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('_ObservabilityHook.afterTrack', () {
+    setUp(_resetCaches);
+
+    test('delegates to Observe.track with key/data/numericValue', () {
+      final processor = _installRecorder();
+      final plugin = ObservabilityPlugin();
+      final hook = plugin.hooks.single;
+
+      final context = LDContextBuilder().kind('user', 'alice').build();
+      final data = LDValue.buildObject()
+          .addValue('plan', LDValue.ofString('pro'))
+          .build();
+
+      hook.afterTrack(
+        TrackSeriesContext.internal(
+          key: 'subscribed',
+          context: context,
+          data: data,
+          numericValue: 9.99,
+        ),
+      );
+
+      expect(processor.recorded, hasLength(1));
+      final span = processor.recorded.single;
+      expect(span.name, equals('launchdarkly.track'));
+      expect(span.attributes.get('key'), equals('subscribed'));
+      expect(span.attributes.get('value'), equals(9.99));
+      expect(span.attributes.get('plan'), equals('pro'));
+    });
+
+    test('is a no-op when product analytics is disabled', () {
+      final processor = _installRecorder();
+      // Simulate `register()` having seeded the gate from
+      // `ProductAnalyticsConfig(trackEvents: false)` — we don't spin up a
+      // real LD client in this unit test, so we set the gate directly.
+      setProductAnalyticsTrackEventsForTest(false);
+      final plugin = ObservabilityPlugin();
+      final hook = plugin.hooks.single;
+
+      hook.afterTrack(
+        TrackSeriesContext.internal(
+          key: 'event',
+          context: LDContextBuilder().kind('user', 'alice').build(),
+          data: null,
+          numericValue: null,
+        ),
+      );
+
+      expect(processor.recorded, isEmpty);
+    });
+
+    test('does not throw when context-key cache is empty', () {
+      final processor = _installRecorder();
+      final plugin = ObservabilityPlugin();
+      final hook = plugin.hooks.single;
+
+      // No afterIdentify ran first — context-key cache is empty.
+      expect(
+        () => hook.afterTrack(
+          TrackSeriesContext.internal(
+            key: 'event',
+            context: LDContextBuilder().kind('user', 'alice').build(),
+            data: null,
+            numericValue: null,
+          ),
+        ),
+        returnsNormally,
+      );
+      expect(processor.recorded, hasLength(1));
+    });
+
+    test('afterTrack does not throw when downstream tracer throws', () {
+      // Swap the global provider's inner to one that throws on every
+      // getTracer() call so the span construction path inside Observe.track
+      // (and therefore the hook's pass-through) is forced to raise. Hook
+      // contract: `LDClient.track(...)` must always return normally, so the
+      // hook MUST catch and swallow.
+      _globalProvider.setInner(_ThrowingTracerProvider());
+      try {
+        final plugin = ObservabilityPlugin();
+        final hook = plugin.hooks.single;
+
+        expect(
+          () => hook.afterTrack(
+            TrackSeriesContext.internal(
+              key: 'event',
+              context: LDContextBuilder().kind('user', 'alice').build(),
+              data: null,
+              numericValue: null,
+            ),
+          ),
+          returnsNormally,
+        );
+      } finally {
+        // Restore a non-throwing inner so subsequent tests aren't poisoned.
+        _globalProvider.setInner(otel_sdk.TracerProviderBase());
+      }
+    });
+  });
+
+  group('_ObservabilityHook.afterIdentify', () {
+    setUp(_resetCaches);
+
+    test(
+      'populates the context-key cache so subsequent track spans include them',
+      () {
+        final processor = _installRecorder();
+        final plugin = ObservabilityPlugin();
+        final hook = plugin.hooks.single;
+
+        final context = LDContextBuilder()
+            .kind('user', 'alice')
+            .kind('org', 'team-a')
+            .build();
+
+        hook.afterIdentify(
+          IdentifySeriesContext.internal(context: context),
+          UnmodifiableMapView(<String, dynamic>{}),
+          IdentifyComplete(),
+        );
+
+        // The cache is populated; emit a track span and check the bare-key
+        // spread shows up in attributes.
+        Observe.track('post-identify-event');
+
+        expect(processor.recorded, hasLength(1));
+        final attrs = processor.recorded.single.attributes;
+        expect(attrs.get('user'), equals('alice'));
+        expect(attrs.get('org'), equals('team-a'));
+      },
+    );
+
+    test('returns the data argument unchanged', () {
+      final plugin = ObservabilityPlugin();
+      final hook = plugin.hooks.single;
+      final input = UnmodifiableMapView(<String, dynamic>{'k': 'v'});
+
+      final result = hook.afterIdentify(
+        IdentifySeriesContext.internal(
+          context: LDContextBuilder().kind('user', 'alice').build(),
+        ),
+        input,
+        IdentifyComplete(),
+      );
+
+      expect(result, same(input));
+    });
+  });
+
+  group('buildSdkMetadataAttributes', () {
+    test('emits required attributes when application metadata is absent', () {
+      final metadata = PluginEnvironmentMetadata(
+        sdk: PluginSdkMetadata(
+          name: 'launchdarkly-flutter-sdk',
+          version: '4.12.0',
+        ),
+        credential: PluginCredentialInfo(
+          type: CredentialType.mobileKey,
+          value: 'mob-fake-key',
+        ),
+      );
+
+      final attrs = buildSdkMetadataAttributes(metadata);
+
+      expect(
+        (attrs['telemetry.sdk.name'] as StringAttribute).value,
+        equals('launchdarkly-flutter-sdk'),
+      );
+      expect(
+        (attrs['telemetry.sdk.version'] as StringAttribute).value,
+        equals('4.12.0'),
+      );
+      expect(
+        (attrs['feature_flag.set.id'] as StringAttribute).value,
+        equals('mob-fake-key'),
+      );
+      expect(
+        (attrs['feature_flag.provider.name'] as StringAttribute).value,
+        equals('LaunchDarkly'),
+      );
+      expect(attrs.containsKey('launchdarkly.application.id'), isFalse);
+      expect(attrs.containsKey('launchdarkly.application.version'), isFalse);
+    });
+
+    test(
+      'includes application id/version when application metadata is provided',
+      () {
+        final metadata = PluginEnvironmentMetadata(
+          sdk: PluginSdkMetadata(
+            name: 'launchdarkly-flutter-sdk',
+            version: '4.12.0',
+          ),
+          credential: PluginCredentialInfo(
+            type: CredentialType.mobileKey,
+            value: 'mob-fake-key',
+          ),
+          application: ApplicationInfo(
+            applicationId: 'my-app',
+            applicationVersion: '1.2.3',
+          ),
+        );
+
+        final attrs = buildSdkMetadataAttributes(metadata);
+
+        expect(
+          (attrs['launchdarkly.application.id'] as StringAttribute).value,
+          equals('my-app'),
+        );
+        expect(
+          (attrs['launchdarkly.application.version'] as StringAttribute).value,
+          equals('1.2.3'),
+        );
+      },
+    );
+  });
+
+  group('buildContextKeyAttributes', () {
+    test('emits bare top-level keys for each context kind', () {
+      final context = LDContextBuilder()
+          .kind('user', 'alice')
+          .kind('org', 'team-a')
+          .build();
+
+      final attrs = buildContextKeyAttributes(context);
+
+      expect((attrs['user'] as StringAttribute).value, equals('alice'));
+      expect((attrs['org'] as StringAttribute).value, equals('team-a'));
+    });
+
+    test('returns an empty map for an invalid/empty context', () {
+      final context = LDContextBuilder().build(); // no kinds
+
+      final attrs = buildContextKeyAttributes(context);
+
+      expect(attrs, isEmpty);
+    });
+  });
+}
+
+/// A tracer provider whose `getTracer` always throws. Used to exercise the
+/// hook-safety try/catch inside `_ObservabilityHook.afterTrack` (and
+/// `Observe.track`).
+class _ThrowingTracerProvider implements otel_api.TracerProvider {
+  @override
+  otel_api.Tracer getTracer(
+    String name, {
+    String? version,
+    String? schemaUrl,
+    List<otel_api.Attribute>? attributes,
+  }) {
+    throw StateError('intentional test failure');
+  }
+
+  @override
+  void forceFlush() {}
+
+  @override
+  void shutdown() {}
+}

--- a/sdk/@launchdarkly/flutter/packages/observability/test/observe_e2e_test.dart
+++ b/sdk/@launchdarkly/flutter/packages/observability/test/observe_e2e_test.dart
@@ -1,0 +1,191 @@
+// E2E test for O11Y-1524 — verify Observe.track emits a launchdarkly.track
+// span over real OTLP to the local backend (devbox SSH-forwarded), and that
+// the row lands in ClickHouse default.traces with the expected attributes.
+//
+// Run with:
+//   flutter test test/observe_e2e_test.dart
+//
+// Prereqs:
+//   - Backend HTTP listener at http://localhost:9096 with OTLP at /otel/v1/traces
+//   - ClickHouse HTTP at http://localhost:8123 with default.traces table
+//
+// This is a real-network test; it's intentionally NOT registered as a default
+// unit-test target.
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:launchdarkly_flutter_client_sdk/launchdarkly_flutter_client_sdk.dart';
+import 'package:launchdarkly_flutter_observability/launchdarkly_flutter_observability.dart';
+import 'package:launchdarkly_flutter_observability/src/observe.dart';
+import 'package:opentelemetry/api.dart' as otel_api;
+import 'package:opentelemetry/sdk.dart' as otel_sdk;
+
+const _backendHost = 'localhost';
+const _backendPort = 9096;
+const _otlpPath = '/otel/v1/traces';
+const _chHost = 'localhost';
+const _chPort = 8123;
+const _projectId = '1';
+
+/// Mirror of Observe.shutdown()-restorable state for tests. We don't call
+/// Observe.shutdown() here because it permanently disables the singleton.
+
+Future<String> _chQueryString(String query) async {
+  final client = HttpClient();
+  try {
+    final uri = Uri(
+      scheme: 'http',
+      host: _chHost,
+      port: _chPort,
+      path: '/',
+      queryParameters: {'query': query},
+    );
+    final req = await client.getUrl(uri);
+    final resp = await req.close();
+    final body = await resp.transform(utf8.decoder).join();
+    return body;
+  } finally {
+    client.close();
+  }
+}
+
+void main() {
+  // CRITICAL: do NOT call TestWidgetsFlutterBinding.ensureInitialized() — its
+  // `createHttpClient` override forces every `HttpClient` (and `http.Client`
+  // built on top of it) to return 400, which would block both the OTLP POST
+  // from CollectorExporter and our ClickHouse polls. Explicitly clear any
+  // HttpOverrides that an earlier test or binding may have installed.
+  HttpOverrides.global = null;
+
+  test(
+    'Observe.track end-to-end: span lands in ClickHouse default.traces',
+    () async {
+      // 1. Generate unique event key.
+      final eventKey =
+          'test-event-flutter-${DateTime.now().microsecondsSinceEpoch}';
+      // ignore: avoid_print
+      print('E2E event key: $eventKey');
+
+      // 2. Build a real TracerProvider with OTLP HTTP exporter pointed at the
+      //    devbox backend, mirroring lib/src/otel/setup.dart but with a faster
+      //    flush cadence.
+      final resourceAttributes = <otel_api.Attribute>[
+        otel_api.Attribute.fromString('highlight.project_id', _projectId),
+        otel_api.Attribute.fromString('service.name', 'flutter-e2e-test'),
+        otel_api.Attribute.fromString('service.version', '0.0.0-e2e'),
+      ];
+
+      final exporter = otel_sdk.CollectorExporter(
+        Uri.parse('http://$_backendHost:$_backendPort$_otlpPath'),
+      );
+      final batchProcessor = otel_sdk.BatchSpanProcessor(
+        exporter,
+        scheduledDelayMillis: 200,
+      );
+      final tracerProvider = otel_sdk.TracerProviderBase(
+        processors: [batchProcessor],
+        resource: otel_sdk.Resource(resourceAttributes),
+      );
+
+      // The opentelemetry-dart package allows only ONE registerGlobalTracerProvider
+      // call per process. If a previous test or `Observe.shutdown()` ran in the
+      // same `flutter test` invocation, calling register again throws. Guard it.
+      try {
+        otel_api.registerGlobalTracerProvider(tracerProvider);
+      } catch (_) {
+        // already registered — swap by setting global via reflection is not
+        // possible. Fall back to using the provider directly is also not
+        // possible because Observe.startSpan reads otel.globalTracerProvider.
+        // For a freshly-spawned `flutter test` process, the first registration
+        // here is THE global, so this branch should never hit in practice.
+      }
+
+      // 3. Seed Observe's process-wide caches the way the plugin's
+      //    afterIdentify + registration would, so that the resulting
+      //    launchdarkly.track span carries representative context/SDK
+      //    metadata.
+      setLDContextKeyAttributes(<String, Attribute>{
+        'user': StringAttribute('alice'),
+        'org': StringAttribute('team-a'),
+      });
+      setLDSdkMetadataAttributes(<String, Attribute>{
+        'telemetry.sdk.name': StringAttribute('launchdarkly-flutter'),
+        'telemetry.sdk.version': StringAttribute('0.0.0-e2e'),
+        'launchdarkly.application.id': StringAttribute('flutter-e2e-test'),
+        'feature_flag.set.id': StringAttribute(_projectId),
+        'feature_flag.provider.name': StringAttribute('launchdarkly'),
+      });
+      setProductAnalyticsTrackEventsForTest(true);
+
+      // 4. Call Observe.track with `data` containing a string field and a
+      //    numericValue. The hook contract under test is: the resulting span
+      //    should carry key=<eventKey>, value=42.0, foo='bar', plus context
+      //    and SDK metadata attrs.
+      Observe.track(
+        eventKey,
+        data: LDValue.buildObject().addString('foo', 'bar').build(),
+        numericValue: 42.0,
+      );
+
+      // 5. Force-flush the batch processor so the exporter posts immediately.
+      tracerProvider.forceFlush();
+      // BatchSpanProcessor.forceFlush is synchronous and just calls
+      // exporter.export(); the HTTP POST itself is fire-and-forget on a
+      // microtask. Give it a moment to actually hit the wire before polling.
+      await Future<void>.delayed(const Duration(milliseconds: 500));
+
+      // 6. Poll ClickHouse for our row. The OTLP handler -> Kafka -> worker
+      //    -> CH pipeline can take a few seconds in the devbox setup.
+      final pollQuery =
+          "SELECT SpanName, ProjectId, TraceAttributes['key'] AS k, "
+          "TraceAttributes['value'] AS v, TraceAttributes['foo'] AS foo, "
+          "TraceAttributes['user'] AS user_attr, "
+          "TraceAttributes['feature_flag.provider.name'] AS provider_name "
+          "FROM default.traces WHERE TraceAttributes['key'] = '$eventKey' "
+          "AND SpanName = 'launchdarkly.track' LIMIT 1 FORMAT JSON";
+
+      final start = DateTime.now();
+      Map<String, dynamic>? row;
+      String lastBody = '';
+      while (DateTime.now().difference(start) < const Duration(seconds: 45)) {
+        final body = await _chQueryString(pollQuery);
+        lastBody = body;
+        final parsed = jsonDecode(body) as Map<String, dynamic>;
+        final data = parsed['data'] as List<dynamic>?;
+        if (data != null && data.isNotEmpty) {
+          row = data.first as Map<String, dynamic>;
+          break;
+        }
+        await Future<void>.delayed(const Duration(seconds: 1));
+      }
+
+      final elapsed = DateTime.now().difference(start);
+      // ignore: avoid_print
+      print('Time-to-trace: ${elapsed.inMilliseconds}ms');
+      // ignore: avoid_print
+      print('Last CH body: $lastBody');
+
+      expect(
+        row,
+        isNotNull,
+        reason:
+            'launchdarkly.track span never appeared in default.traces. '
+            'Last CH response: $lastBody',
+      );
+
+      // 7. Assert key fields.
+      expect(row!['SpanName'], 'launchdarkly.track');
+      expect(row['ProjectId'].toString(), _projectId);
+      expect(row['k'], eventKey);
+      // numericValue=42.0 is emitted as a double-typed OTLP attribute; CH
+      // serializes Map(String, String) as the stringified value.
+      expect(row['v'], '42');
+      expect(row['foo'], 'bar');
+      expect(row['user_attr'], 'alice');
+      expect(row['provider_name'], 'launchdarkly');
+    },
+    timeout: const Timeout(Duration(minutes: 2)),
+  );
+}

--- a/sdk/@launchdarkly/flutter/packages/observability/test/observe_test.dart
+++ b/sdk/@launchdarkly/flutter/packages/observability/test/observe_test.dart
@@ -1,0 +1,432 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:launchdarkly_flutter_client_sdk/launchdarkly_flutter_client_sdk.dart';
+import 'package:launchdarkly_flutter_observability/launchdarkly_flutter_observability.dart';
+import 'package:launchdarkly_flutter_observability/src/observe.dart';
+import 'package:opentelemetry/api.dart' as otel_api;
+import 'package:opentelemetry/sdk.dart' as otel_sdk;
+
+/// Test-only span processor that captures every finished span into an
+/// in-memory list so the test can assert on the span name and attributes
+/// emitted by `Observe.track`.
+class _RecordingSpanProcessor implements otel_sdk.SpanProcessor {
+  final List<otel_sdk.ReadOnlySpan> recorded = <otel_sdk.ReadOnlySpan>[];
+
+  @override
+  void onStart(otel_sdk.ReadWriteSpan span, otel_api.Context parentContext) {}
+
+  @override
+  void onEnd(otel_sdk.ReadOnlySpan span) {
+    recorded.add(span);
+  }
+
+  @override
+  void forceFlush() {}
+
+  @override
+  void shutdown() {}
+}
+
+/// Tracer provider whose inner delegate is swappable. The opentelemetry-dart
+/// package's `registerGlobalTracerProvider` can only be called once per
+/// process; this delegating wrapper is installed once and then has its inner
+/// state reset between tests. It also lets tests temporarily swap in a
+/// throwing provider to exercise hook-safety code paths.
+class _SwappableTracerProvider implements otel_api.TracerProvider {
+  otel_api.TracerProvider _inner;
+
+  _SwappableTracerProvider(this._inner);
+
+  void setInner(otel_api.TracerProvider inner) {
+    _inner = inner;
+  }
+
+  @override
+  otel_api.Tracer getTracer(
+    String name, {
+    String? version,
+    String? schemaUrl,
+    List<otel_api.Attribute>? attributes,
+  }) {
+    return _inner.getTracer(
+      name,
+      version: version ?? '',
+      schemaUrl: schemaUrl ?? '',
+      attributes: attributes ?? const [],
+    );
+  }
+
+  @override
+  void forceFlush() => _inner.forceFlush();
+
+  @override
+  void shutdown() => _inner.shutdown();
+}
+
+/// Singleton swappable provider installed once at process start. Tests obtain
+/// a fresh [_RecordingSpanProcessor] via [_installRecorder] without violating
+/// the opentelemetry-dart "register once" constraint.
+final _SwappableTracerProvider _globalProvider = () {
+  // Install the swappable wrapper exactly once. Initial inner is a no-op
+  // tracer provider; [_installRecorder] swaps in a recording one per test.
+  final initial = otel_sdk.TracerProviderBase();
+  final wrapper = _SwappableTracerProvider(initial);
+  otel_api.registerGlobalTracerProvider(wrapper);
+  return wrapper;
+}();
+
+/// Reset the global tracer provider to a fresh recording one for the current
+/// test, returning the new [_RecordingSpanProcessor] so the test can assert on
+/// captured spans.
+_RecordingSpanProcessor _installRecorder() {
+  final processor = _RecordingSpanProcessor();
+  final provider = otel_sdk.TracerProviderBase(processors: [processor]);
+  _globalProvider.setInner(provider);
+  return processor;
+}
+
+void _resetCaches() {
+  // Reset the package-private caches between tests so order independence
+  // holds. (`Observe.track` reads these caches as the base attribute bag.)
+  setLDContextKeyAttributes(<String, Attribute>{});
+  setLDSdkMetadataAttributes(<String, Attribute>{});
+  setProductAnalyticsTrackEventsForTest(true);
+}
+
+/// Match a span recorded by [_RecordingSpanProcessor] against a name +
+/// expected attribute subset. Only string-valued attributes are compared for
+/// readability; numeric/bool attributes are inspected via direct .get(key).
+Matcher _hasSpanName(String name) =>
+    predicate<otel_sdk.ReadOnlySpan>((s) => s.name == name, 'name == $name');
+
+void main() {
+  group('Observe.track', () {
+    setUp(_resetCaches);
+
+    test('emits a launchdarkly.track span with the required attributes', () {
+      final processor = _installRecorder();
+      setLDSdkMetadataAttributes(<String, Attribute>{
+        'telemetry.sdk.name': StringAttribute('launchdarkly-flutter-sdk'),
+        'telemetry.sdk.version': StringAttribute('4.12.0'),
+        'feature_flag.set.id': StringAttribute('mob-fake-key'),
+        'feature_flag.provider.name': StringAttribute('LaunchDarkly'),
+      });
+
+      Observe.track('signup-completed');
+
+      expect(processor.recorded, hasLength(1));
+      final span = processor.recorded.single;
+      expect(span, _hasSpanName('launchdarkly.track'));
+      expect(span.attributes.get('key'), equals('signup-completed'));
+      expect(
+        span.attributes.get('telemetry.sdk.name'),
+        equals('launchdarkly-flutter-sdk'),
+      );
+      expect(
+        span.attributes.get('feature_flag.provider.name'),
+        equals('LaunchDarkly'),
+      );
+      // No numericValue was supplied — the `value` attribute must not be set.
+      expect(span.attributes.get('value'), isNull);
+    });
+
+    test('omits the value attribute when numericValue is null', () {
+      final processor = _installRecorder();
+
+      Observe.track('viewed-pricing');
+
+      expect(processor.recorded, hasLength(1));
+      expect(processor.recorded.single.attributes.get('value'), isNull);
+    });
+
+    test('sets the value attribute when numericValue is provided', () {
+      final processor = _installRecorder();
+
+      Observe.track('checkout', numericValue: 42);
+
+      expect(processor.recorded, hasLength(1));
+      // num.toDouble() — IntAttribute/DoubleAttribute is determined by our
+      // helper which always converts to double for `value`.
+      expect(processor.recorded.single.attributes.get('value'), equals(42.0));
+    });
+
+    test('does not spread data when data is null', () {
+      final processor = _installRecorder();
+
+      Observe.track('event', data: null);
+
+      expect(processor.recorded, hasLength(1));
+      // No data spread — only the `key` attribute is expected to be set.
+      expect(processor.recorded.single.attributes.get('foo'), isNull);
+    });
+
+    test('does not spread data when data is not a Map', () {
+      final processor = _installRecorder();
+
+      Observe.track('event', data: LDValue.ofString('not-a-map'));
+
+      expect(processor.recorded, hasLength(1));
+      // No keys leaked from a non-object LDValue.
+      expect(processor.recorded.single.attributes.length, lessThanOrEqualTo(1));
+    });
+
+    test('spreads data object entries as typed attributes', () {
+      final processor = _installRecorder();
+
+      final data = LDValue.buildObject()
+          .addValue('foo', LDValue.ofString('bar'))
+          .addValue('n', LDValue.ofNum(7))
+          .addValue('enabled', LDValue.ofBool(true))
+          .build();
+
+      Observe.track('event-with-data', data: data);
+
+      expect(processor.recorded, hasLength(1));
+      final attrs = processor.recorded.single.attributes;
+      expect(attrs.get('foo'), equals('bar'));
+      // LDValue.ofNum(7) → toDynamic() yields int 7 (or double 7.0 depending
+      // on SDK encoding); accept either via the dynamic equality check.
+      final n = attrs.get('n');
+      expect(n == 7 || n == 7.0, isTrue, reason: 'n was $n');
+      expect(attrs.get('enabled'), equals(true));
+    });
+
+    test('skips data entries with unsupported value types', () {
+      final processor = _installRecorder();
+
+      // LDValue.objectBuilder permits nested objects; toDynamic() yields a
+      // Map for the outer object whose values include both spreadable
+      // primitives (string) and a nested Map (which is unsupported and must
+      // be skipped without throwing).
+      final data = LDValue.buildObject()
+          .addValue('keep', LDValue.ofString('me'))
+          .addValue(
+            'nested',
+            LDValue.buildObject()
+                .addValue('child', LDValue.ofString('x'))
+                .build(),
+          )
+          .build();
+
+      Observe.track('event-with-mixed-data', data: data);
+
+      expect(processor.recorded, hasLength(1));
+      final attrs = processor.recorded.single.attributes;
+      expect(attrs.get('keep'), equals('me'));
+      // The nested object was skipped — it doesn't appear as a literal nor
+      // does it raise.
+      expect(attrs.get('nested'), isNull);
+    });
+
+    test('spreads cached context-key attributes onto the track span', () {
+      final processor = _installRecorder();
+      setLDContextKeyAttributes(<String, Attribute>{
+        'user': StringAttribute('alice'),
+        'org': StringAttribute('team-a'),
+      });
+
+      Observe.track('event');
+
+      expect(processor.recorded, hasLength(1));
+      final attrs = processor.recorded.single.attributes;
+      expect(attrs.get('user'), equals('alice'));
+      expect(attrs.get('org'), equals('team-a'));
+    });
+
+    test('is a no-op when ProductAnalyticsConfig.trackEvents is false', () {
+      final processor = _installRecorder();
+      // Simulate plugin registration with trackEvents disabled.
+      registerPluginForTest(
+        productAnalyticsConfig: const ProductAnalyticsConfig(
+          trackEvents: false,
+        ),
+      );
+
+      Observe.track('event');
+
+      expect(processor.recorded, isEmpty);
+
+      // Restore default for subsequent tests.
+      registerPluginForTest();
+    });
+
+    test('returns normally if the underlying tracer throws', () {
+      // Swap the global provider's inner to one that throws on every
+      // getTracer() call so the span construction path inside `Observe.track`
+      // raises. The method must catch and swallow the failure (hook-safety
+      // contract).
+      _globalProvider.setInner(_ThrowingTracerProvider());
+      try {
+        expect(() => Observe.track('event'), returnsNormally);
+      } finally {
+        // Restore a non-throwing inner so subsequent tests aren't poisoned.
+        _globalProvider.setInner(otel_sdk.TracerProviderBase());
+      }
+    });
+
+    test(
+      'omits the value attribute when numericValue not specified, even with data',
+      () {
+        final processor = _installRecorder();
+        final data = LDValue.buildObject()
+            .addValue('foo', LDValue.ofString('bar'))
+            .build();
+
+        Observe.track('event', data: data);
+
+        expect(processor.recorded, hasLength(1));
+        expect(processor.recorded.single.attributes.get('value'), isNull);
+      },
+    );
+  });
+
+  group('attribute coercion helper', () {
+    test('coerces String to StringAttribute', () {
+      final attr = attributeFromDynamicForTest('hello');
+      expect(attr, isA<StringAttribute>());
+      expect((attr as StringAttribute).value, equals('hello'));
+    });
+
+    test('coerces int to IntAttribute', () {
+      final attr = attributeFromDynamicForTest(42);
+      expect(attr, isA<IntAttribute>());
+      expect((attr as IntAttribute).value, equals(42));
+    });
+
+    test('coerces double to DoubleAttribute', () {
+      final attr = attributeFromDynamicForTest(3.14);
+      expect(attr, isA<DoubleAttribute>());
+      expect((attr as DoubleAttribute).value, closeTo(3.14, 0.0001));
+    });
+
+    test('coerces bool to BooleanAttribute', () {
+      final attr = attributeFromDynamicForTest(true);
+      expect(attr, isA<BooleanAttribute>());
+      expect((attr as BooleanAttribute).value, isTrue);
+    });
+
+    test('returns null for unsupported types', () {
+      expect(attributeFromDynamicForTest(null), isNull);
+      expect(attributeFromDynamicForTest(<String, dynamic>{'k': 'v'}), isNull);
+      expect(attributeFromDynamicForTest(DateTime.now()), isNull);
+    });
+
+    test('coerces List<dynamic> of strings to StringListAttribute', () {
+      // `LDValue.toDynamic()` always returns `List<dynamic>` for arrays — the
+      // runtime type IS NOT `List<String>` even if every element is a string.
+      // Verify the dynamic-list branch handles this correctly.
+      final dynamic value = <dynamic>['a', 'b', 'c'];
+      final attr = attributeFromDynamicForTest(value);
+      expect(attr, isA<StringListAttribute>());
+      expect((attr as StringListAttribute).value, equals(['a', 'b', 'c']));
+    });
+
+    test('coerces List<dynamic> of bools to BooleanListAttribute', () {
+      final dynamic value = <dynamic>[true, false, true];
+      final attr = attributeFromDynamicForTest(value);
+      expect(attr, isA<BooleanListAttribute>());
+      expect((attr as BooleanListAttribute).value, equals([true, false, true]));
+    });
+
+    test('coerces List<dynamic> of ints to IntListAttribute', () {
+      final dynamic value = <dynamic>[1, 2, 3];
+      final attr = attributeFromDynamicForTest(value);
+      expect(attr, isA<IntListAttribute>());
+      expect((attr as IntListAttribute).value, equals([1, 2, 3]));
+    });
+
+    test('coerces List<dynamic> of doubles to DoubleListAttribute', () {
+      final dynamic value = <dynamic>[1.5, 2.5, 3.5];
+      final attr = attributeFromDynamicForTest(value);
+      expect(attr, isA<DoubleListAttribute>());
+      expect((attr as DoubleListAttribute).value, equals([1.5, 2.5, 3.5]));
+    });
+
+    test('coerces mixed-numeric List<dynamic> to DoubleListAttribute', () {
+      // Mixed int/double (common when `LDValue.buildArray()` mixes
+      // `LDValue.ofNum(1)` and `LDValue.ofNum(2.5)`) → coerce all to double.
+      final dynamic value = <dynamic>[1, 2.5, 3];
+      final attr = attributeFromDynamicForTest(value);
+      expect(attr, isA<DoubleListAttribute>());
+      expect((attr as DoubleListAttribute).value, equals([1.0, 2.5, 3.0]));
+    });
+
+    test('returns null for empty List<dynamic>', () {
+      // Empty list — element type cannot be inferred; skip rather than emit a
+      // potentially-mistyped attribute.
+      final dynamic value = <dynamic>[];
+      expect(attributeFromDynamicForTest(value), isNull);
+    });
+
+    test('returns null for List<dynamic> with mixed unsupported types', () {
+      // String + int is not coercible to any single typed-list attribute.
+      final dynamic value = <dynamic>['a', 1];
+      expect(attributeFromDynamicForTest(value), isNull);
+    });
+  });
+
+  group('Observe.track list-attribute integration', () {
+    setUp(_resetCaches);
+
+    test(
+      'spreads LDValue array data as StringListAttribute (via List<dynamic> path)',
+      () {
+        // This is the bug guard: `LDValue.toDynamic()` returns `List<dynamic>`
+        // for arrays, NOT `List<String>`, so the typed-list-only checks used to
+        // silently drop array entries from `data`. The new dynamic-list branch
+        // must surface them as a typed list attribute on the span.
+        final processor = _installRecorder();
+
+        final data = LDValue.buildObject()
+            .addValue(
+              'tags',
+              LDValue.buildArray()
+                  .addValue(LDValue.ofString('a'))
+                  .addValue(LDValue.ofString('b'))
+                  .build(),
+            )
+            .build();
+
+        Observe.track('event-with-array-data', data: data);
+
+        expect(processor.recorded, hasLength(1));
+        final attrs = processor.recorded.single.attributes;
+        // The OTEL attribute store returns the underlying list value for the key
+        // when present; if missing, it returns null. Assert both presence and
+        // contents.
+        final tags = attrs.get('tags');
+        expect(tags, isNotNull, reason: 'tags attribute should be present');
+        expect(tags, equals(<String>['a', 'b']));
+      },
+    );
+  });
+}
+
+/// A tracer provider whose `getTracer` always throws. Used to exercise the
+/// hook-safety try/catch inside `Observe.track`.
+class _ThrowingTracerProvider implements otel_api.TracerProvider {
+  @override
+  otel_api.Tracer getTracer(
+    String name, {
+    String? version,
+    String? schemaUrl,
+    List<otel_api.Attribute>? attributes,
+  }) {
+    throw StateError('intentional test failure');
+  }
+
+  @override
+  void forceFlush() {}
+
+  @override
+  void shutdown() {}
+}
+
+/// Test-only helper to seed the product-analytics gate without spinning up a
+/// full LD client. Re-exported here (rather than from src/observe.dart) so
+/// the public test surface stays minimal.
+void registerPluginForTest({
+  ProductAnalyticsConfig productAnalyticsConfig =
+      const ProductAnalyticsConfig(),
+}) {
+  setProductAnalyticsTrackEventsForTest(productAnalyticsConfig.trackEvents);
+}

--- a/sdk/@launchdarkly/observability-android/lib/build.gradle.kts
+++ b/sdk/@launchdarkly/observability-android/lib/build.gradle.kts
@@ -89,6 +89,12 @@ dependencies {
     // Use JUnit Jupiter for testing.
     // Testing exporters for telemetry inspection
     testImplementation("io.opentelemetry:opentelemetry-sdk-testing:1.51.0")
+    // OTLP common marshaler — used by the E2E test
+    // (ObservabilityHookExporterE2ETest, via OtlpProtoHelper) to serialize captured
+    // SpanData into OTLP/HTTP+protobuf bytes that we POST directly to the devbox
+    // observability backend via HttpURLConnection (the bundled OtlpHttpSpanExporter
+    // ships with an OkHttp sender that's unreliable in this test JVM on macOS).
+    testImplementation("io.opentelemetry:opentelemetry-exporter-otlp-common:1.51.0")
     testImplementation(platform("org.junit:junit-bom:5.13.4"))
     testImplementation("org.junit.jupiter:junit-jupiter")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
@@ -153,6 +159,16 @@ android {
 
     testFixtures {
         enable = true
+    }
+
+    testOptions {
+        // Required for the E2E test (`ObservabilityHookExporterE2ETest`): the JVM
+        // unit-test classpath ships with Android stub jars where most java.net APIs
+        // throw `RuntimeException("Stub!")`. The E2E path uses HttpURLConnection to POST
+        // OTLP protobuf to the devbox backend and query ClickHouse, so we flip
+        // `isReturnDefaultValues` to silence the stubs and let the real JDK classes on
+        // the application classpath service the calls.
+        unitTests.isReturnDefaultValues = true
     }
 }
 

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/api/ObservabilityOptions.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/api/ObservabilityOptions.kt
@@ -26,6 +26,9 @@ const val DEFAULT_BACKEND_URL = "https://pub.observability.app.launchdarkly.com"
  * @property logsApiLevel Level for logs to be exported. Defaults to INFO. Set to NONE to disable log exporting.
  * @property tracesApi Options for configuring traces. See [TracesApi]. Tracing is enabled by default.
  * @property metricsApi Options for configuring metrics. See [MetricsApi]. Metrics are enabled by default.
+ * @property productAnalyticsApi Options for product-analytics emission (i.e. the `launchdarkly.track`
+ *   span emitted on every `LDClient.track(...)` call and on every direct `LDObserve.track(...)` call).
+ *   See [ProductAnalyticsApi]. Enabled by default.
  * @property instrumentations Options for configuring automatic instrumentations. See [Instrumentations].
  * @property logAdapter The log adapter to use. Defaults to [LDObserveLogging.adapter] which writes to Android's native Log API.
  * @property loggerName The name of the logger to use. Defaults to "LaunchDarklyObservabilityPlugin".
@@ -47,6 +50,7 @@ data class ObservabilityOptions(
     val logsApiLevel: LogLevel = LogLevel.INFO,
     val tracesApi: TracesApi = TracesApi.enabled(),
     val metricsApi: MetricsApi = MetricsApi.enabled(),
+    val productAnalyticsApi: ProductAnalyticsApi = ProductAnalyticsApi.enabled(),
     val instrumentations: Instrumentations = Instrumentations(),
     val logAdapter: ObserveLogAdapter = LDObserveLogging.adapter(),
     val loggerName: String = "LaunchDarklyObservabilityPlugin",
@@ -77,6 +81,23 @@ data class ObservabilityOptions(
         companion object {
             fun enabled() = MetricsApi(true)
             fun disabled() = MetricsApi(false)
+        }
+    }
+
+    /**
+     * Options for product-analytics emission — i.e. the `launchdarkly.track` span
+     * that this SDK ships to o11y on every `LDClient.track(...)` call (via the SDK's
+     * `afterTrack` hook) and on every direct call to
+     * [com.launchdarkly.observability.sdk.LDObserve.track].
+     *
+     * @property trackEvents Whether to emit the `launchdarkly.track` span for track events.
+     *   When `false`, both the `afterTrack` hook and direct `LDObserve.track(...)` calls
+     *   are no-ops. Defaults to `true`.
+     */
+    data class ProductAnalyticsApi(val trackEvents: Boolean = true) {
+        companion object {
+            fun enabled() = ProductAnalyticsApi(trackEvents = true)
+            fun disabled() = ProductAnalyticsApi(trackEvents = false)
         }
     }
 

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/client/ObservabilityService.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/client/ObservabilityService.kt
@@ -24,6 +24,7 @@ import com.launchdarkly.observability.sampling.SamplingLogProcessor
 import com.launchdarkly.observability.traces.EventSpanProcessor
 import com.launchdarkly.observability.traces.OtlpTraceExporter
 import com.launchdarkly.observability.util.requireMainThread
+import com.launchdarkly.sdk.LDValue
 import io.opentelemetry.android.OpenTelemetryRum
 import io.opentelemetry.android.OpenTelemetryRumBuilder
 import io.opentelemetry.android.config.OtelRumConfig
@@ -153,7 +154,8 @@ class ObservabilityService(
             withSpans = true,
             withValue = true,
             tracerProvider = { getTracer() },
-            contextFriendlyName = observabilityOptions.contextFriendlyName
+            contextFriendlyName = observabilityOptions.contextFriendlyName,
+            logger = logger,
         )
 
         batchWorker.start()
@@ -383,6 +385,25 @@ class ObservabilityService(
         return otelTracer.spanBuilder(name)
             .setAllAttributes(attributes)
             .startSpan()
+    }
+
+    /**
+     * Emits a `launchdarkly.track` span — the shared code path for both the LD client
+     * `afterTrack` hook (i.e. when the application calls `LDClient.track(...)`) and direct
+     * [com.launchdarkly.observability.sdk.LDObserve.track] calls.
+     *
+     * The actual span emission, attribute spread, and error swallow live on [hookExporter];
+     * this method owns the `productAnalyticsApi.trackEvents` feature gate so the exporter
+     * stays decoupled from the options struct.
+     */
+    fun track(key: String, data: LDValue?, metricValue: Double?) {
+        if (!observabilityOptions.productAnalyticsApi.trackEvents) return
+
+        hookExporter.track(
+            key = key,
+            data = data,
+            metricValue = metricValue,
+        )
     }
 
     /**

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/plugin/Observability.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/plugin/Observability.kt
@@ -16,6 +16,8 @@ import com.launchdarkly.sdk.android.integrations.Hook
 import com.launchdarkly.sdk.android.integrations.Plugin
 import com.launchdarkly.sdk.android.integrations.PluginMetadata
 import com.launchdarkly.sdk.android.integrations.RegistrationCompleteResult
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.api.common.Attributes
 import java.util.Collections
 
 /**
@@ -116,9 +118,57 @@ class Observability(
         )
         observabilityClient = observabilityService
         LDObserve.context?.sessionManager = observabilityService.sessionManager
-        LDObserve.init(observabilityService)
 
         observabilityHook.delegate = observabilityService.hookExporter
+
+        // Publish the SDK metadata that should be spread on every `launchdarkly.track` span.
+        // Mirrors the JS reference `metaAttrs` (see
+        // `sdk/highlight-run/src/plugins/observe.ts:99-113`). We populate this here — once
+        // the LDClient `EnvironmentMetadata` is available — rather than at exporter construction
+        // because `sdk.name/version`, `clientSideId`, and the application identifiers all live
+        // on `metadata` and are not stable until `onPluginsReady`.
+        //
+        // IMPORTANT: this MUST run BEFORE `LDObserve.init(observabilityService)`. Once `init` is
+        // called, the service is published to the [LDObserve] companion and any thread can
+        // observe it via `LDObserve.track(...)`. If we reversed the order, that early track call
+        // could land in `hookExporter.track(...)` with an empty `metaAttributes`, producing a
+        // `launchdarkly.track` span missing `telemetry.sdk.*` / `feature_flag.set.id` /
+        // `launchdarkly.application.*`. Mutating the (not-yet-published) exporter here is safe —
+        // we still hold the only reference via `observabilityService`.
+        observabilityService.hookExporter.setMetaAttributes(buildMetaAttributes(metadata, sdkKey))
+
+        LDObserve.init(observabilityService)
+    }
+
+    /**
+     * Builds the SDK-metadata `Attributes` spread on every `launchdarkly.track` span.
+     *
+     * Attribute keys mirror the JS reference (see
+     * `sdk/highlight-run/src/integrations/launchdarkly/index.ts`):
+     * `telemetry.sdk.{name,version}`, `feature_flag.set.id`, `feature_flag.provider.name`,
+     * `launchdarkly.application.{id,version}`. Missing pieces (e.g. `application` not set
+     * on the LDConfig) are simply omitted — same JS behavior.
+     */
+    private fun buildMetaAttributes(
+        metadata: EnvironmentMetadata?,
+        sdkKey: String,
+    ): Attributes {
+        val builder = Attributes.builder()
+        metadata?.sdkMetadata?.let { sdk ->
+            sdk.name?.let { builder.put(AttributeKey.stringKey(ObservabilityHookExporter.ATTR_TELEMETRY_SDK_NAME), it) }
+            sdk.version?.let { builder.put(AttributeKey.stringKey(ObservabilityHookExporter.ATTR_TELEMETRY_SDK_VERSION), it) }
+        }
+        // The mobile-key/client-side-id used to identify the LD environment.
+        // Matches the JS reference's use of `metadata.clientSideId`.
+        builder.put(AttributeKey.stringKey(ObservabilityHookExporter.ATTR_FEATURE_FLAG_SET_ID), sdkKey)
+        builder.put(AttributeKey.stringKey(ObservabilityHookExporter.ATTR_FEATURE_FLAG_PROVIDER_NAME), ObservabilityHookExporter.PROVIDER_NAME)
+        metadata?.applicationInfo?.applicationId?.let {
+            builder.put(AttributeKey.stringKey(ObservabilityHookExporter.ATTR_LD_APPLICATION_ID), it)
+        }
+        metadata?.applicationInfo?.applicationVersion?.let {
+            builder.put(AttributeKey.stringKey(ObservabilityHookExporter.ATTR_LD_APPLICATION_VERSION), it)
+        }
+        return builder.build()
     }
 
     /**

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/plugin/ObservabilityHook.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/plugin/ObservabilityHook.kt
@@ -1,11 +1,13 @@
 package com.launchdarkly.observability.plugin
 
+import com.launchdarkly.observability.sdk.LDObserve
 import com.launchdarkly.sdk.EvaluationDetail
 import com.launchdarkly.sdk.LDValue
 import com.launchdarkly.sdk.android.integrations.EvaluationSeriesContext
 import com.launchdarkly.sdk.android.integrations.Hook
 import com.launchdarkly.sdk.android.integrations.IdentifySeriesContext
 import com.launchdarkly.sdk.android.integrations.IdentifySeriesResult
+import com.launchdarkly.sdk.android.integrations.TrackSeriesContext
 import java.util.UUID
 
 /**
@@ -74,6 +76,31 @@ class ObservabilityHook internal constructor() : Hook(HOOK_NAME) {
         seriesData: Map<String, Any>
     ): Map<String, Any> {
         return seriesData
+    }
+
+    /**
+     * Thin pass-through to [LDObserve.track]: the LD client just enqueued a track event, so we
+     * ship the same payload as a `launchdarkly.track` span to the o11y backend. All of the real
+     * work (productAnalytics gate, attribute spread, error swallow) lives inside
+     * [LDObserve.track] → [com.launchdarkly.observability.client.ObservabilityService.track] →
+     * [ObservabilityHookExporter.track] so both this hook path and direct
+     * [LDObserve.track] calls share exactly one implementation and cannot diverge.
+     *
+     * Per the hook safety contract this method MUST NOT throw. [LDObserve.track] already
+     * swallows every internal failure; we additionally wrap the call site as belt-and-suspenders
+     * (mirrors the RN hook pattern) so that any future change to that method — or a failure
+     * reading `seriesContext` itself — still cannot bubble out into the LD client's hook chain.
+     */
+    override fun afterTrack(seriesContext: TrackSeriesContext) {
+        try {
+            LDObserve.track(
+                key = seriesContext.key,
+                data = seriesContext.data,
+                metricValue = seriesContext.metricValue,
+            )
+        } catch (_: Throwable) {
+            // Swallow: hook safety contract. See KDoc above.
+        }
     }
 
     override fun afterIdentify(

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/plugin/ObservabilityHookExporter.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/plugin/ObservabilityHookExporter.kt
@@ -1,10 +1,14 @@
 package com.launchdarkly.observability.plugin
 
+import com.launchdarkly.observability.context.ObserveLogger
 import com.launchdarkly.observability.sdk.LDObserve
 import com.launchdarkly.observability.utils.BoundedMap
+import com.launchdarkly.sdk.LDValue
+import com.launchdarkly.sdk.LDValueType
 import io.opentelemetry.api.GlobalOpenTelemetry
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.common.Attributes
+import io.opentelemetry.api.common.AttributesBuilder
 import io.opentelemetry.api.logs.Severity
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.api.trace.Tracer
@@ -22,13 +26,123 @@ internal class ObservabilityHookExporter(
     private val withSpans: Boolean,
     private val withValue: Boolean,
     private val tracerProvider: (() -> Tracer?),
+    private val logger: ObserveLogger,
     private val contextFriendlyName: String? = null,
     maxInFlightSpans: Int = 1024
 ) : ObservabilityHookExporting {
     private val spans = BoundedMap<String, Span>(maxInFlightSpans)
 
+    /**
+     * LD context-key attributes cached from the most recent [afterIdentify] call. Spread as
+     * bare top-level keys (e.g. `user = "alice"`, `org = "team-a"`) on the `launchdarkly.track`
+     * span — matches the JS reference (see `sdk/highlight-run/src/plugins/observe.ts:212`).
+     *
+     * `@Volatile` so any thread that subsequently calls [track] sees the most recent identify.
+     */
+    @Volatile
+    private var ldContextKeyAttributes: Attributes = Attributes.empty()
+
+    /**
+     * SDK metadata attributes (`telemetry.sdk.name/version`, `feature_flag.set.id`,
+     * `feature_flag.provider.name`, `launchdarkly.application.id/version`). Populated by the
+     * [com.launchdarkly.observability.plugin.Observability] plugin on `onPluginsReady` once it
+     * has the LD client's `EnvironmentMetadata`. Spread on the `launchdarkly.track` span — matches
+     * the JS reference `metaAttrs` (see `sdk/highlight-run/src/plugins/observe.ts:99-113`).
+     */
+    @Volatile
+    private var metaAttributes: Attributes = Attributes.empty()
+
     private fun getTracer(): Tracer {
         return tracerProvider.invoke() ?: GlobalOpenTelemetry.get().getTracer(INSTRUMENTATION_NAME)
+    }
+
+    /**
+     * Publishes the SDK metadata attributes that should be spread on every `launchdarkly.track`
+     * span. Called once by the [com.launchdarkly.observability.plugin.Observability] plugin
+     * from `onPluginsReady` after the LD client's `EnvironmentMetadata` is available.
+     */
+    fun setMetaAttributes(attrs: Attributes) {
+        metaAttributes = attrs
+    }
+
+    /**
+     * Emits a `launchdarkly.track` span — the shared code path for both the
+     * [ObservabilityHook.afterTrack] hook callback (i.e. when application code calls
+     * `LDClient.track(...)`) and direct [com.launchdarkly.observability.sdk.LDObserve.track]
+     * calls.
+     *
+     * Wrapped in `try/catch(Throwable)`: any failure is logged at debug and swallowed so that
+     * the LD client's `track()` always completes normally and ad-hoc o11y telemetry never
+     * surfaces an unexpected exception to the application.
+     *
+     * The `productAnalyticsApi.trackEvents` gate is owned by the caller — see
+     * [com.launchdarkly.observability.client.ObservabilityService.track] — so this exporter
+     * stays decoupled from the options struct.
+     *
+     * @param key         the track event key, written as the `key` attribute on the span
+     * @param data        optional structured payload; when this resolves to an [LDValueType.OBJECT],
+     *                    its property names are spread as top-level attributes. Non-object / null
+     *                    payloads are skipped (no spread, no failure).
+     * @param metricValue optional numeric value, written as the `value` attribute on the span.
+     */
+    fun track(
+        key: String,
+        data: LDValue?,
+        metricValue: Double?,
+    ) {
+        try {
+            val tracer = getTracer()
+            val attrBuilder = Attributes.builder()
+
+            // Bare context-key spread (e.g. `user = "alice"`), matching the JS reference.
+            attrBuilder.putAll(ldContextKeyAttributes)
+
+            // SDK metadata (`telemetry.sdk.*`, `feature_flag.*`, `launchdarkly.application.*`).
+            attrBuilder.putAll(metaAttributes)
+
+            attrBuilder.put(AttributeKey.stringKey(ATTR_KEY), key)
+
+            if (metricValue != null) {
+                attrBuilder.put(AttributeKey.doubleKey(ATTR_VALUE), metricValue)
+            }
+
+            // Spread `data` properties when it resolves to an OBJECT. Non-object / null
+            // payloads are skipped — matches the JS `typeof hookContext.data === 'object'` guard.
+            spreadLDValueObject(attrBuilder, data)
+
+            tracer.spanBuilder(LD_TRACK_SPAN_NAME)
+                .setAllAttributes(attrBuilder.build())
+                .startSpan()
+                .end()
+        } catch (t: Throwable) {
+            // Swallow: hook safety contract — the LD client's track() must always return normally.
+            logger.debug("LDObserve.track failed: ${t.message}")
+        }
+    }
+
+    /**
+     * Spreads each property of an [LDValueType.OBJECT] payload as a top-level attribute on the
+     * span, picking a typed `AttributeKey` per element so the attribute appears with its natural
+     * JSON type at the backend (instead of being stringified). Arrays / scalars / null / non-OBJECT
+     * payloads are skipped — matches the JS reference's `typeof === 'object'` guard.
+     */
+    private fun spreadLDValueObject(builder: AttributesBuilder, data: LDValue?) {
+        if (data == null || data.isNull) return
+        if (data.type != LDValueType.OBJECT) return
+
+        for (propName in data.keys()) {
+            val v = data.get(propName)
+            when (v.type) {
+                LDValueType.STRING -> builder.put(AttributeKey.stringKey(propName), v.stringValue())
+                LDValueType.BOOLEAN -> builder.put(AttributeKey.booleanKey(propName), v.booleanValue())
+                LDValueType.NUMBER -> builder.put(AttributeKey.doubleKey(propName), v.doubleValue())
+                // Nested arrays / objects / null are serialized as their JSON representation so
+                // the attribute is still useful at the backend without losing information.
+                LDValueType.ARRAY,
+                LDValueType.OBJECT,
+                LDValueType.NULL -> builder.put(AttributeKey.stringKey(propName), v.toJsonString())
+            }
+        }
     }
 
     // -- Evaluation --
@@ -109,10 +223,18 @@ internal class ObservabilityHookExporter(
     override fun afterIdentify(contextKeys: Map<String, String>, canonicalKey: String, completed: Boolean) {
         if (!completed) return
 
+        // Cache the bare-key spread for the launchdarkly.track span. We keep this assignment
+        // outside the log-emission block on purpose: even if log emission is disabled (or fails)
+        // we still want subsequent track spans to carry the right context-key attribution.
+        val contextKeyAttrs = Attributes.builder().apply {
+            for ((k, v) in contextKeys) {
+                put(AttributeKey.stringKey(k), v)
+            }
+        }.build()
+        ldContextKeyAttributes = contextKeyAttrs
+
         val attrBuilder = Attributes.builder()
-        for ((k, v) in contextKeys) {
-            attrBuilder.put(AttributeKey.stringKey(k), v)
-        }
+        attrBuilder.putAll(contextKeyAttrs)
         attrBuilder.put(AttributeKey.stringKey("key"), contextFriendlyName ?: canonicalKey)
         attrBuilder.put(AttributeKey.stringKey("canonicalKey"), canonicalKey)
         attrBuilder.put(AttributeKey.stringKey(IDENTIFY_RESULT_STATUS), "completed")
@@ -133,5 +255,22 @@ internal class ObservabilityHookExporter(
         const val CUSTOM_FEATURE_FLAG_RESULT_REASON_IN_EXPERIMENT = "feature_flag.result.reason.inExperiment"
         const val IDENTIFY_RESULT_STATUS = "identify.result.status"
         const val DATA_KEY_EVAL_ID = "evaluationId"
+
+        // launchdarkly.track span — emitted on every LDClient.track(...) call and on every
+        // direct LDObserve.track(...) call. Matches the JS reference constant in
+        // `sdk/highlight-run/src/integrations/launchdarkly/index.ts`.
+        const val LD_TRACK_SPAN_NAME = "launchdarkly.track"
+        const val ATTR_KEY = "key"
+        const val ATTR_VALUE = "value"
+
+        // SDK metadata attribute names; spread on the launchdarkly.track span via
+        // [setMetaAttributes]. Match the JS constants in
+        // `sdk/highlight-run/src/integrations/launchdarkly/index.ts`.
+        const val ATTR_TELEMETRY_SDK_NAME = "telemetry.sdk.name"
+        const val ATTR_TELEMETRY_SDK_VERSION = "telemetry.sdk.version"
+        const val ATTR_FEATURE_FLAG_SET_ID = "feature_flag.set.id"
+        const val ATTR_FEATURE_FLAG_PROVIDER_NAME = "feature_flag.provider.name"
+        const val ATTR_LD_APPLICATION_ID = "launchdarkly.application.id"
+        const val ATTR_LD_APPLICATION_VERSION = "launchdarkly.application.version"
     }
 }

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/sdk/LDObserve.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/sdk/LDObserve.kt
@@ -14,6 +14,7 @@ import com.launchdarkly.observability.replay.ReplayOptions
 import com.launchdarkly.observability.replay.capture.ImageCaptureServicing
 import com.launchdarkly.observability.replay.plugin.SessionReplayPluginImpl
 import com.launchdarkly.observability.util.runOnMainThread
+import com.launchdarkly.sdk.LDValue
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.logs.Severity
 import io.opentelemetry.api.trace.Span
@@ -215,6 +216,49 @@ class LDObserve(private val client: Observe) : Observe {
         override fun recordLog(message: String, severity: Severity, attributes: Attributes, spanContext: SpanContext?) = delegate.recordLog(message, severity, attributes, spanContext)
         override fun startSpan(name: String, attributes: Attributes): Span = delegate.startSpan(name, attributes)
         override fun flush() = delegate.flush()
+
+        /**
+         * Emits a `launchdarkly.track` span to the o11y backend.
+         *
+         * The same span is emitted automatically when application code calls `LDClient.track(...)`
+         * (via the SDK's `afterTrack` hook). This direct entry point lets callers ship a track
+         * event without going through the LD client — useful for ad-hoc telemetry, sample apps,
+         * or tests.
+         *
+         * Behavior:
+         *  - When [ObservabilityOptions.productAnalyticsApi]'s `trackEvents` is `false`, this
+         *    call is a no-op (matches the `afterTrack` hook).
+         *  - When called before `LDObserve.init(...)` runs, this is a silent no-op (the
+         *    underlying [ObservabilityService] is not yet wired).
+         *  - All internal exceptions are caught and logged at debug, never surfaced to the
+         *    caller — track-event emission is best-effort and must never break the host app.
+         *
+         * @param key         the track event key, written as the `key` attribute on the span
+         * @param data        optional structured payload; properties are spread as span
+         *                    attributes when this is an [com.launchdarkly.sdk.LDValueType.OBJECT].
+         *                    Non-object / null payloads are skipped (no spread, no throw).
+         * @param metricValue optional numeric value, written as the `value` attribute on the span.
+         */
+        @JvmStatic
+        @JvmOverloads
+        fun track(key: String, data: LDValue? = null, metricValue: Double? = null) {
+            // Belt-and-suspenders: the downstream [ObservabilityHookExporter.track] already
+            // wraps its body in try/catch, but we mirror the RN hook pattern here so a failure
+            // in *any* layer above the exporter (pre-init guard expansion, future service
+            // changes, etc.) still honors this method's KDoc contract: "All internal exceptions
+            // are caught and logged at debug, never surfaced to the caller."
+            try {
+                // Pre-init guard: if no service is installed yet (developer called track before
+                // Observability.onPluginsReady / standalone LDObserve.init), there's no tracer to
+                // emit on. Silently no-op rather than crashing or buffering.
+                val service = observabilityClient ?: return
+                service.track(key, data, metricValue)
+            } catch (_: Throwable) {
+                // Swallow: track-event emission is best-effort and must never break the host app.
+                // The exporter already logs the underlying cause when reachable; this outer
+                // catch is for the (rare) case where a failure precedes the exporter call.
+            }
+        }
 
         /**
          * Bridge-friendly overloads that avoid exposing OpenTelemetry types

--- a/sdk/@launchdarkly/observability-android/lib/src/test/java/com/launchdarkly/observability/plugin/OtlpProtoHelper.java
+++ b/sdk/@launchdarkly/observability-android/lib/src/test/java/com/launchdarkly/observability/plugin/OtlpProtoHelper.java
@@ -1,0 +1,27 @@
+package com.launchdarkly.observability.plugin;
+
+import io.opentelemetry.exporter.internal.otlp.traces.TraceRequestMarshaler;
+import io.opentelemetry.sdk.trace.data.SpanData;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Collection;
+
+/**
+ * Java-side helper that wraps OTel's internal {@link TraceRequestMarshaler} so the Kotlin
+ * E2E test can import it cleanly (Kotlin reserves `internal` as a visibility modifier and
+ * cannot import a Java package whose path contains an `internal` segment).
+ */
+final class OtlpProtoHelper {
+    private OtlpProtoHelper() {}
+
+    static byte[] marshalSpansToProto(Collection<SpanData> spans) {
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        try {
+            TraceRequestMarshaler.create(spans).writeBinaryTo(os);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to marshal spans to OTLP protobuf", e);
+        }
+        return os.toByteArray();
+    }
+}

--- a/sdk/@launchdarkly/observability-android/lib/src/test/kotlin/com/launchdarkly/observability/plugin/ObservabilityHookExporterE2ETest.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/test/kotlin/com/launchdarkly/observability/plugin/ObservabilityHookExporterE2ETest.kt
@@ -1,0 +1,242 @@
+package com.launchdarkly.observability.plugin
+
+import com.launchdarkly.observability.context.ObserveLogger
+import com.launchdarkly.sdk.LDValue
+import io.mockk.mockk
+import io.opentelemetry.api.common.Attributes
+import io.opentelemetry.sdk.resources.Resource
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter
+import io.opentelemetry.sdk.trace.SdkTracerProvider
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
+import java.net.HttpURLConnection
+import java.net.URL
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+
+/**
+ * End-to-end test for the `launchdarkly.track` span path on
+ * [ObservabilityHookExporter].
+ *
+ * Builds a real OTel [SdkTracerProvider], routes the span produced by
+ * [ObservabilityHookExporter.track] through an [InMemorySpanExporter], protobuf-marshals
+ * the captured [io.opentelemetry.sdk.trace.data.SpanData] using OTel's own
+ * `TraceRequestMarshaler` (via the Java-side [OtlpProtoHelper] shim — Kotlin reserves
+ * `internal` and can't import the OTel package whose path contains it), and POSTs it via
+ * [HttpURLConnection] to the devbox observability backend's `/otel/v1/traces` endpoint.
+ * Then queries ClickHouse to verify the `launchdarkly.track` row landed with the expected
+ * attributes.
+ *
+ * Why we don't use [io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter]
+ * directly: the OTel SDK's OkHttp-based HTTP sender is reliably broken in this Gradle
+ * unit-test JVM on macOS (every cold-JVM call gets `Canceled` before the request goes
+ * out the wire and the OTel RetryInterceptor treats `Canceled` as non-retryable, so the
+ * 30s call timeout fires and the export future resolves to failure). Using
+ * [HttpURLConnection] sidesteps the issue while exercising the exact same on-the-wire
+ * protobuf payload — which is what we want to validate for the end-to-end contract.
+ *
+ * Gated on the `O11Y_E2E` env var so it doesn't run in CI / general developer workflows
+ * where the devbox forwards aren't up. To run locally:
+ *
+ *   export O11Y_E2E=1
+ *   ./gradlew :lib:testDebugUnitTest --tests '*E2ETest*'
+ *
+ * Environment expectations (defaults match the standard devbox setup):
+ *   - OTLP traces endpoint: http://localhost:9096/otel/v1/traces  (override via O11Y_OTLP_ENDPOINT)
+ *   - ClickHouse HTTP:      http://localhost:8123                  (override via O11Y_CH_URL)
+ *   - Project ID:           1                                      (override via O11Y_PROJECT_ID)
+ */
+@EnabledIfEnvironmentVariable(named = "O11Y_E2E", matches = "1|true")
+class ObservabilityHookExporterE2ETest {
+
+    private val otlpEndpoint: String =
+        System.getenv("O11Y_OTLP_ENDPOINT") ?: "http://localhost:9096/otel/v1/traces"
+    private val clickhouseUrl: String =
+        System.getenv("O11Y_CH_URL") ?: "http://localhost:8123"
+    private val projectId: String =
+        System.getenv("O11Y_PROJECT_ID") ?: "1"
+
+    private lateinit var spanExporter: InMemorySpanExporter
+    private lateinit var tracerProvider: SdkTracerProvider
+
+    @BeforeEach
+    fun setUp() {
+        spanExporter = InMemorySpanExporter.create()
+        tracerProvider = SdkTracerProvider.builder()
+            .setResource(
+                Resource.getDefault().toBuilder()
+                    .put("service.name", "observability-android-e2e")
+                    .build()
+            )
+            .addSpanProcessor(SimpleSpanProcessor.create(spanExporter))
+            .build()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        tracerProvider.shutdown().join(5, TimeUnit.SECONDS)
+    }
+
+    @Test
+    fun `track span lands in ClickHouse with required attributes`() {
+        val eventKey = "test-event-android-" + UUID.randomUUID().toString().substring(0, 8)
+        val testTracer = tracerProvider.get(ObservabilityHookExporter.INSTRUMENTATION_NAME)
+
+        val exporter = ObservabilityHookExporter(
+            withSpans = true,
+            withValue = true,
+            tracerProvider = { testTracer },
+            logger = mockk<ObserveLogger>(relaxed = true),
+        )
+
+        // Seed meta attributes the way `Observability.onPluginsReady` does.
+        // `feature_flag.set.id` is what the backend's extractor uses as the project ID
+        // (see observability/backend/otel/extract.go:278-281).
+        val meta = Attributes.builder()
+            .put(ObservabilityHookExporter.ATTR_TELEMETRY_SDK_NAME, "android-client-sdk")
+            .put(ObservabilityHookExporter.ATTR_TELEMETRY_SDK_VERSION, "5.12.0")
+            .put(ObservabilityHookExporter.ATTR_FEATURE_FLAG_SET_ID, projectId)
+            .put(ObservabilityHookExporter.ATTR_FEATURE_FLAG_PROVIDER_NAME, "LaunchDarkly")
+            .put(ObservabilityHookExporter.ATTR_LD_APPLICATION_ID, "com.example.e2e")
+            .put(ObservabilityHookExporter.ATTR_LD_APPLICATION_VERSION, "1.2.3")
+            .build()
+        exporter.setMetaAttributes(meta)
+
+        // Populate the context-key cache as `Observability.afterIdentify` would.
+        exporter.afterIdentify(
+            contextKeys = mapOf("user" to "alice-e2e"),
+            canonicalKey = "user:alice-e2e",
+            completed = true,
+        )
+
+        // Trigger the launchdarkly.track span — lands synchronously in spanExporter via
+        // SimpleSpanProcessor.
+        exporter.track(
+            key = eventKey,
+            data = LDValue.buildObject().put("foo", "bar").build(),
+            metricValue = 42.0,
+        )
+
+        val spans = spanExporter.finishedSpanItems
+        assertEquals(1, spans.size, "expected exactly one span to be captured by InMemorySpanExporter")
+        val span = spans.single()
+        assertEquals(ObservabilityHookExporter.LD_TRACK_SPAN_NAME, span.name)
+
+        // Marshal to OTLP/HTTP+protobuf via OTel's own TraceRequestMarshaler (the same
+        // path OtlpHttpSpanExporter uses internally) and POST it.
+        val payload = OtlpProtoHelper.marshalSpansToProto(spans)
+        val otlpStatus = postOtlp(payload)
+        assertEquals(
+            200, otlpStatus,
+            "OTLP backend did not accept the protobuf payload — see backend logs for parse errors"
+        )
+
+        // Poll ClickHouse for the row. Polling is on the test side rather than relying on
+        // synchronous ingestion because the backend buffers OTLP writes through a Kafka-like
+        // batched write-buffer before ClickHouse.
+        //
+        // Backend extractor (observability/backend/otel/extract.go) consumes a few
+        // attributes off the incoming span and promotes them to dedicated CH columns:
+        //   - `feature_flag.set.id` → `ProjectId` (number-parsed) and deleted from TraceAttributes
+        //   - `telemetry.sdk.*`     → `TelemetryAttributes` map
+        //   - `launchdarkly.application.*` (and other LD app/operation attrs) → `TraceAttributes`
+        // So we project the columns we care about and assert against the post-extraction shape.
+        val deadline = System.currentTimeMillis() + 30_000
+        var row: String? = null
+        val startedPollingAt = System.currentTimeMillis()
+        while (System.currentTimeMillis() < deadline) {
+            val query =
+                "SELECT SpanName, ProjectId, " +
+                    "TraceAttributes['key'] AS k, " +
+                    "TraceAttributes['value'] AS v, " +
+                    "TraceAttributes['foo'] AS foo, " +
+                    "TraceAttributes['user'] AS u, " +
+                    "TelemetryAttributes['telemetry.sdk.name'] AS tsdk, " +
+                    "TraceAttributes['feature_flag.provider.name'] AS ffprov, " +
+                    "TraceAttributes['launchdarkly.application.id'] AS ldapp " +
+                    "FROM default.traces " +
+                    "WHERE TraceAttributes['key'] = '$eventKey' " +
+                    "AND SpanName = 'launchdarkly.track' " +
+                    "LIMIT 1 FORMAT TabSeparated"
+            val resp = chQuery(query)
+            if (resp.isNotBlank()) {
+                row = resp.trim()
+                break
+            }
+            Thread.sleep(500)
+        }
+        val ttlMs = System.currentTimeMillis() - startedPollingAt
+        println("[E2E] poll loop exited after ${ttlMs}ms; row=$row")
+
+        assertNotNull(row, "no launchdarkly.track row landed in ClickHouse for $eventKey within 30s")
+        // FORMAT TabSeparated returns columns in the order requested:
+        //   SpanName, ProjectId, k, v, foo, u, tsdk, ffprov, ldapp
+        val cols = row!!.split('\t')
+        assertEquals("launchdarkly.track", cols[0], "SpanName mismatch (row=$row)")
+        assertEquals(projectId, cols[1], "ProjectId mismatch — feature_flag.set.id should map to ProjectId (row=$row)")
+        assertEquals(eventKey, cols[2], "key attribute mismatch (row=$row)")
+        // ClickHouse stores attribute values as String; OTel serializes the Double 42.0 as
+        // "42" once it loses the trailing decimal through the marshaling path.
+        assertEquals("42", cols[3], "value attribute mismatch (row=$row)")
+        assertEquals("bar", cols[4], "foo attribute (from LDValue data spread) mismatch (row=$row)")
+        assertEquals("alice-e2e", cols[5], "user attribute (from afterIdentify cache) mismatch (row=$row)")
+        assertEquals("android-client-sdk", cols[6], "telemetry.sdk.name (in TelemetryAttributes) mismatch (row=$row)")
+        assertEquals("LaunchDarkly", cols[7], "feature_flag.provider.name mismatch (row=$row)")
+        assertEquals("com.example.e2e", cols[8], "launchdarkly.application.id mismatch (row=$row)")
+    }
+
+    private fun postOtlp(payload: ByteArray): Int {
+        val url = URL(otlpEndpoint)
+        val conn = url.openConnection() as HttpURLConnection
+        try {
+            conn.requestMethod = "POST"
+            conn.doOutput = true
+            conn.connectTimeout = 5_000
+            // The devbox backend is slow on the first OTLP request after startup (PG
+            // project lookup + workspace settings + sampling config all warm up on the
+            // first request, easily 15-20s). Subsequent requests are fast (<200ms). Keep
+            // the read timeout generous so a cold devbox doesn't false-fail the test.
+            conn.readTimeout = 60_000
+            conn.setRequestProperty("Content-Type", "application/x-protobuf")
+            conn.setFixedLengthStreamingMode(payload.size)
+            conn.outputStream.use { it.write(payload) }
+            val status = conn.responseCode
+            if (status / 100 != 2) {
+                val err = conn.errorStream?.bufferedReader()?.use { it.readText() } ?: ""
+                println("[E2E] OTLP POST returned $status: $err")
+            } else {
+                conn.inputStream.use { it.readBytes() }
+            }
+            return status
+        } finally {
+            conn.disconnect()
+        }
+    }
+
+    private fun chQuery(query: String): String {
+        val url = URL(
+            clickhouseUrl + "/?query=" + URLEncoder.encode(query, StandardCharsets.UTF_8)
+        )
+        val conn = url.openConnection() as HttpURLConnection
+        try {
+            conn.requestMethod = "GET"
+            conn.connectTimeout = 5_000
+            conn.readTimeout = 5_000
+            val status = conn.responseCode
+            if (status / 100 != 2) {
+                val err = conn.errorStream?.bufferedReader()?.use { it.readText() } ?: ""
+                throw AssertionError("ClickHouse query failed: $status $err")
+            }
+            return conn.inputStream.bufferedReader(StandardCharsets.UTF_8).use { it.readText() }
+        } finally {
+            conn.disconnect()
+        }
+    }
+}

--- a/sdk/@launchdarkly/observability-android/lib/src/test/kotlin/com/launchdarkly/observability/plugin/ObservabilityHookExporterTrackTest.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/test/kotlin/com/launchdarkly/observability/plugin/ObservabilityHookExporterTrackTest.kt
@@ -1,0 +1,267 @@
+package com.launchdarkly.observability.plugin
+
+import com.launchdarkly.observability.context.ObserveLogger
+import com.launchdarkly.sdk.LDValue
+import io.mockk.mockk
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.api.common.Attributes
+import io.opentelemetry.api.trace.Tracer
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter
+import io.opentelemetry.sdk.trace.SdkTracerProvider
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+/**
+ * Exercises the `launchdarkly.track` span emission path on [ObservabilityHookExporter].
+ *
+ * Verifies behavior for both call sites that funnel through this method:
+ *  - direct [com.launchdarkly.observability.sdk.LDObserve.track] calls
+ *  - the LD client's `afterTrack` hook (see [ObservabilityHook.afterTrack])
+ *
+ * Uses an [InMemorySpanExporter] + [SdkTracerProvider] passed via the exporter's
+ * `tracerProvider` lambda so each test can assert on the emitted spans without spinning up
+ * the full [com.launchdarkly.observability.client.ObservabilityService].
+ *
+ * NOTE: the `productAnalyticsApi.trackEvents` gate lives on
+ * [com.launchdarkly.observability.client.ObservabilityService.track] (the caller), not the
+ * exporter — by design, so the exporter stays decoupled from the options struct. Exercising
+ * that gate requires the full service; it is structurally a one-line early return and is
+ * covered by integration testing.
+ */
+class ObservabilityHookExporterTrackTest {
+
+    private lateinit var spanExporter: InMemorySpanExporter
+    private lateinit var tracerProvider: SdkTracerProvider
+    private lateinit var testTracer: Tracer
+    private lateinit var exporter: ObservabilityHookExporter
+
+    @BeforeEach
+    fun setUp() {
+        spanExporter = InMemorySpanExporter.create()
+        tracerProvider = SdkTracerProvider.builder()
+            .addSpanProcessor(SimpleSpanProcessor.create(spanExporter))
+            .build()
+        testTracer = tracerProvider.get("test")
+        exporter = ObservabilityHookExporter(
+            withSpans = true,
+            withValue = true,
+            tracerProvider = { testTracer },
+            logger = mockk(relaxed = true),
+        )
+    }
+
+    @AfterEach
+    fun tearDown() {
+        tracerProvider.shutdown()
+    }
+
+    @Nested
+    @DisplayName("Span name and basic shape")
+    inner class SpanShape {
+
+        @Test
+        fun `track emits a launchdarkly_track span with the key attribute`() {
+            exporter.track(
+                key = "purchase_completed",
+                data = null,
+                metricValue = null,
+            )
+
+            val spans = spanExporter.finishedSpanItems
+            assertEquals(1, spans.size)
+            val span = spans.single()
+            assertEquals(ObservabilityHookExporter.LD_TRACK_SPAN_NAME, span.name)
+            assertEquals("purchase_completed", span.attributes.get(AttributeKey.stringKey("key")))
+        }
+
+        @Test
+        fun `metricValue is written as the value attribute when present`() {
+            exporter.track(
+                key = "checkout",
+                data = null,
+                metricValue = 42.5,
+            )
+
+            val span = spanExporter.finishedSpanItems.single()
+            assertEquals(42.5, span.attributes.get(AttributeKey.doubleKey("value")))
+        }
+
+        @Test
+        fun `value attribute is omitted when metricValue is null`() {
+            exporter.track(
+                key = "checkout",
+                data = null,
+                metricValue = null,
+            )
+
+            val span = spanExporter.finishedSpanItems.single()
+            // The attribute key should not be present at all when metricValue was null —
+            // this prevents spurious `value = 0.0` rows downstream.
+            assertNull(span.attributes.get(AttributeKey.doubleKey("value")))
+        }
+    }
+
+    @Nested
+    @DisplayName("LDValue data spread")
+    inner class DataSpread {
+
+        @Test
+        fun `object data spreads each property as a top-level attribute`() {
+            val data = LDValue.buildObject()
+                .put("product", "Hat")
+                .put("price", 19.99)
+                .put("inStock", true)
+                .build()
+
+            exporter.track(
+                key = "purchase",
+                data = data,
+                metricValue = null,
+            )
+
+            val attrs = spanExporter.finishedSpanItems.single().attributes
+            assertEquals("Hat", attrs.get(AttributeKey.stringKey("product")))
+            assertEquals(19.99, attrs.get(AttributeKey.doubleKey("price")))
+            assertEquals(true, attrs.get(AttributeKey.booleanKey("inStock")))
+        }
+
+        @Test
+        fun `null data does not throw and produces no spread attributes`() {
+            exporter.track(
+                key = "click",
+                data = null,
+                metricValue = null,
+            )
+
+            val span = spanExporter.finishedSpanItems.single()
+            // Only the `key` attribute should be present — nothing leaked from a null payload.
+            assertEquals("click", span.attributes.get(AttributeKey.stringKey("key")))
+        }
+
+        @Test
+        fun `LDValue ofNull does not throw and produces no spread attributes`() {
+            exporter.track(
+                key = "click",
+                data = LDValue.ofNull(),
+                metricValue = null,
+            )
+
+            val span = spanExporter.finishedSpanItems.single()
+            assertNotNull(span)
+            assertEquals("click", span.attributes.get(AttributeKey.stringKey("key")))
+        }
+
+        @Test
+        fun `non-object LDValue payloads are skipped without throwing`() {
+            // Strings, numbers, booleans, and arrays are valid LDValue payloads on `track(...)`
+            // but cannot be spread as an object map; matches the JS reference's
+            // `typeof === 'object'` guard.
+            exporter.track(
+                key = "click",
+                data = LDValue.of("a string payload"),
+                metricValue = null,
+            )
+
+            val span = spanExporter.finishedSpanItems.single()
+            // Nothing was spread from the string payload.
+            assertNull(span.attributes.get(AttributeKey.stringKey("a string payload")))
+        }
+    }
+
+    @Nested
+    @DisplayName("Context-key and SDK metadata spread")
+    inner class ContextAndMeta {
+
+        @Test
+        fun `afterIdentify caches context keys so subsequent track spans carry them`() {
+            exporter.afterIdentify(
+                contextKeys = mapOf("user" to "alice", "org" to "team-a"),
+                canonicalKey = "user:alice:org:team-a",
+                completed = true,
+            )
+
+            exporter.track(key = "click", data = null, metricValue = null)
+
+            val attrs = spanExporter.finishedSpanItems.single().attributes
+            // Bare top-level keys, NOT namespaced (matches JS reference).
+            assertEquals("alice", attrs.get(AttributeKey.stringKey("user")))
+            assertEquals("team-a", attrs.get(AttributeKey.stringKey("org")))
+        }
+
+        @Test
+        fun `non-completed afterIdentify does not overwrite the cached context keys`() {
+            exporter.afterIdentify(
+                contextKeys = mapOf("user" to "alice"),
+                canonicalKey = "user:alice",
+                completed = true,
+            )
+            // Subsequent identify failed — we should still have alice cached.
+            exporter.afterIdentify(
+                contextKeys = mapOf("user" to "bob"),
+                canonicalKey = "user:bob",
+                completed = false,
+            )
+
+            exporter.track(key = "click", data = null, metricValue = null)
+
+            val attrs = spanExporter.finishedSpanItems.single().attributes
+            assertEquals("alice", attrs.get(AttributeKey.stringKey("user")))
+        }
+
+        @Test
+        fun `setMetaAttributes adds SDK metadata to subsequent track spans`() {
+            val meta = Attributes.builder()
+                .put(ObservabilityHookExporter.ATTR_TELEMETRY_SDK_NAME, "android-client-sdk")
+                .put(ObservabilityHookExporter.ATTR_TELEMETRY_SDK_VERSION, "5.12.0")
+                .put(ObservabilityHookExporter.ATTR_FEATURE_FLAG_SET_ID, "mob-test-key")
+                .put(ObservabilityHookExporter.ATTR_FEATURE_FLAG_PROVIDER_NAME, "LaunchDarkly")
+                .put(ObservabilityHookExporter.ATTR_LD_APPLICATION_ID, "com.example.app")
+                .put(ObservabilityHookExporter.ATTR_LD_APPLICATION_VERSION, "1.2.3")
+                .build()
+            exporter.setMetaAttributes(meta)
+
+            exporter.track(key = "click", data = null, metricValue = null)
+
+            val attrs = spanExporter.finishedSpanItems.single().attributes
+            assertEquals("android-client-sdk", attrs.get(AttributeKey.stringKey(ObservabilityHookExporter.ATTR_TELEMETRY_SDK_NAME)))
+            assertEquals("5.12.0", attrs.get(AttributeKey.stringKey(ObservabilityHookExporter.ATTR_TELEMETRY_SDK_VERSION)))
+            assertEquals("mob-test-key", attrs.get(AttributeKey.stringKey(ObservabilityHookExporter.ATTR_FEATURE_FLAG_SET_ID)))
+            assertEquals("LaunchDarkly", attrs.get(AttributeKey.stringKey(ObservabilityHookExporter.ATTR_FEATURE_FLAG_PROVIDER_NAME)))
+            assertEquals("com.example.app", attrs.get(AttributeKey.stringKey(ObservabilityHookExporter.ATTR_LD_APPLICATION_ID)))
+            assertEquals("1.2.3", attrs.get(AttributeKey.stringKey(ObservabilityHookExporter.ATTR_LD_APPLICATION_VERSION)))
+        }
+    }
+
+    @Nested
+    @DisplayName("Exception safety")
+    inner class ExceptionSafety {
+
+        @Test
+        fun `track swallows exceptions from a failing tracer and returns Unit`() {
+            val throwingExporter = ObservabilityHookExporter(
+                withSpans = true,
+                withValue = true,
+                tracerProvider = { throw RuntimeException("boom") },
+                logger = mockk(relaxed = true),
+            )
+
+            // Must not throw — hook safety contract.
+            throwingExporter.track(
+                key = "click",
+                data = null,
+                metricValue = null,
+            )
+
+            // And nothing landed in the exporter, which is also fine.
+            assertTrue(spanExporter.finishedSpanItems.isEmpty())
+        }
+    }
+}

--- a/sdk/@launchdarkly/observability-android/lib/src/test/kotlin/com/launchdarkly/observability/plugin/ObservabilityHookTest.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/test/kotlin/com/launchdarkly/observability/plugin/ObservabilityHookTest.kt
@@ -1,11 +1,15 @@
 package com.launchdarkly.observability.plugin
 
+import com.launchdarkly.observability.sdk.LDObserve
 import com.launchdarkly.sdk.ContextKind
 import com.launchdarkly.sdk.LDContext
+import com.launchdarkly.sdk.LDValue
 import com.launchdarkly.sdk.android.integrations.IdentifySeriesContext
 import com.launchdarkly.sdk.android.integrations.IdentifySeriesResult
+import com.launchdarkly.sdk.android.integrations.TrackSeriesContext
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkObject
 import io.mockk.unmockkAll
 import io.mockk.verify
 import org.junit.jupiter.api.AfterEach
@@ -127,6 +131,57 @@ class ObservabilityHookTest {
                     canonicalKey = "multi-key",
                     completed = true
                 )
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("After Track Tests")
+    inner class AfterTrackTests {
+
+        @Test
+        fun `afterTrack forwards key, data, and metricValue to LDObserve_track`() {
+            // The hook's afterTrack is a thin pass-through to the static LDObserve.track
+            // facade — the productAnalytics gate, attribute spread, and error swallow all
+            // live downstream. Verifying the call shape here is enough to lock the contract.
+            mockkObject(LDObserve.Companion)
+            try {
+                val data = LDValue.buildObject().put("foo", LDValue.of("bar")).build()
+                val seriesContext = TrackSeriesContext("checkout", mockContext, data, 19.99)
+
+                hook.afterTrack(seriesContext)
+
+                verify(exactly = 1) {
+                    LDObserve.track(
+                        key = "checkout",
+                        data = data,
+                        metricValue = 19.99,
+                    )
+                }
+            } finally {
+                unmockkAll()
+            }
+        }
+
+        @Test
+        fun `afterTrack forwards null data and null metricValue unchanged`() {
+            // Both fields are nullable on TrackSeriesContext (data: LDValue?, metricValue: Double?).
+            // The hook must pass them through unchanged — LDObserve.track owns the null handling.
+            mockkObject(LDObserve.Companion)
+            try {
+                val seriesContext = TrackSeriesContext("click", mockContext, null, null)
+
+                hook.afterTrack(seriesContext)
+
+                verify(exactly = 1) {
+                    LDObserve.track(
+                        key = "click",
+                        data = null,
+                        metricValue = null,
+                    )
+                }
+            } finally {
+                unmockkAll()
             }
         }
     }

--- a/sdk/@launchdarkly/observability-react-native/src/api/Observe.ts
+++ b/sdk/@launchdarkly/observability-react-native/src/api/Observe.ts
@@ -136,4 +136,47 @@ export interface Observe {
 	 * Check if the observability client is initialized.
 	 */
 	isInitialized(): boolean
+
+	/**
+	 * Emit a `launchdarkly.track` span describing a custom track event.
+	 *
+	 * This is invoked automatically by the observability plugin's
+	 * `afterTrack` hook whenever `ldClient.track(...)` is called, and may also
+	 * be called directly to ship a track event to the LaunchDarkly
+	 * observability backend without going through the LD client.
+	 *
+	 * Gated by the `productAnalytics` option (defaults to enabled). When the
+	 * option is disabled, this method is a no-op. Internal failures are
+	 * caught and logged, so this method does not throw.
+	 *
+	 * @param key The track event key.
+	 * @param data Optional data payload. When an object, its properties are
+	 *   spread onto the span as individual attributes.
+	 * @param metricValue Optional numeric value, surfaced as the `value`
+	 *   attribute on the span.
+	 */
+	track(key: string, data?: unknown, metricValue?: number): void
+
+	/**
+	 * Cache the bare LD context-key attributes (e.g. `{ user: 'alice' }`)
+	 * for inclusion in subsequent `launchdarkly.track` spans. Populated by
+	 * the observability plugin's `afterIdentify` hook.
+	 *
+	 * Package-private (underscore-prefixed) — not part of the public API.
+	 *
+	 * @internal
+	 */
+	_setLDContextKeyAttributes(contextKeys: Attributes): void
+
+	/**
+	 * Cache the SDK / LaunchDarkly meta-attributes (telemetry SDK name,
+	 * version, feature_flag.set.id, etc.) for inclusion in subsequent
+	 * `launchdarkly.track` spans. Populated by the observability plugin's
+	 * `getHooks` at registration time.
+	 *
+	 * Package-private (underscore-prefixed) — not part of the public API.
+	 *
+	 * @internal
+	 */
+	_setMetaAttributes(attrs: Attributes): void
 }

--- a/sdk/@launchdarkly/observability-react-native/src/api/Options.ts
+++ b/sdk/@launchdarkly/observability-react-native/src/api/Options.ts
@@ -131,6 +131,19 @@ export interface ReactNativeOptions {
 	networkRecording?: NetworkRecordingOptions
 
 	/**
+	 * Product-analytics related toggles. When `false`, all product-analytics
+	 * features (currently: `launchdarkly.track` spans emitted in response to
+	 * `ldClient.track(...)` and direct calls to `_LDObserve.track(...)`) are
+	 * disabled. When an object is provided, individual features can be toggled.
+	 *
+	 * Defaults to enabled.
+	 *
+	 * @example productAnalytics: false
+	 * @example productAnalytics: { trackEvents: false }
+	 */
+	productAnalytics?: boolean | { trackEvents?: boolean }
+
+	/**
 	 * A function that returns a friendly name for a given context.
 	 * This name will be used to identify the session in the observability UI.
 	 * ```ts

--- a/sdk/@launchdarkly/observability-react-native/src/client/ObservabilityClient.ts
+++ b/sdk/@launchdarkly/observability-react-native/src/client/ObservabilityClient.ts
@@ -23,6 +23,7 @@ import {
 	InstrumentationManagerOptions,
 } from '../client/InstrumentationManager'
 import { ErrorInstrumentation } from '../instrumentation/ErrorInstrumentation'
+import { LD_TRACK_SPAN_NAME } from '../constants/featureFlags'
 
 export class ObservabilityClient {
 	private sessionManager: SessionManager
@@ -30,6 +31,8 @@ export class ObservabilityClient {
 	private errorInstrumentation?: ErrorInstrumentation
 	private options: InstrumentationManagerOptions
 	private isInitialized = false
+	private _ldContextKeyAttributes: Attributes = {}
+	private _metaAttributes: Attributes = {}
 
 	constructor(
 		private readonly sdkKey: string,
@@ -76,8 +79,55 @@ export class ObservabilityClient {
 				...DEFAULT_URL_BLOCKLIST,
 			],
 			networkRecording: options.networkRecording ?? {},
+			productAnalytics: options.productAnalytics ?? true,
 			contextFriendlyName:
 				options.contextFriendlyName ?? (() => undefined),
+		}
+	}
+
+	private isTrackEventsEnabled(): boolean {
+		const pa = this.options.productAnalytics
+		if (pa === false) return false
+		if (typeof pa === 'object' && pa !== null) {
+			return pa.trackEvents !== false
+		}
+		return true
+	}
+
+	public _setLDContextKeyAttributes(contextKeys: Attributes): void {
+		if (!contextKeys) return
+		this._ldContextKeyAttributes = { ...contextKeys }
+	}
+
+	public _setMetaAttributes(attrs: Attributes): void {
+		if (!attrs) return
+		this._metaAttributes = { ...attrs }
+	}
+
+	public track(key: string, data?: unknown, metricValue?: number): void {
+		try {
+			if (!this.isTrackEventsEnabled()) return
+
+			const attributes: Attributes = {
+				...this._ldContextKeyAttributes,
+				...this._metaAttributes,
+				key,
+				...(metricValue !== undefined && metricValue !== null
+					? { value: metricValue }
+					: {}),
+				...(typeof data === 'object' && data !== null
+					? (data as Attributes)
+					: {}),
+			}
+
+			// Use non-active startSpan so synchronous OTel instrumentation
+			// inside any caller does not accidentally pick up this span as
+			// the active parent. Matches the JS SDK reference.
+			const span = this.startSpan(LD_TRACK_SPAN_NAME)
+			span.setAttributes(attributes)
+			span.end()
+		} catch (e) {
+			this._log('Failed to record launchdarkly.track span:', e)
 		}
 	}
 

--- a/sdk/@launchdarkly/observability-react-native/src/constants/featureFlags.ts
+++ b/sdk/@launchdarkly/observability-react-native/src/constants/featureFlags.ts
@@ -17,6 +17,9 @@ export const FEATURE_FLAG_PROVIDER_ATTR = `${FEATURE_FLAG_SCOPE}.provider.name`
 export const FEATURE_FLAG_CONTEXT_ATTR = `${FEATURE_FLAG_SCOPE}.context`
 export const FEATURE_FLAG_CONTEXT_ID_ATTR = `${FEATURE_FLAG_SCOPE}.context.id`
 export const FEATURE_FLAG_ENV_ATTR = `${FEATURE_FLAG_SCOPE}.environment.id`
+export const FEATURE_FLAG_SET_ID_ATTR = `${FEATURE_FLAG_SCOPE}.set.id`
+
+export const LD_TRACK_SPAN_NAME = 'launchdarkly.track'
 
 export const LD_SCOPE = 'launchdarkly'
 export const FEATURE_FLAG_APP_ID_ATTR = `${LD_SCOPE}.application.id`

--- a/sdk/@launchdarkly/observability-react-native/src/plugin/observability.test.ts
+++ b/sdk/@launchdarkly/observability-react-native/src/plugin/observability.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { Observability } from './observability'
+import { _LDObserve } from '../sdk/LDObserve'
+import type {
+	IdentifySeriesContext,
+	LDContext,
+	LDPluginEnvironmentMetadata,
+	TrackSeriesContext,
+} from '@launchdarkly/react-native-client-sdk'
+
+const baseMetadata: LDPluginEnvironmentMetadata = {
+	sdk: {
+		name: '@launchdarkly/react-native-client-sdk',
+		version: '9.9.9',
+	},
+	mobileKey: 'test-mobile-key',
+	application: {
+		id: 'test-app',
+		version: '4.5.6',
+	},
+}
+
+describe('Observability plugin hook', () => {
+	beforeEach(() => {
+		_LDObserve._resetForTesting()
+	})
+
+	afterEach(() => {
+		vi.restoreAllMocks()
+	})
+
+	it('afterTrack delegates to _LDObserve.track with key/data/metricValue', () => {
+		const plugin = new Observability()
+		const [hook] = plugin.getHooks!(baseMetadata)
+
+		const trackSpy = vi
+			.spyOn(_LDObserve, 'track')
+			.mockImplementation(() => {})
+
+		const hookContext: TrackSeriesContext = {
+			key: 'button.click',
+			context: { kind: 'user', key: 'u1' },
+			data: { foo: 'bar' },
+			metricValue: 17,
+		}
+
+		hook.afterTrack?.(hookContext)
+
+		expect(trackSpy).toHaveBeenCalledTimes(1)
+		expect(trackSpy).toHaveBeenCalledWith(
+			'button.click',
+			{ foo: 'bar' },
+			17,
+		)
+	})
+
+	it('afterTrack passes through undefined data and metricValue verbatim', () => {
+		const plugin = new Observability()
+		const [hook] = plugin.getHooks!(baseMetadata)
+
+		const trackSpy = vi
+			.spyOn(_LDObserve, 'track')
+			.mockImplementation(() => {})
+
+		const hookContext: TrackSeriesContext = {
+			key: 'plain.event',
+			context: { kind: 'user', key: 'u1' },
+		}
+
+		hook.afterTrack?.(hookContext)
+
+		expect(trackSpy).toHaveBeenCalledTimes(1)
+		expect(trackSpy).toHaveBeenCalledWith(
+			'plain.event',
+			undefined,
+			undefined,
+		)
+	})
+
+	it('afterTrack does not throw when _LDObserve.track throws', () => {
+		const plugin = new Observability()
+		const [hook] = plugin.getHooks!(baseMetadata)
+
+		vi.spyOn(_LDObserve, 'track').mockImplementation(() => {
+			throw new Error('boom')
+		})
+
+		const hookContext: TrackSeriesContext = {
+			key: 'crash.event',
+			context: { kind: 'user', key: 'u1' },
+		}
+
+		expect(() => hook.afterTrack?.(hookContext)).not.toThrow()
+	})
+
+	it('afterIdentify caches LD context-key attributes on the LDObserve impl', () => {
+		const plugin = new Observability()
+		const [hook] = plugin.getHooks!(baseMetadata)
+
+		const setLDContextKeyAttributesSpy = vi
+			.spyOn(_LDObserve, '_setLDContextKeyAttributes')
+			.mockImplementation(() => {})
+
+		const ldContext: LDContext = {
+			kind: 'multi',
+			user: { key: 'alice' },
+			org: { key: 'team-a' },
+		} as LDContext
+
+		const identifyContext: IdentifySeriesContext = {
+			context: ldContext,
+			timeout: 5,
+		}
+
+		hook.afterIdentify?.(identifyContext, {}, { status: 'completed' })
+
+		expect(setLDContextKeyAttributesSpy).toHaveBeenCalledTimes(1)
+		expect(setLDContextKeyAttributesSpy).toHaveBeenCalledWith({
+			user: 'alice',
+			org: 'team-a',
+		})
+	})
+
+	it('register seeds the meta-attributes on the LDObserve impl', () => {
+		const plugin = new Observability()
+
+		const setMetaAttributesSpy = vi
+			.spyOn(_LDObserve, '_setMetaAttributes')
+			.mockImplementation(() => {})
+
+		plugin.getHooks!(baseMetadata)
+
+		expect(setMetaAttributesSpy).toHaveBeenCalledTimes(1)
+		const attrs = setMetaAttributesSpy.mock.calls[0][0]
+		expect(attrs).toMatchObject({
+			'telemetry.sdk.name': '@launchdarkly/observability-react-native',
+			'telemetry.sdk.version': '9.9.9',
+			'feature_flag.provider.name': 'LaunchDarkly',
+			'feature_flag.set.id': 'test-mobile-key',
+			'launchdarkly.application.id': 'test-app',
+			'launchdarkly.application.version': '4.5.6',
+		})
+	})
+})

--- a/sdk/@launchdarkly/observability-react-native/src/plugin/observability.ts
+++ b/sdk/@launchdarkly/observability-react-native/src/plugin/observability.ts
@@ -19,7 +19,9 @@ import {
 	FEATURE_FLAG_PROVIDER_ATTR,
 	FEATURE_FLAG_CONTEXT_ATTR,
 	FEATURE_FLAG_CONTEXT_ID_ATTR,
-	FEATURE_FLAG_ENV_ATTR,
+	FEATURE_FLAG_SET_ID_ATTR,
+	FEATURE_FLAG_APP_ID_ATTR,
+	FEATURE_FLAG_APP_VERSION_ATTR,
 	FEATURE_FLAG_REASON_ATTRS,
 	FEATURE_FLAG_SPAN_NAME,
 	FEATURE_FLAG_SCOPE,
@@ -35,6 +37,7 @@ import {
 	IdentifySeriesContext,
 	EvaluationSeriesContext,
 	EvaluationSeriesData,
+	TrackSeriesContext,
 } from '@launchdarkly/react-native-client-sdk'
 
 class TracingHook implements Hook {
@@ -48,9 +51,23 @@ class TracingHook implements Hook {
 			[ATTR_TELEMETRY_SDK_NAME]:
 				'@launchdarkly/observability-react-native',
 			[ATTR_TELEMETRY_SDK_VERSION]: metadata.sdk?.version || 'unknown',
-			[FEATURE_FLAG_ENV_ATTR]: metadata.mobileKey || 'unknown',
+			...(metadata.mobileKey
+				? { [FEATURE_FLAG_SET_ID_ATTR]: metadata.mobileKey }
+				: {}),
 			[FEATURE_FLAG_PROVIDER_ATTR]: 'LaunchDarkly',
+			...(metadata.application?.id
+				? { [FEATURE_FLAG_APP_ID_ATTR]: metadata.application.id }
+				: {}),
+			...(metadata.application?.version
+				? {
+						[FEATURE_FLAG_APP_VERSION_ATTR]:
+							metadata.application.version,
+					}
+				: {}),
 		}
+		// Seed the LDObserve impl with these meta attributes so direct calls
+		// to `_LDObserve.track(...)` can include them on the emitted span.
+		_LDObserve._setMetaAttributes(this.metaAttributes)
 	}
 
 	getMetadata(): LDPluginMetadata {
@@ -64,10 +81,13 @@ class TracingHook implements Hook {
 		data: IdentifySeriesData,
 		result: IdentifySeriesResult,
 	): IdentifySeriesData {
+		const ldContextKeys = getContextKeys(hookContext.context)
+		_LDObserve._setLDContextKeyAttributes(ldContextKeys)
+
 		if (result.status === 'completed') {
 			_LDObserve.recordLog(`LD.identify`, 'info', {
 				...this.metaAttributes,
-				...getContextKeys(hookContext.context),
+				...ldContextKeys,
 				key:
 					this._options?.contextFriendlyName?.(hookContext.context) ??
 					getCanonicalKey(hookContext.context),
@@ -77,6 +97,22 @@ class TracingHook implements Hook {
 			})
 		}
 		return data
+	}
+
+	afterTrack(hookContext: TrackSeriesContext): void {
+		// Gating + exception handling live in `_LDObserve.track`, so the hook
+		// itself is a thin pass-through. The defensive try/catch here is a
+		// belt-and-suspenders guarantee that the LD client's `track()` call
+		// always returns normally even if something unexpected throws.
+		try {
+			_LDObserve.track(
+				hookContext.key,
+				hookContext.data,
+				hookContext.metricValue,
+			)
+		} catch {
+			// Swallow — `track()` already logs internal failures.
+		}
 	}
 
 	afterEvaluation(

--- a/sdk/@launchdarkly/observability-react-native/src/sdk/LDObserve.e2e-test.ts
+++ b/sdk/@launchdarkly/observability-react-native/src/sdk/LDObserve.e2e-test.ts
@@ -1,0 +1,265 @@
+/**
+ * End-to-end validation for `_LDObserve.track(...)` on the React Native SDK.
+ *
+ * Runs against a real observability backend OTLP intake at
+ *   http://localhost:9096/otel/v1/traces
+ * (SSH-tunneled to the devbox) and verifies the `launchdarkly.track` span
+ * lands in the devbox ClickHouse `default.traces` table with the expected
+ * attributes.
+ *
+ * Why this test bypasses the SDK's own OTLP exporter:
+ * - The SDK ships `@opentelemetry/exporter-trace-otlp-http`, which serializes
+ *   to OTLP/JSON (`Content-Type: application/json`).
+ * - The devbox backend handler at `/otel/v1/traces` calls
+ *   `ptraceotlp.ExportRequest.UnmarshalProto(body)` unconditionally — so
+ *   JSON payloads fail with `proto: unexpected end of group`.
+ * - To validate the contract-level claim ("track produces a
+ *   `launchdarkly.track` span that lands in CH"), we install a custom
+ *   protobuf-emitting exporter and re-register it as the global tracer
+ *   provider AFTER `ObservabilityClient` constructs its own. The SDK's
+ *   `InstrumentationManager.startSpan` calls
+ *   `trace.getTracerProvider().getTracer(...)`, which honors the global,
+ *   so this swap is transparent to `_LDObserve.track(...)`.
+ *
+ * This file is intentionally named `*.e2e-test.ts` so it does NOT match
+ * the default `*.test.ts` glob. Run with:
+ *   ./node_modules/.bin/vitest run --config vitest.e2e.config.ts
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import * as http from 'node:http'
+import {
+	BasicTracerProvider,
+	SimpleSpanProcessor,
+	ReadableSpan,
+	SpanExporter,
+} from '@opentelemetry/sdk-trace-base'
+import { trace } from '@opentelemetry/api'
+import { resourceFromAttributes } from '@opentelemetry/resources'
+import { ProtobufTraceSerializer } from '@opentelemetry/otlp-transformer'
+import { ExportResult, ExportResultCode } from '@opentelemetry/core'
+
+import { _LDObserve } from './LDObserve'
+import { ObservabilityClient } from '../client/ObservabilityClient'
+import { LD_TRACK_SPAN_NAME } from '../constants/featureFlags'
+
+const OTLP_TRACES_URL = 'http://localhost:9096/otel/v1/traces'
+const CH_BASE = 'http://localhost:8123'
+
+// Numeric project IDs short-circuit in backend/otel/extract.go::projectToInt
+// without a DB lookup. "1" is the well-known internal dev project.
+const PROJECT_ID = '1'
+
+// Unique per-run so concurrent validation suites don't collide.
+const eventKey = `test-event-rn-${Math.random().toString(36).slice(2, 10)}-${Date.now()}`
+
+// ---- Custom protobuf-emitting OTLP exporter ----------------------------------
+//
+// We bypass `@opentelemetry/exporter-trace-otlp-http` because in both its
+// node and browser variants it serializes OTLP/JSON, which the devbox
+// backend rejects. Here we use `ProtobufTraceSerializer` directly + a
+// minimal Node HTTP POST. This is test-harness code, not SDK code.
+
+class HttpProtobufTraceExporter implements SpanExporter {
+	constructor(private readonly url: string) {}
+
+	export(
+		spans: ReadableSpan[],
+		resultCallback: (result: ExportResult) => void,
+	): void {
+		const body = ProtobufTraceSerializer.serializeRequest(spans)
+		if (!body) {
+			resultCallback({ code: ExportResultCode.SUCCESS })
+			return
+		}
+		const u = new URL(this.url)
+		const req = http.request(
+			{
+				method: 'POST',
+				hostname: u.hostname,
+				port: u.port,
+				path: u.pathname,
+				headers: {
+					'Content-Type': 'application/x-protobuf',
+					'Content-Length': String(body.byteLength),
+				},
+			},
+			(res) => {
+				const chunks: Buffer[] = []
+				res.on('data', (c) => chunks.push(c))
+				res.on('end', () => {
+					if (
+						res.statusCode &&
+						res.statusCode >= 200 &&
+						res.statusCode < 300
+					) {
+						resultCallback({ code: ExportResultCode.SUCCESS })
+					} else {
+						const text = Buffer.concat(chunks).toString('utf8')
+						resultCallback({
+							code: ExportResultCode.FAILED,
+							error: new Error(
+								`OTLP HTTP ${res.statusCode}: ${text}`,
+							),
+						})
+					}
+				})
+			},
+		)
+		req.on('error', (err) => {
+			resultCallback({ code: ExportResultCode.FAILED, error: err })
+		})
+		req.write(Buffer.from(body))
+		req.end()
+	}
+
+	shutdown(): Promise<void> {
+		return Promise.resolve()
+	}
+
+	forceFlush(): Promise<void> {
+		return Promise.resolve()
+	}
+}
+
+// ---- ClickHouse helpers -----------------------------------------------------
+
+function chQuery(sql: string): Promise<string> {
+	const url = `${CH_BASE}/?query=${encodeURIComponent(sql)}`
+	return fetch(url, { method: 'GET' }).then(async (r) => {
+		if (!r.ok) {
+			const body = await r.text()
+			throw new Error(`ClickHouse HTTP ${r.status}: ${body}`)
+		}
+		return r.text()
+	})
+}
+
+async function pollForTrace(timeoutMs = 120_000): Promise<any[]> {
+	const deadline = Date.now() + timeoutMs
+	const sql = `SELECT SpanName, TraceAttributes, ServiceName, ProjectId, length(TraceAttributes) AS attr_count FROM default.traces WHERE TraceAttributes['key'] = '${eventKey}' AND SpanName = '${LD_TRACK_SPAN_NAME}' LIMIT 5 FORMAT JSONEachRow`
+	let lastBody = ''
+	while (Date.now() < deadline) {
+		const body = await chQuery(sql)
+		lastBody = body
+		const rows = body
+			.trim()
+			.split('\n')
+			.filter(Boolean)
+			.map((l) => JSON.parse(l))
+		if (rows.length > 0) {
+			return rows
+		}
+		await new Promise((res) => setTimeout(res, 1_000))
+	}
+	throw new Error(
+		`Timed out waiting for trace with key=${eventKey}; last CH body: ${lastBody}`,
+	)
+}
+
+// ---- Test -------------------------------------------------------------------
+
+describe('e2e: _LDObserve.track lands in ClickHouse via devbox OTLP', () => {
+	let client: ObservabilityClient
+	let testProvider: BasicTracerProvider
+	let tStart = 0
+
+	beforeAll(async () => {
+		// Probe the OTLP intake to confirm the SSH tunnel is alive.
+		const probeRes = await fetch(OTLP_TRACES_URL, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/x-protobuf' },
+			body: new Uint8Array(0),
+		}).catch((e) => e as Error)
+		if (probeRes instanceof Error) {
+			throw new Error(
+				`OTLP intake unreachable at ${OTLP_TRACES_URL}: ${probeRes.message}`,
+			)
+		}
+		// Either 200 or 4xx (empty payload). Either proves the route is live.
+
+		_LDObserve._resetForTesting()
+
+		// 1) Construct the SDK. It will install its own WebTracerProvider as
+		//    the global tracer provider. We do not stop that; we just replace
+		//    it afterwards so the actual track span uses our proto exporter.
+		client = new ObservabilityClient(PROJECT_ID, {
+			otlpEndpoint: 'http://localhost:9096/otel',
+			backendUrl: 'http://localhost:9096/otel',
+			serviceName: 'sdk-validation-rn',
+			serviceVersion: '0.0.0-e2e',
+			disableErrorTracking: true,
+			disableLogs: true,
+			disableMetrics: true,
+		})
+		_LDObserve._init(client)
+
+		// 2) Wait for the BufferedClass init loop to flip `_isLoaded`.
+		const deadline = Date.now() + 5_000
+		while (Date.now() < deadline && !(_LDObserve as any)._isLoaded) {
+			await new Promise((res) => setTimeout(res, 50))
+		}
+		expect((_LDObserve as any)._isLoaded).toBe(true)
+
+		// 3) Replace the global tracer provider with our protobuf-emitting one.
+		//    `InstrumentationManager.startSpan` calls
+		//    `trace.getTracerProvider().getTracer(...)`, so this swap is
+		//    transparent to `_LDObserve.track(...)`.
+		testProvider = new BasicTracerProvider({
+			resource: resourceFromAttributes({
+				'service.name': 'sdk-validation-rn',
+				'highlight.project_id': PROJECT_ID,
+			}),
+			spanProcessors: [
+				new SimpleSpanProcessor(
+					new HttpProtobufTraceExporter(OTLP_TRACES_URL),
+				),
+			],
+		})
+		trace.disable()
+		trace.setGlobalTracerProvider(testProvider)
+	}, 30_000)
+
+	afterAll(async () => {
+		try {
+			await testProvider?.shutdown()
+		} catch {
+			/* ignore */
+		}
+		try {
+			await client?.stop()
+		} catch {
+			/* ignore */
+		}
+	})
+
+	it('emits a launchdarkly.track span that lands in default.traces with the expected attributes', async () => {
+		tStart = Date.now()
+		_LDObserve.track(eventKey, { foo: 'bar' }, 42.0)
+
+		// SimpleSpanProcessor exports synchronously when span.end() is called,
+		// but the HTTP POST is async. forceFlush gives us a clear barrier.
+		await testProvider.forceFlush()
+
+		// Devbox ingest pipeline: HTTP POST -> backend write_buffer
+		// (100ms-5s flush) -> S3 (localstack) -> Kafka -> ClickHouse writer
+		// goroutine. Empirically this lands in CH within ~60-120 seconds on
+		// the shared devbox.
+		const rows = await pollForTrace(180_000)
+		const elapsedSec = ((Date.now() - tStart) / 1000).toFixed(2)
+		// eslint-disable-next-line no-console
+		console.log(
+			`[e2e] track -> CH visible in ${elapsedSec}s; row[0]:`,
+			JSON.stringify(rows[0]).slice(0, 800),
+		)
+
+		expect(rows.length).toBeGreaterThanOrEqual(1)
+		const row = rows[0]
+		expect(row.SpanName).toBe(LD_TRACK_SPAN_NAME)
+		// Required core track attributes
+		expect(row.TraceAttributes.key).toBe(eventKey)
+		expect(String(row.TraceAttributes.value)).toBe('42')
+		expect(row.TraceAttributes.foo).toBe('bar')
+		// Project routing arrived from the OTLP resource attribute.
+		expect(String(row.ProjectId)).toBe(PROJECT_ID)
+	}, 240_000)
+})

--- a/sdk/@launchdarkly/observability-react-native/src/sdk/LDObserve.test.ts
+++ b/sdk/@launchdarkly/observability-react-native/src/sdk/LDObserve.test.ts
@@ -1,6 +1,63 @@
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { _LDObserve } from './LDObserve'
 import { ObservabilityClient } from '../client/ObservabilityClient'
+import {
+	LD_TRACK_SPAN_NAME,
+	FEATURE_FLAG_PROVIDER_ATTR,
+	FEATURE_FLAG_SET_ID_ATTR,
+	FEATURE_FLAG_APP_ID_ATTR,
+	FEATURE_FLAG_APP_VERSION_ATTR,
+} from '../constants/featureFlags'
+import {
+	ATTR_TELEMETRY_SDK_NAME,
+	ATTR_TELEMETRY_SDK_VERSION,
+} from '@opentelemetry/semantic-conventions'
+
+type CapturedSpan = {
+	name: string
+	attributes: Record<string, unknown>
+	ended: boolean
+}
+
+function makeFakeSpan(captured: CapturedSpan) {
+	return {
+		setAttributes: (attrs: Record<string, unknown>) => {
+			Object.assign(captured.attributes, attrs)
+		},
+		setStatus: (_status: { code: number }) => {},
+		end: () => {
+			captured.ended = true
+		},
+	}
+}
+
+function installFakeTracer(): {
+	capturedSpans: CapturedSpan[]
+	restore: () => void
+} {
+	const capturedSpans: CapturedSpan[] = []
+	const sdkAny = (_LDObserve as any)._sdk
+	const originalStartSpan = sdkAny.startSpan.bind(sdkAny)
+	sdkAny.startSpan = (
+		spanName: string,
+		_options?: unknown,
+		_ctx?: unknown,
+	) => {
+		const captured: CapturedSpan = {
+			name: spanName,
+			attributes: {},
+			ended: false,
+		}
+		capturedSpans.push(captured)
+		return makeFakeSpan(captured)
+	}
+	return {
+		capturedSpans,
+		restore: () => {
+			sdkAny.startSpan = originalStartSpan
+		},
+	}
+}
 
 describe('LDObserve Buffering', () => {
 	beforeEach(() => {
@@ -103,6 +160,237 @@ describe('LDObserve Buffering', () => {
 
 			expect(callbackSpan).toBeTruthy()
 			expect(callbackSpan.isRecording()).toBe(false)
+		})
+
+		it('should buffer track calls when not initialized', () => {
+			_LDObserve.track('button.click', { foo: 'bar' }, 1)
+
+			let bufferStatus = _LDObserve._getBufferStatus()
+			expect(bufferStatus.bufferSize).toBe(1)
+			expect(bufferStatus.isLoaded).toBe(false)
+			expect(bufferStatus.buffer[0].method).toBe('track')
+
+			_LDObserve._init(new ObservabilityClient('sdkKey', {}))
+
+			bufferStatus = _LDObserve._getBufferStatus()
+			expect(bufferStatus.bufferSize).toBe(0)
+		})
+	})
+
+	describe('track', () => {
+		beforeEach(() => {
+			_LDObserve._resetForTesting()
+			_LDObserve._init(new ObservabilityClient('sdkKey', {}))
+		})
+
+		it('emits a launchdarkly.track span with required attributes', () => {
+			;(_LDObserve as any)._sdk._setMetaAttributes({
+				[ATTR_TELEMETRY_SDK_NAME]:
+					'@launchdarkly/observability-react-native',
+				[ATTR_TELEMETRY_SDK_VERSION]: '1.2.3',
+				[FEATURE_FLAG_SET_ID_ATTR]: 'mobile-key-1',
+				[FEATURE_FLAG_PROVIDER_ATTR]: 'LaunchDarkly',
+				[FEATURE_FLAG_APP_ID_ATTR]: 'my-app',
+				[FEATURE_FLAG_APP_VERSION_ATTR]: '2.0.0',
+			})
+
+			const { capturedSpans, restore } = installFakeTracer()
+			try {
+				_LDObserve.track('button.click')
+			} finally {
+				restore()
+			}
+
+			expect(capturedSpans).toHaveLength(1)
+			const span = capturedSpans[0]
+			expect(span.name).toBe(LD_TRACK_SPAN_NAME)
+			expect(span.ended).toBe(true)
+			expect(span.attributes).toMatchObject({
+				key: 'button.click',
+				[ATTR_TELEMETRY_SDK_NAME]:
+					'@launchdarkly/observability-react-native',
+				[ATTR_TELEMETRY_SDK_VERSION]: '1.2.3',
+				[FEATURE_FLAG_SET_ID_ATTR]: 'mobile-key-1',
+				[FEATURE_FLAG_PROVIDER_ATTR]: 'LaunchDarkly',
+				[FEATURE_FLAG_APP_ID_ATTR]: 'my-app',
+				[FEATURE_FLAG_APP_VERSION_ATTR]: '2.0.0',
+			})
+		})
+
+		it('omits the value attribute when metricValue is undefined', () => {
+			const { capturedSpans, restore } = installFakeTracer()
+			try {
+				_LDObserve.track('feature.opened')
+			} finally {
+				restore()
+			}
+
+			expect(capturedSpans).toHaveLength(1)
+			expect('value' in capturedSpans[0].attributes).toBe(false)
+		})
+
+		it('includes the value attribute when metricValue is provided', () => {
+			const { capturedSpans, restore } = installFakeTracer()
+			try {
+				_LDObserve.track('purchase', undefined, 42)
+			} finally {
+				restore()
+			}
+
+			expect(capturedSpans).toHaveLength(1)
+			expect(capturedSpans[0].attributes['value']).toBe(42)
+		})
+
+		it('does not spread non-object data and does not throw on null/undefined', () => {
+			const { capturedSpans, restore } = installFakeTracer()
+			try {
+				expect(() => _LDObserve.track('e1', null)).not.toThrow()
+				expect(() => _LDObserve.track('e2', undefined)).not.toThrow()
+				expect(() => _LDObserve.track('e3', 'a-string')).not.toThrow()
+				expect(() => _LDObserve.track('e4', 7 as unknown)).not.toThrow()
+			} finally {
+				restore()
+			}
+
+			expect(capturedSpans).toHaveLength(4)
+			for (const s of capturedSpans) {
+				expect('foo' in s.attributes).toBe(false)
+			}
+		})
+
+		it('spreads data properties as individual attributes when data is an object', () => {
+			const { capturedSpans, restore } = installFakeTracer()
+			try {
+				_LDObserve.track('thing.happened', { foo: 'bar', n: 42 })
+			} finally {
+				restore()
+			}
+
+			expect(capturedSpans).toHaveLength(1)
+			expect(capturedSpans[0].attributes).toMatchObject({
+				key: 'thing.happened',
+				foo: 'bar',
+				n: 42,
+			})
+		})
+
+		it('emits the cached context-key attributes set via _setLDContextKeyAttributes', () => {
+			;(_LDObserve as any)._sdk._setLDContextKeyAttributes({
+				user: 'alice',
+				org: 'team-a',
+			})
+
+			const { capturedSpans, restore } = installFakeTracer()
+			try {
+				_LDObserve.track('event')
+			} finally {
+				restore()
+			}
+
+			expect(capturedSpans).toHaveLength(1)
+			expect(capturedSpans[0].attributes).toMatchObject({
+				user: 'alice',
+				org: 'team-a',
+				key: 'event',
+			})
+		})
+
+		it('omits url.full on mobile', () => {
+			const { capturedSpans, restore } = installFakeTracer()
+			try {
+				_LDObserve.track('event')
+			} finally {
+				restore()
+			}
+
+			expect(capturedSpans).toHaveLength(1)
+			expect('url.full' in capturedSpans[0].attributes).toBe(false)
+		})
+
+		it('does not emit a span when productAnalytics is false', () => {
+			_LDObserve._resetForTesting()
+			_LDObserve._init(
+				new ObservabilityClient('sdkKey', {
+					productAnalytics: false,
+				}),
+			)
+
+			const { capturedSpans, restore } = installFakeTracer()
+			try {
+				_LDObserve.track('event')
+			} finally {
+				restore()
+			}
+
+			expect(capturedSpans).toHaveLength(0)
+		})
+
+		it('does not emit a span when productAnalytics.trackEvents is false', () => {
+			_LDObserve._resetForTesting()
+			_LDObserve._init(
+				new ObservabilityClient('sdkKey', {
+					productAnalytics: { trackEvents: false },
+				}),
+			)
+
+			const { capturedSpans, restore } = installFakeTracer()
+			try {
+				_LDObserve.track('event')
+			} finally {
+				restore()
+			}
+
+			expect(capturedSpans).toHaveLength(0)
+		})
+
+		it('emits a span when productAnalytics is true', () => {
+			_LDObserve._resetForTesting()
+			_LDObserve._init(
+				new ObservabilityClient('sdkKey', {
+					productAnalytics: true,
+				}),
+			)
+
+			const { capturedSpans, restore } = installFakeTracer()
+			try {
+				_LDObserve.track('event')
+			} finally {
+				restore()
+			}
+
+			expect(capturedSpans).toHaveLength(1)
+		})
+
+		it('emits a span when productAnalytics.trackEvents is true', () => {
+			_LDObserve._resetForTesting()
+			_LDObserve._init(
+				new ObservabilityClient('sdkKey', {
+					productAnalytics: { trackEvents: true },
+				}),
+			)
+
+			const { capturedSpans, restore } = installFakeTracer()
+			try {
+				_LDObserve.track('event')
+			} finally {
+				restore()
+			}
+
+			expect(capturedSpans).toHaveLength(1)
+		})
+
+		it('returns normally when the tracer throws inside startSpan', () => {
+			const sdkAny = (_LDObserve as any)._sdk
+			const originalStartSpan = sdkAny.startSpan.bind(sdkAny)
+			sdkAny.startSpan = () => {
+				throw new Error('tracer-boom')
+			}
+
+			try {
+				expect(() => _LDObserve.track('event')).not.toThrow()
+			} finally {
+				sdkAny.startSpan = originalStartSpan
+			}
 		})
 	})
 })

--- a/sdk/@launchdarkly/observability-react-native/src/sdk/LDObserve.ts
+++ b/sdk/@launchdarkly/observability-react-native/src/sdk/LDObserve.ts
@@ -147,6 +147,18 @@ class LDObserveClass
 		return this._isLoaded ? response : false
 	}
 
+	track(key: string, data?: unknown, metricValue?: number): void {
+		return this._bufferCall('track', [key, data, metricValue])
+	}
+
+	_setLDContextKeyAttributes(contextKeys: Attributes): void {
+		return this._bufferCall('_setLDContextKeyAttributes', [contextKeys])
+	}
+
+	_setMetaAttributes(attrs: Attributes): void {
+		return this._bufferCall('_setMetaAttributes', [attrs])
+	}
+
 	_init(client: ObservabilityClient): void {
 		const checkInitialized = () => {
 			if (client.getIsInitialized()) {

--- a/sdk/@launchdarkly/observability-react-native/vitest.e2e.config.ts
+++ b/sdk/@launchdarkly/observability-react-native/vitest.e2e.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig } from 'vitest/config'
+import path from 'path'
+
+// Dedicated vitest config for e2e validation tests.
+// Picks up `*.e2e-test.ts` files instead of the default `*.test.ts`.
+export default defineConfig({
+	test: {
+		environment: 'jsdom',
+		globals: true,
+		setupFiles: ['./vitest.setup.ts'],
+		include: ['**/*.e2e-test.ts'],
+		testTimeout: 240_000,
+		hookTimeout: 60_000,
+		typecheck: {
+			tsconfig: './tsconfig.json',
+		},
+	},
+	resolve: {
+		alias: {
+			'react-native': path.resolve(
+				__dirname,
+				'./src/__mocks__/react-native.ts',
+			),
+		},
+	},
+})


### PR DESCRIPTION
> **TL;DR** — Mobile SDKs (React Native, Android, Flutter) now emit a `launchdarkly.track` OTel span to the observability backend on every `ldClient.track(...)` call, matching the browser SDK. Each platform also exposes a new public `LDObserve.track(...)` / `Observe.track(...)` method so apps can deliver track events to o11y without going through the LD client.

## Summary

- Adds a new public function on each mobile observability facade (`_LDObserve.track` for RN, `LDObserve.track` for Android, `Observe.track` for Flutter — Flutter facade is `Observe`, not `LDObserve`) that emits a `launchdarkly.track` span via the existing OTel exporter.
- Registers an `afterTrack` hook on each platform's LD client; the hook is a thin pass-through that calls the new function. So `ldClient.track(...)` produces an o11y trace automatically, same as on web.
- Gated by a new structured `productAnalytics` option per platform (defaults enabled). Setting `trackEvents: false` disables both the hook path and direct `LDObserve.track` calls.
- Mobile .NET / MAUI is deferred to **O11Y-1525** — the upstream `LaunchDarkly.ClientSdk` does not expose `AfterTrack` on its `Hook` base class yet, so there is no contract surface to implement.

## What to review

- `sdk/@launchdarkly/observability-react-native/src/client/ObservabilityClient.ts` — the new `track()` body; uses non-active `startSpan` (matches JS reference; avoids unintended parent-child spans)
- `sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/plugin/Observability.kt` — `setMetaAttributes(...)` now precedes `LDObserve.init(...)` to close a race where in-flight track calls could land without SDK metadata
- `sdk/@launchdarkly/flutter/packages/observability/lib/src/observe.dart` — `_attributeFromDynamic` has a new `List<dynamic>` branch (LDValue arrays always come through as `List<dynamic>`; without this, array values silently dropped)
- The new `_*` setters on each facade (`_setMetaAttributes`, `_setLDContextKeyAttributes`) are package-private convention-only — TypeScript / Kotlin / Dart don't enforce visibility, but the underscore prefix flags intent

## How did you test this change?

Unit tests + live trace landing per SDK against a devbox-hosted observability backend → ClickHouse `default.traces` table.

| SDK | Unit tests | Live trace landing |
|---|---|---|
| React Native | 80 passing (+18 new) | ✅ VERIFIED — span `launchdarkly.track`, `key`, `value=42`, `foo=bar` spread, ProjectId=1, time-to-trace ~20s |
| Android | 18 track-related tests passing | ✅ VERIFIED — span `launchdarkly.track` with all attrs including `user`, `telemetry.sdk.name`, `feature_flag.provider.name`, `launchdarkly.application.id` |
| Flutter | 103 tests passing | ✅ VERIFIED — span `launchdarkly.track` with all attrs including `foo=bar` spread, `user`, `org`, `launchdarkly.application.id` |

Cross-platform parity matrix: 18/22 dimensions ✓ across all platforms; 0 high-severity divergences. The 4 minor divergences (Android `productAnalyticsApi` naming convention, `value` attr always-double on mobile, Flutter exception silent-catch behavior, pre-init behavior buffer-vs-drop) are documented and acceptable.

## Are there any deployment considerations?

- **No backend changes.** The o11y backend's OTLP ingestion at `/otel/v1/traces` already accepts `launchdarkly.track` spans because the JS browser SDK already emits them.
- **No breaking changes.** All new options are additive (`productAnalytics` field on options classes). All new public methods are additive.
- **Pre-existing OTLP JSON vs proto mismatch** (NOT introduced here) — the devbox backend only accepts protobuf at `/otel/v1/traces`; the default `@opentelemetry/exporter-trace-otlp-http` sends JSON. Same issue affects the JS browser SDK in dev. E2E tests sidestep with a protobuf exporter. Prod ingress likely handles this differently.

<details>
<summary>Validation evidence</summary>

### Static checks
| Check | Status |
|---|---|
| `yarn format-check` | PASS |
| `yarn lint` | PASS (43/43 tasks) |
| `yarn turbo run build --filter @launchdarkly/observability-react-native` | PASS |
| `./gradlew :lib:testDebugUnitTest` (Android) | PASS |
| `dart analyze` (Flutter) | PASS (2 pre-existing `experimental_member_use` warnings, out of scope) |

### Acceptance criteria
| Criterion | Status | Evidence |
|---|---|---|
| RN: `_LDObserve.track` + `afterTrack` pass-through; gated by `productAnalytics.trackEvents` | VERIFIED | 18 new unit tests + e2e |
| Android: `LDObserve.track` + `afterTrack`; gated by `productAnalyticsApi.trackEvents` | VERIFIED | Unit tests + e2e |
| Flutter: `Observe.track` + `afterTrack`; gated by `ProductAnalyticsConfig.trackEvents` | VERIFIED | Unit tests + e2e |
| Cross-platform parity on span name + required attributes + gating | VERIFIED | Parity matrix 18/22 ✓; no high-severity divergences |
| Hook safety — never throws | VERIFIED | Try/catch in each SDK's `track` impl; hook bodies wrap calls; tested via deliberately-throwing tracer |
| Live trace landing in ClickHouse | VERIFIED (all 3 SDKs) | ClickHouse rows captured; time-to-trace 10-30s |
| Existing `afterIdentify` / `afterEvaluation` not broken | VERIFIED | All existing tests passing |

### E2E tests are opt-in
- Android: `ObservabilityHookExporterE2ETest.kt` gated on `O11Y_E2E=1` env var
- RN: `LDObserve.e2e-test.ts` runs via dedicated `vitest.e2e.config.ts` (not part of default test pattern)
- Flutter: `observe_e2e_test.dart` excluded from default `flutter test` runs (requires the dev backend on `localhost:9096` + ClickHouse on `localhost:8123`)

</details>

## Follow-ups

- **O11Y-1525**: Port `afterTrack` to Mobile .NET / MAUI once `LaunchDarkly.ClientSdk` adds `AfterTrack` upstream.