### PR TITLE
ci(ruby): run e2e bundle install non-frozen

### DIFF
--- a/.github/workflows/ruby-plugin.yml
+++ b/.github/workflows/ruby-plugin.yml
@@ -61,7 +61,11 @@ jobs:
               uses: ruby/setup-ruby@3ff19f5e2baf30647122352b96108b1fbe250c64 # v1
               with:
                   ruby-version: '3.3'
-                  bundler-cache: true
+                  # bundler-cache implies frozen (deployment) mode. These e2e apps use the local
+                  # launchdarkly-observability gem via `path:`, whose version is bumped by release-please
+                  # without updating Gemfile.lock, so a frozen `bundle install` fails on the version drift.
+                  # Install non-frozen (the "Install dependencies" step below) to absorb the bump.
+                  bundler-cache: false
                   working-directory: ./e2e/ruby/rails/demo
             - name: Install dependencies
               run: bundle install
@@ -82,7 +86,11 @@ jobs:
               uses: ruby/setup-ruby@3ff19f5e2baf30647122352b96108b1fbe250c64 # v1
               with:
                   ruby-version: '3.3'
-                  bundler-cache: true
+                  # bundler-cache implies frozen (deployment) mode. These e2e apps use the local
+                  # launchdarkly-observability gem via `path:`, whose version is bumped by release-please
+                  # without updating Gemfile.lock, so a frozen `bundle install` fails on the version drift.
+                  # Install non-frozen (the "Install dependencies" step below) to absorb the bump.
+                  bundler-cache: false
                   working-directory: ./e2e/ruby/rails/api-only
             - name: Install dependencies
               run: bundle install

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -71,7 +71,11 @@ jobs:
               uses: ruby/setup-ruby@319994f95fa847cf3fb3cd3dbe89f6dcde9f178f # v1
               with:
                   ruby-version: '3.3.4'
-                  bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+                  # bundler-cache implies frozen (deployment) mode. These e2e apps use the local
+                  # launchdarkly-observability gem via `path:`, whose version is bumped by release-please
+                  # without updating Gemfile.lock, so a frozen `bundle install` fails on the version drift.
+                  # Install non-frozen (the "Install dependencies" step below) to absorb the bump.
+                  bundler-cache: false
             - name: Install dependencies
               run: bundle install
             - name: Test
@@ -90,7 +94,11 @@ jobs:
               uses: ruby/setup-ruby@319994f95fa847cf3fb3cd3dbe89f6dcde9f178f # v1
               with:
                   ruby-version: '3.3.4'
-                  bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+                  # bundler-cache implies frozen (deployment) mode. These e2e apps use the local
+                  # launchdarkly-observability gem via `path:`, whose version is bumped by release-please
+                  # without updating Gemfile.lock, so a frozen `bundle install` fails on the version drift.
+                  # Install non-frozen (the "Install dependencies" step below) to absorb the bump.
+                  bundler-cache: false
             - name: Install dependencies
               run: bundle install
             - name: Test


### PR DESCRIPTION
## Problem

The Ruby e2e jobs fail on the release PR (and will fail on `main` after it merges) with:

```
The gemspecs for path gems changed, but the lockfile can't be updated because frozen mode is set
The process '/opt/.../bin/bundle' failed with exit code 16
```

Example failure: the **Rails API-Only E2E Tests** and **Rails E2E Tests** jobs on the release-please PR (#574).

### Root cause

The e2e apps (`e2e/ruby/rails/demo`, `e2e/ruby/rails/api-only`) depend on the local SDK via:

```ruby
gem 'launchdarkly-observability', path: '../../../../sdk/@launchdarkly/observability-ruby'
```

`ruby/setup-ruby` with `bundler-cache: true` runs `bundle install` in **deployment / frozen** mode whenever a `Gemfile.lock` is present (it unconditionally sets `bundle config --local deployment true`). release-please bumps the gem's `version.rb` (e.g. `0.2.0` → `0.2.1`) but does **not** update the committed e2e `Gemfile.lock` files (its ruby `extra-files` are only `version.rb` and `PROVENANCE.md`, and a `Gemfile.lock` can't carry release-please annotations). So immediately after a version bump the lockfile records the old version, the path gem's gemspec records the new one, and the frozen install refuses to reconcile them.

This isn't one-off: it breaks **every** Ruby release PR, and poisons `main`'s e2e jobs once a release merges.

## Fix

Set `bundler-cache: false` on the four e2e jobs across both Ruby workflows (`ruby-plugin.yml`: `e2e-rails`, `e2e-rails-api-only`; `ruby.yml`: `e2e`, `e2e-api-only`). Each job already has an explicit `Install dependencies → bundle install` step; with caching off, that install runs **non-frozen** and absorbs the path-gem version bump (only the path gem's version line changes — third-party deps stay pinned by the lockfile).

The SDK `build` jobs are intentionally left on `bundler-cache: true` — they have no committed `Gemfile.lock`, so setup-ruby generates one fresh and never hits frozen mode.

### Why this approach

The version bump lives only on the release branch, so a lockfile bump can't live on `main` without breaking `main`. A workflow change is version-agnostic and durable. Trade-off: the e2e jobs lose gem caching (~1–2 min slower); acceptable for these infrequent jobs. A follow-up could restore caching via a manual `actions/cache` step if desired.

This will green the Ruby e2e jobs on release PR #574 once it rebases onto `main`.

## Test plan

- [ ] CI on this PR runs the Ruby e2e jobs against the consistent `main` state (version.rb and lockfiles both at the current version) — they should pass, proving the non-frozen install is a safe no-op on the happy path.
- [ ] After merge, confirm the Ruby e2e jobs go green on the release-please PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow tuning for e2e jobs; no runtime or application code changes, with a modest trade-off of slower e2e installs without gem caching.
> 
> **Overview**
> Disables **`bundler-cache`** on the four Ruby Rails e2e jobs in **`ruby-plugin.yml`** and **`ruby.yml`**, so **`ruby/setup-ruby`** no longer runs a frozen **`bundle install`** when a committed **`Gemfile.lock`** is present.
> 
> Those e2e apps pin the local **`launchdarkly-observability`** gem via **`path:`**; release-please bumps the gem version without updating the lockfile, which previously caused exit code 16 on release PRs. Each job still runs an explicit **`bundle install`** step, which can reconcile the path-gem version while leaving third-party deps locked. SDK **`build`** jobs are unchanged and keep **`bundler-cache: true`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fdb8c6e68d4979b8d487ce45fa9d18df52864be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->