### PR TITLE
fix(ruby): silence observability plugin warnings (log bridge, nil context id, instrumentation options)

### DIFF
--- a/e2e/ruby/rails/demo/test/integration/observability_instrumentation_test.rb
+++ b/e2e/ruby/rails/demo/test/integration/observability_instrumentation_test.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+# End-to-end coverage for the LaunchDarkly observability plugin's Rails
+# auto-instrumentation.
+#
+# Background: the plugin configures OpenTelemetry from `Plugin#register`, which
+# runs when the LaunchDarkly client is created. In this app that happens in
+# `config/initializers/launchdarkly.rb` — i.e. DURING Rails boot — so the OTel
+# Rails-family instrumentations (Rack, ActionPack, ActiveRecord, ...) install
+# correctly. A customer who instead creates the client lazily AFTER boot sees
+# "Instrumentation: OpenTelemetry::Instrumentation::ActionPack failed to install"
+# because the ActiveSupport.on_load hooks those instrumentations rely on have
+# already fired. These tests pin the working boot-time behavior so a regression
+# (or a change that breaks instrumentation install) is caught in CI.
+class ObservabilityInstrumentationTest < ActionDispatch::IntegrationTest
+  # The Rails-family instrumentations that must attach during a boot-time init.
+  # These are exactly the ones that report "failed to install" on the lazy path.
+  RAILS_INSTRUMENTATIONS = %w[Rack ActionPack ActiveRecord ActiveSupport Rails].freeze
+
+  def instrumentation_instance(name)
+    Object.const_get("OpenTelemetry::Instrumentation::#{name}::Instrumentation").instance
+  end
+
+  test 'rails auto-instrumentation installed during boot' do
+    RAILS_INSTRUMENTATIONS.each do |name|
+      assert instrumentation_instance(name).installed?,
+             "#{name} instrumentation should be installed after a boot-time plugin init " \
+             '(it reports "failed to install" when the client is created lazily after boot)'
+    end
+  end
+
+  test 'http request produces a server span via the rack instrumentation' do
+    exporter = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new
+    processor = OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor.new(exporter)
+    OpenTelemetry.tracer_provider.add_span_processor(processor)
+
+    get pages_home_url
+    assert_response :success
+
+    server_spans = exporter.finished_spans.select { |s| s.kind == :server }
+    refute_empty server_spans, 'expected an HTTP server span from the Rack/ActionPack instrumentation'
+  end
+end

--- a/e2e/ruby/rails/demo/test/test_helper.rb
+++ b/e2e/ruby/rails/demo/test/test_helper.rb
@@ -1,6 +1,14 @@
 # frozen_string_literal: true
 
 ENV['RAILS_ENV'] ||= 'test'
+
+# The observability plugin only configures OpenTelemetry (and installs the Rails
+# auto-instrumentation) when the LaunchDarkly client registers it, which requires
+# a non-empty SDK key. Set a dummy key BEFORE the app boots so the instrumentation
+# attaches during initialization. The key is invalid, so the client never connects
+# (background connection attempts fail gracefully and do not affect tests).
+ENV['LAUNCHDARKLY_SDK_KEY'] ||= 'sdk-test-0000000000000000000000'
+
 require_relative '../config/environment'
 require 'rails/test_help'
 

--- a/sdk/@launchdarkly/observability-ruby/lib/launchdarkly_observability.rb
+++ b/sdk/@launchdarkly/observability-ruby/lib/launchdarkly_observability.rb
@@ -179,8 +179,12 @@ module LaunchDarklyObservability
     private
 
     def otel_logger_provider_available?
-      defined?(OpenTelemetry::SDK::Logs::LoggerProvider) &&
-        OpenTelemetry.respond_to?(:logger_provider) &&
+      # `defined?` returns nil (not false) when the constant is absent, so guard
+      # first and return an explicit boolean — never nil. Mirrors the inlined
+      # copy in the Railtie (see rails.rb).
+      return false unless defined?(OpenTelemetry::SDK::Logs::LoggerProvider)
+
+      OpenTelemetry.respond_to?(:logger_provider) &&
         OpenTelemetry.logger_provider.is_a?(OpenTelemetry::SDK::Logs::LoggerProvider)
     end
   end

