### PR TITLE
ci(flutter): publish observability from tag-triggered workflow

### DIFF
--- a/.github/workflows/flutter-observability-publish.yml
+++ b/.github/workflows/flutter-observability-publish.yml
@@ -1,0 +1,45 @@
+name: 'Publish Flutter Observability'
+
+# Mirrors the launchdarkly/flutter-client-sdk publishing setup: release-please only creates
+# tags, and this tag-triggered workflow publishes. pub.dev OIDC publishing is only permitted
+# from a tag-triggered workflow. Prerelease versions can also be published by pushing a
+# matching tag manually.
+on:
+    push:
+        tags:
+            - 'launchdarkly_flutter_observability-*'
+
+permissions:
+    id-token: write # Required for authentication using OIDC.
+    contents: read
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+    publish:
+        name: Publish to pub.dev
+        runs-on: ubuntu-latest
+        permissions:
+            id-token: write # Required for authentication using OIDC.
+        defaults:
+            run:
+                working-directory: ./sdk/@launchdarkly/flutter/packages/observability
+        steps:
+            - uses: actions/checkout@v4
+
+            # setup-dart configures the temporary pub.dev OIDC credential that `flutter pub
+            # publish` reads. subosito/flutter-action does not do this on its own.
+            - name: Install Dart
+              uses: dart-lang/setup-dart@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c # v1
+
+            - name: Install Flutter
+              uses: subosito/flutter-action@0ca7a949e71ae44c8e688a51c5e7e93b2c87e295 # v2
+              with:
+                  channel: 'stable'
+                  cache: true
+
+            - name: Install dependencies
+              run: flutter pub get
+
+            - name: Publish to pub.dev
+              run: flutter pub publish --force

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -175,28 +175,7 @@ jobs:
             upload-assets: true
             upload-tag-name: ${{ needs.release-package.outputs.ruby-plugin-tag-name }}
 
-    release-flutter-plugin:
-        runs-on: ubuntu-latest
-        permissions:
-            id-token: write # Required for OIDC authentication to pub.dev.
-            contents: read
-        needs: ['release-package']
-        if: ${{ needs.release-package.outputs.flutter-plugin-released == 'true' }}
-        defaults:
-            run:
-                working-directory: ./sdk/@launchdarkly/flutter/packages/observability
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v4
-
-            - name: Install Flutter
-              uses: subosito/flutter-action@0ca7a949e71ae44c8e688a51c5e7e93b2c87e295 # v2
-              with:
-                  channel: 'stable'
-                  cache: true
-
-            - name: Install dependencies
-              run: flutter pub get
-
-            - name: Publish to pub.dev
-              run: flutter pub publish --force
+    # NOTE: Flutter publishing is handled by .github/workflows/flutter-observability-publish.yml,
+    # which is triggered by the git tag that release-please creates. This mirrors the
+    # launchdarkly/flutter-client-sdk setup: pub.dev OIDC publishing is only permitted from a
+    # tag-triggered workflow, not from this branch-triggered (push: main) run.


### PR DESCRIPTION
## Summary
- Moves Flutter (`launchdarkly_flutter_observability`) publishing out of the branch-triggered `release-please.yml` run, which could never authenticate to pub.dev: pub.dev OIDC publishing is only permitted from a **tag-triggered** workflow, so the old job fell back to interactive OAuth and hung in CI.
- Adds `flutter-observability-publish.yml`, a tag-triggered workflow (`launchdarkly_flutter_observability-*`) that authenticates via `dart-lang/setup-dart` (OIDC) + `subosito/flutter-action`, mirroring the proven `launchdarkly/flutter-client-sdk` setup.

## Follow-ups (out of band, require pub.dev admin)
- The package must exist on pub.dev (first version published manually) before automated publishing can be enabled.
- Enable automated publishing on the package's pub.dev Admin page: repository `launchdarkly/observability-sdk`, tag pattern `launchdarkly_flutter_observability-{{version}}`.

## Test plan
- [ ] Merge, let release-please cut a release tag, and confirm the publish workflow triggers and authenticates via OIDC.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only release plumbing change; no runtime SDK or application code is modified.
> 
> **Overview**
> **Flutter observability** publishing no longer runs inside the branch-triggered `release-please.yml` job that ran on `main`; that path could not use pub.dev OIDC and would hang on interactive auth.
> 
> A new workflow **`flutter-observability-publish.yml`** runs on tags `launchdarkly_flutter_observability-*` (the tags release-please still creates). It publishes from `sdk/@launchdarkly/flutter/packages/observability` using **`dart-lang/setup-dart`** for OIDC credentials plus **`subosito/flutter-action`**, then `flutter pub publish --force`. `release-please.yml` now only documents that Flutter publish is delegated to this tag workflow, aligned with the flutter-client-sdk pattern.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6081a1fd18c3ffc3d4723c06849e0e811907df88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->