--- a/sdk/@launchdarkly/observability-ruby/lib/launchdarkly_observability.rb
+++ b/sdk/@launchdarkly/observability-ruby/lib/launchdarkly_observability.rb
@@ -13,7 +13,13 @@ require_relative 'launchdarkly_observability/source_context'
 
 require_relative 'launchdarkly_observability/middleware'
 require_relative 'launchdarkly_observability/otel_log_bridge'
-require_relative 'launchdarkly_observability/rails'
+
+# NOTE: rails.rb is required at the *bottom* of this file, after the
+# LaunchDarklyObservability module body has been fully defined. Its Railtie
+# registers a `config.after_initialize` hook that runs synchronously when the
+# gem is required lazily after Rails has booted. That hook references module
+# constants and `class << self` methods, so they must already exist when the
+# require runs. See the require at the end of this file.
 
 module LaunchDarklyObservability
   # Default OTLP endpoint for LaunchDarkly Observability
@@ -179,3 +185,9 @@ module LaunchDarklyObservability
     end
   end
 end
+
+# Required last, on purpose: the Rails Railtie's `config.after_initialize` hook
+# can run synchronously during this require (lazy require after Rails has
+# booted), and it depends on the fully-defined LaunchDarklyObservability module
+# above. See the note next to the other require_relative calls at the top.
+require_relative 'launchdarkly_observability/rails'

--- a/sdk/@launchdarkly/observability-ruby/lib/launchdarkly_observability/hook.rb
+++ b/sdk/@launchdarkly/observability-ruby/lib/launchdarkly_observability/hook.rb
@@ -67,7 +67,7 @@ module LaunchDarklyObservability
       return data unless span
 
       add_result_attributes(span, detail)
-      handle_evaluation_error(span, detail)
+      handle_evaluation_error(span, series_context, detail)
       add_feature_flag_event(span, series_context, detail)
 
       span.finish
@@ -179,31 +179,56 @@ module LaunchDarklyObservability
       end
     end
 
-    def handle_evaluation_error(span, detail)
+    def handle_evaluation_error(span, series_context, detail)
       reason = detail.reason
       return unless reason.respond_to?(:kind) && reason.kind == :ERROR
 
       error_kind = reason.respond_to?(:error_kind) ? reason.error_kind.to_s : 'general'
 
-      error_type = case error_kind.upcase
-                   when 'FLAG_NOT_FOUND'
-                     'flag_not_found'
-                   when 'MALFORMED_FLAG'
-                     'parse_error'
-                   when 'USER_NOT_SPECIFIED', 'CLIENT_NOT_READY'
-                     'provider_not_ready'
-                   when 'WRONG_TYPE'
-                     'type_mismatch'
-                   else
-                     'general'
-                   end
+      span.set_attribute(ERROR_TYPE, error_type_for(error_kind))
 
-      span.set_attribute(ERROR_TYPE, error_type)
-
-      error_message = "Flag evaluation error: #{error_kind}"
+      error_message = error_message_for(error_kind, series_context)
       span.set_attribute(ERROR_MESSAGE, error_message)
 
       span.status = OpenTelemetry::Trace::Status.error(error_message)
+    end
+
+    # Maps a LaunchDarkly evaluation error kind to an OpenTelemetry feature-flag
+    # `error.type` value. USER_NOT_SPECIFIED means the *context* was missing or
+    # invalid — not that the provider was unready — so it maps to
+    # `invalid_context`, not `provider_not_ready` (which is CLIENT_NOT_READY).
+    def error_type_for(error_kind)
+      case error_kind.upcase
+      when 'FLAG_NOT_FOUND'
+        'flag_not_found'
+      when 'MALFORMED_FLAG'
+        'parse_error'
+      when 'USER_NOT_SPECIFIED'
+        'invalid_context'
+      when 'CLIENT_NOT_READY'
+        'provider_not_ready'
+      when 'WRONG_TYPE'
+        'type_mismatch'
+      else
+        'general'
+      end
+    end
+
+    # Builds the span error message. For an invalid context the SDK returns
+    # USER_NOT_SPECIFIED and otherwise drops *why* it was invalid from the
+    # trace; recover that from the context's own validation error so someone
+    # debugging in traces sees e.g. "context key must not be null or empty"
+    # instead of a bare error kind. The SDK's validation messages are static and
+    # structural (never key/kind/attribute values), so this leaks no context
+    # data.
+    def error_message_for(error_kind, series_context)
+      base = "Flag evaluation error: #{error_kind}"
+
+      context = series_context.context
+      return base unless context.respond_to?(:valid?) && !context.valid?
+      return base unless context.respond_to?(:error) && context.error
+
+      "#{base} (#{context.error})"
     end
   end
 end

--- a/sdk/@launchdarkly/observability-ruby/lib/launchdarkly_observability/opentelemetry_config.rb
+++ b/sdk/@launchdarkly/observability-ruby/lib/launchdarkly_observability/opentelemetry_config.rb
@@ -105,9 +105,16 @@ module LaunchDarklyObservability
     # User-provided instrumentation config is merged on top of defaults,
     # so users only need to specify the instrumentations they want to override.
     def configure_instrumentations(config)
+      # Only pass options that the instrumentations actually accept. Unknown
+      # options are not fatal but emit a warning on every boot ("ignored the
+      # following unknown configuration options [...]"):
+      # - `enable_recognize_route` is not an option on the Rails, Rack, or
+      #   ActionPack instrumentations; route-based span naming (http.route) is
+      #   handled automatically by the ActionPack instrumentation.
+      # - ActiveRecord has no `db_statement` option; SQL capture comes from the
+      #   database adapter instrumentations (Mysql2, PG, ...) which default to
+      #   obfuscating statements.
       defaults = {
-        'OpenTelemetry::Instrumentation::Rails' => { enable_recognize_route: true },
-        'OpenTelemetry::Instrumentation::ActiveRecord' => { db_statement: :include },
         'OpenTelemetry::Instrumentation::Net::HTTP' => { untraced_hosts: [] },
         'OpenTelemetry::Instrumentation::Rack' => { untraced_endpoints: ['/health', '/healthz', '/ready'] }
       }

--- a/sdk/@launchdarkly/observability-ruby/lib/launchdarkly_observability/rails.rb
+++ b/sdk/@launchdarkly/observability-ruby/lib/launchdarkly_observability/rails.rb
@@ -127,8 +127,18 @@ module LaunchDarklyObservability
           warn "[LaunchDarklyObservability] Could not attach log bridge to Rails.logger: #{e.message}"
         end
 
+        # The availability check is inlined here rather than delegating to
+        # LaunchDarklyObservability.otel_logger_provider_available? on purpose.
+        # rails.rb is required from launchdarkly_observability.rb *before* that
+        # file's `class << self` block (which defines the module method) has run.
+        # When the gem is lazily required after Rails has booted, the
+        # `config.after_initialize` hook above executes synchronously while this
+        # file is still loading, so the module method does not exist yet and the
+        # delegation raised "undefined method `otel_logger_provider_available?'".
         def otel_logger_provider_available?
-          LaunchDarklyObservability.send(:otel_logger_provider_available?)
+          defined?(OpenTelemetry::SDK::Logs::LoggerProvider) &&
+            OpenTelemetry.respond_to?(:logger_provider) &&
+            OpenTelemetry.logger_provider.is_a?(OpenTelemetry::SDK::Logs::LoggerProvider)
         end
       end
 

--- a/sdk/@launchdarkly/observability-ruby/lib/launchdarkly_observability/rails.rb
+++ b/sdk/@launchdarkly/observability-ruby/lib/launchdarkly_observability/rails.rb
@@ -136,8 +136,12 @@ module LaunchDarklyObservability
         # file is still loading, so the module method does not exist yet and the
         # delegation raised "undefined method `otel_logger_provider_available?'".
         def otel_logger_provider_available?
-          defined?(OpenTelemetry::SDK::Logs::LoggerProvider) &&
-            OpenTelemetry.respond_to?(:logger_provider) &&
+          # `defined?` returns nil (not false) when the constant is absent, so
+          # guard first and return an explicit boolean — callers (and the
+          # railtie test) expect true/false, never nil.
+          return false unless defined?(OpenTelemetry::SDK::Logs::LoggerProvider)
+
+          OpenTelemetry.respond_to?(:logger_provider) &&
             OpenTelemetry.logger_provider.is_a?(OpenTelemetry::SDK::Logs::LoggerProvider)
         end
       end

--- a/sdk/@launchdarkly/observability-ruby/test/hook_test.rb
+++ b/sdk/@launchdarkly/observability-ruby/test/hook_test.rb
@@ -233,6 +233,53 @@ class HookTest < Minitest::Test
     refute flag_event.attributes.key?('feature_flag.context.id')
   end
 
+  # USER_NOT_SPECIFIED means the context was missing or invalid — not that the
+  # provider was unready. It must map to the OTel `invalid_context` error.type,
+  # not `provider_not_ready` (which is reserved for CLIENT_NOT_READY).
+  def test_user_not_specified_maps_to_invalid_context_error_type
+    series_context = create_series_context
+    detail = create_error_detail(error_kind: :USER_NOT_SPECIFIED)
+
+    data = @hook.before_evaluation(series_context, {})
+    @hook.after_evaluation(series_context, data, detail)
+
+    span = @exporter.finished_spans.first
+    assert_equal 'invalid_context', span.attributes['error.type']
+  end
+
+  def test_client_not_ready_maps_to_provider_not_ready_error_type
+    series_context = create_series_context
+    detail = create_error_detail(error_kind: :CLIENT_NOT_READY)
+
+    data = @hook.before_evaluation(series_context, {})
+    @hook.after_evaluation(series_context, data, detail)
+
+    span = @exporter.finished_spans.first
+    assert_equal 'provider_not_ready', span.attributes['error.type']
+  end
+
+  # When the context is invalid the SDK returns USER_NOT_SPECIFIED but otherwise
+  # drops *why* it was invalid. Surface the context's own validation error on the
+  # span error message so the failure is debuggable from the trace alone.
+  def test_invalid_context_error_message_includes_validation_reason
+    invalid_context = LaunchDarkly::LDContext.create({ key: 'k', kind: 123 })
+    refute invalid_context.valid?
+    refute_nil invalid_context.error
+
+    series_context = LaunchDarkly::Interfaces::Hooks::EvaluationSeriesContext.new(
+      'my-flag', invalid_context, false, :variation
+    )
+    detail = create_error_detail(error_kind: :USER_NOT_SPECIFIED)
+
+    data = @hook.before_evaluation(series_context, {})
+    @hook.after_evaluation(series_context, data, detail)
+
+    span = @exporter.finished_spans.first
+    assert_equal 'invalid_context', span.attributes['error.type']
+    assert_includes span.attributes['error.message'], invalid_context.error
+    assert_equal OpenTelemetry::Trace::Status::ERROR, span.status.code
+  end
+
   def test_nil_context_does_not_raise_and_still_records_event
     series_context = LaunchDarkly::Interfaces::Hooks::EvaluationSeriesContext.new(
       'my-flag', nil, false, :variation

--- a/sdk/@launchdarkly/observability-ruby/test/rails_railtie_test.rb
+++ b/sdk/@launchdarkly/observability-ruby/test/rails_railtie_test.rb
@@ -114,5 +114,30 @@ class RailsRailtieTest < Minitest::Test
            'ViewHelpers should be defined after loading rails.rb'
     assert defined?(LaunchDarklyObservability::Railtie),
            'Railtie should be defined after loading rails.rb'
+
+    # Regression: the Railtie's `attach_otel_log_bridge` runs from the synchronous
+    # `config.after_initialize` block *during* the require of launchdarkly_observability.rb,
+    # before that file's `class << self` block (which defines the module-level
+    # `otel_logger_provider_available?`) has executed. The Railtie used to delegate to
+    # that not-yet-defined method, so the bridge attach failed with:
+    #
+    #   Could not attach log bridge to Rails.logger: undefined method
+    #   `otel_logger_provider_available?' for module LaunchDarklyObservability
+    #
+    # The Railtie's check must be self-contained. Simulate the load-order state by
+    # removing the module method, then assert the Railtie check still works.
+    sc = LaunchDarklyObservability.singleton_class
+    saved = sc.instance_method(:otel_logger_provider_available?)
+    sc.send(:remove_method, :otel_logger_provider_available?)
+    begin
+      result = nil
+      assert_silent do
+        result = LaunchDarklyObservability::Railtie.send(:otel_logger_provider_available?)
+      end
+      assert_includes [true, false], result
+    ensure
+      sc.send(:define_method, :otel_logger_provider_available?, saved)
+      sc.send(:private, :otel_logger_provider_available?)
+    end
   end
 end


### PR DESCRIPTION
## Summary

Follow-up to #575. A customer integrating the Ruby observability plugin reported a flood of warnings/errors in their logs after traces started flowing. The most urgent one — the nil `feature_flag.context.id` OTel error — shipped separately in **0.2.2** (#641). This PR carries the rest of the fixes (each with a regression test), sharpens how invalid contexts surface on the trace, closes the e2e gap that let them through, and de-flakes the railtie test.

Diagnosed from the customer's log dump:

| Log line | Cause | Fix |
|---|---|---|
| `Could not attach log bridge to Rails.logger: undefined method 'otel_logger_provider_available?'` | Railtie's `after_initialize` runs synchronously during a lazy (post-boot) `require`, before the module method it delegated to was defined | Inline the check in the Railtie; move the `rails.rb` require to the bottom of the main file |
| `Instrumentation ... ignored the following unknown configuration options [:db_statement] / [:enable_recognize_route]` | Options that don't exist on the pinned instrumentation versions | Remove them (route naming is automatic via ActionPack; SQL capture is via the DB adapter instrumentations) |

> The `OpenTelemetry error: invalid ... attribute value type NilClass for key 'feature_flag.context.id'` line is already fixed and released in 0.2.2 (#641). This PR builds on top of that fix.

## Better invalid-context diagnostics

A nil `feature_flag.context.id` (the thing #641 silenced) is itself a signal: that evaluation ran against an **invalid** context and fell back to the flag's default value. Two changes make that legible on the trace instead of silent:

- `USER_NOT_SPECIFIED` now maps to the OpenTelemetry feature-flag `error.type = invalid_context`. It was `provider_not_ready`, which is misleading — the provider is fine, the context isn't; `provider_not_ready` is now reserved for `CLIENT_NOT_READY`.
- The span's `error.message` now includes the context's own validation reason (e.g. `Flag evaluation error: USER_NOT_SPECIFIED (context kind must be a string)`), recovered from `LDContext#error`. The SDK's validation messages are static and structural — never key/kind/attribute values — so no context data is leaked.

## De-flake the railtie test

`otel_logger_provider_available?` began with `defined?(...)`, which returns a string or nil — so when `OpenTelemetry::SDK::Logs` wasn't loaded yet, the `&&` chain returned nil instead of false and the railtie regression test (which asserts true/false) flaked ~3/8 runs depending on test order. Both copies of the predicate — the Railtie's inlined one and the module-level one — now guard the constant first and return a strict boolean.

## Tests

- Gem suite: regression tests for the log-bridge load order and the new invalid-context `error.type`/message. 118 runs, 0 failures across repeated runs; rubocop clean.
- **e2e:** new `ObservabilityInstrumentationTest` in the Rails demo app asserts the Rails-family instrumentations report `installed? == true` after boot (the inverse of "failed to install") and that a request produces a server span. The demo app only ever exercised the boot-time-init happy path, which is why this slipped through.

## Not included (follow-up)

The `Instrumentation: ... failed to install` warnings are a separate issue: the plugin configures auto-instrumentation from `Plugin#register` (at `LDClient.new`), so when a client is created lazily *after* Rails boots, the Rails instrumentations' `ActiveSupport.on_load` hooks have already fired. Fixing that (install instrumentation during Rails boot) plus a lazy-init e2e variant is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
