### PR TITLE
feat(ruby): install Rails auto-instrumentation during boot (fix lazy-init 'failed to install')

### DIFF
--- a/e2e/ruby/rails/demo/app/models/lazy_ld_client.rb
+++ b/e2e/ruby/rails/demo/app/models/lazy_ld_client.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Mirrors an application that creates the LaunchDarkly client lazily — e.g. from
+# a model on first use — instead of during boot in a config/initializer. Enabled
+# with LD_LAZY_INIT=1 (see config/initializers/launchdarkly.rb) and exercised by
+# the lazy-init e2e test, which verifies the Railtie installs OpenTelemetry
+# auto-instrumentation at boot even though the client is created afterward.
+class LazyLdClient
+  def self.instance
+    @instance ||= begin
+      plugin = LaunchDarklyObservability::Plugin.new(
+        otlp_endpoint: ENV.fetch('OTEL_EXPORTER_OTLP_ENDPOINT', LaunchDarklyObservability::DEFAULT_ENDPOINT),
+        service_name: 'rails-demo-app',
+        service_version: '1.0.0'
+      )
+      config = LaunchDarkly::Config.new(plugins: [plugin])
+      LaunchDarkly::LDClient.new(ENV.fetch('LAUNCHDARKLY_SDK_KEY', ''), config)
+    end
+  end
+end

--- a/e2e/ruby/rails/demo/config/initializers/launchdarkly.rb
+++ b/e2e/ruby/rails/demo/config/initializers/launchdarkly.rb
@@ -1,16 +1,22 @@
 require 'launchdarkly-server-sdk'
 require 'launchdarkly_observability'
 
-observability_plugin = LaunchDarklyObservability::Plugin.new(
-  otlp_endpoint: ENV.fetch('OTEL_EXPORTER_OTLP_ENDPOINT', LaunchDarklyObservability::DEFAULT_ENDPOINT),
-  service_name: 'rails-demo-app',
-  service_version: '1.0.0'
-)
+# Set LD_LAZY_INIT=1 to defer LaunchDarkly client creation until first use
+# (see app/models/lazy_ld_client.rb) instead of creating it here during boot. This
+# mirrors apps that build the client lazily — e.g. from a model on first request
+# — and exercises the Railtie's boot-time auto-instrumentation install path.
+unless ENV['LD_LAZY_INIT']
+  observability_plugin = LaunchDarklyObservability::Plugin.new(
+    otlp_endpoint: ENV.fetch('OTEL_EXPORTER_OTLP_ENDPOINT', LaunchDarklyObservability::DEFAULT_ENDPOINT),
+    service_name: 'rails-demo-app',
+    service_version: '1.0.0'
+  )
 
-sdk_key = ENV.fetch('LAUNCHDARKLY_SDK_KEY') do
-  Rails.logger.warn '[LaunchDarkly] LAUNCHDARKLY_SDK_KEY not set, client will not connect'
-  ''
+  sdk_key = ENV.fetch('LAUNCHDARKLY_SDK_KEY') do
+    Rails.logger.warn '[LaunchDarkly] LAUNCHDARKLY_SDK_KEY not set, client will not connect'
+    ''
+  end
+
+  config = LaunchDarkly::Config.new(plugins: [observability_plugin])
+  Rails.configuration.ld_client = LaunchDarkly::LDClient.new(sdk_key, config)
 end
-
-config = LaunchDarkly::Config.new(plugins: [observability_plugin])
-Rails.configuration.ld_client = LaunchDarkly::LDClient.new(sdk_key, config)

--- a/e2e/ruby/rails/demo/test/integration/lazy_init_instrumentation_test.rb
+++ b/e2e/ruby/rails/demo/test/integration/lazy_init_instrumentation_test.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'open3'
+
+# Regression test for lazy LaunchDarkly client initialization.
+#
+# When the client is created lazily (after Rails has booted) rather than in a
+# config/initializer, the OTel Rails-family instrumentations used to report
+# "Instrumentation: ... failed to install" — their ActiveSupport.on_load hooks
+# had already fired by the time the plugin configured OpenTelemetry. The gem's
+# Railtie now installs auto-instrumentation during boot, independent of when the
+# client is created, so it attaches regardless.
+#
+# This must run in a SEPARATE process because instrumentation install is a
+# one-time, global side effect: the main test suite boots with the client
+# created during boot, so we boot a fresh Rails process with LD_LAZY_INIT=1 (no
+# client created at boot — see config/initializers/launchdarkly.rb) and assert
+# the Rails instrumentations are installed anyway.
+class LazyInitInstrumentationTest < ActiveSupport::TestCase
+  CHECK_SCRIPT = <<~'RUBY'
+    names = %w[Rack ActionPack ActiveRecord ActiveSupport Rails]
+    installed = names.all? do |n|
+      Object.const_get("OpenTelemetry::Instrumentation::#{n}::Instrumentation").instance.installed?
+    end
+    # Creating the client lazily (post-boot) must still work without raising.
+    LazyLdClient.instance
+    puts(installed ? 'LAZY_INSTRUMENTATION_OK' : 'LAZY_INSTRUMENTATION_FAILED')
+  RUBY
+
+  test 'rails auto-instrumentation installs at boot even when the client is created lazily' do
+    output = boot_lazy_and_run(CHECK_SCRIPT)
+
+    assert_includes output, 'LAZY_INSTRUMENTATION_OK',
+                    "Rails auto-instrumentation should install at boot in lazy mode.\n--- subprocess output ---\n#{output}"
+  end
+
+  private
+
+  def boot_lazy_and_run(script)
+    env = {
+      'LD_LAZY_INIT' => '1',
+      'LAUNCHDARKLY_SDK_KEY' => 'sdk-test-0000000000000000000000',
+      'RAILS_ENV' => 'test'
+    }
+    rails_bin = Rails.root.join('bin/rails').to_s
+    stdout, stderr, _status = Open3.capture3(env, rails_bin, 'runner', script, chdir: Rails.root.to_s)
+    "#{stdout}\n#{stderr}"
+  end
+end

--- a/e2e/ruby/rails/demo/test/integration/observability_instrumentation_test.rb
+++ b/e2e/ruby/rails/demo/test/integration/observability_instrumentation_test.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+# End-to-end coverage for the LaunchDarkly observability plugin's Rails
+# auto-instrumentation.
+#
+# Background: the plugin configures OpenTelemetry from `Plugin#register`, which
+# runs when the LaunchDarkly client is created. In this app that happens in
+# `config/initializers/launchdarkly.rb` — i.e. DURING Rails boot — so the OTel
+# Rails-family instrumentations (Rack, ActionPack, ActiveRecord, ...) install
+# correctly. A customer who instead creates the client lazily AFTER boot sees
+# "Instrumentation: OpenTelemetry::Instrumentation::ActionPack failed to install"
+# because the ActiveSupport.on_load hooks those instrumentations rely on have
+# already fired. These tests pin the working boot-time behavior so a regression
+# (or a change that breaks instrumentation install) is caught in CI.
+class ObservabilityInstrumentationTest < ActionDispatch::IntegrationTest
+  # The Rails-family instrumentations that must attach during a boot-time init.
+  # These are exactly the ones that report "failed to install" on the lazy path.
+  RAILS_INSTRUMENTATIONS = %w[Rack ActionPack ActiveRecord ActiveSupport Rails].freeze
+
+  def instrumentation_instance(name)
+    Object.const_get("OpenTelemetry::Instrumentation::#{name}::Instrumentation").instance
+  end
+
+  test 'rails auto-instrumentation installed during boot' do
+    RAILS_INSTRUMENTATIONS.each do |name|
+      assert instrumentation_instance(name).installed?,
+             "#{name} instrumentation should be installed after a boot-time plugin init " \
+             '(it reports "failed to install" when the client is created lazily after boot)'
+    end
+  end
+
+  test 'http request produces a server span via the rack instrumentation' do
+    exporter = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new
+    processor = OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor.new(exporter)
+    OpenTelemetry.tracer_provider.add_span_processor(processor)
+
+    get pages_home_url
+    assert_response :success
+
+    server_spans = exporter.finished_spans.select { |s| s.kind == :server }
+    refute_empty server_spans, 'expected an HTTP server span from the Rack/ActionPack instrumentation'
+  end
+end

--- a/e2e/ruby/rails/demo/test/test_helper.rb
+++ b/e2e/ruby/rails/demo/test/test_helper.rb
@@ -1,6 +1,14 @@
 # frozen_string_literal: true
 
 ENV['RAILS_ENV'] ||= 'test'
+
+# The observability plugin only configures OpenTelemetry (and installs the Rails
+# auto-instrumentation) when the LaunchDarkly client registers it, which requires
+# a non-empty SDK key. Set a dummy key BEFORE the app boots so the instrumentation
+# attaches during initialization. The key is invalid, so the client never connects
+# (background connection attempts fail gracefully and do not affect tests).
+ENV['LAUNCHDARKLY_SDK_KEY'] ||= 'sdk-test-0000000000000000000000'
+
 require_relative '../config/environment'
 require 'rails/test_help'
 

--- a/sdk/@launchdarkly/observability-ruby/.rubocop.yml
+++ b/sdk/@launchdarkly/observability-ruby/.rubocop.yml
@@ -24,6 +24,12 @@ Lint/DuplicateBranch:
 Naming/MethodParameterName:
     Enabled: false
 
+Naming/FileName:
+    # launchdarkly-observability.rb is intentionally hyphenated to match the gem
+    # name so Bundler.require can auto-load the gem (and its Railtie) at boot.
+    Exclude:
+        - 'lib/launchdarkly-observability.rb'
+
 Naming/PredicateMethod:
     Enabled: false
 

--- a/sdk/@launchdarkly/observability-ruby/README.md
+++ b/sdk/@launchdarkly/observability-ruby/README.md
@@ -92,6 +92,15 @@ Rails.configuration.ld_client = LaunchDarkly::LDClient.new(
 at_exit { Rails.configuration.ld_client.close }
 ```
 
+> **Lazy client initialization:** Creating the LaunchDarkly client during boot
+> (as above) is recommended. If your app instead creates the client lazily —
+> e.g. from a model on first request, after Rails has finished booting — the gem
+> still installs the Rails auto-instrumentation during boot via its Railtie, as
+> long as `LAUNCHDARKLY_SDK_KEY` is set in the environment before Rails boots. If
+> it isn't, the OpenTelemetry Rails instrumentations can't attach (their load
+> hooks have already fired) and the plugin logs a single warning explaining how
+> to fix it.
+
 Use in controllers:
 
 ```ruby
@@ -145,10 +154,12 @@ LaunchDarklyObservability::Plugin.new(
   enable_logs: true,     # default: true
   enable_metrics: true,  # default: true
 
-  # Optional: Custom instrumentation configuration
+  # Optional: Custom instrumentation configuration. Keys are instrumentation
+  # class names; values are that instrumentation's own options (only pass
+  # options the installed instrumentation version supports).
   instrumentations: {
-    'OpenTelemetry::Instrumentation::Rails' => { enable_recognize_route: true },
-    'OpenTelemetry::Instrumentation::ActiveRecord' => { db_statement: :include }
+    'OpenTelemetry::Instrumentation::Rack' => { untraced_endpoints: ['/health'] },
+    'OpenTelemetry::Instrumentation::Net::HTTP' => { untraced_hosts: ['internal.example.com'] }
   }
 )
 ```

--- a/sdk/@launchdarkly/observability-ruby/lib/launchdarkly-observability.rb
+++ b/sdk/@launchdarkly/observability-ruby/lib/launchdarkly-observability.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# Entry point matching the gem name (`launchdarkly-observability`) so that
+# Bundler.require auto-loads the gem during application boot. Without this,
+# Bundler's default `require 'launchdarkly-observability'` fails (the real entry
+# point is the underscore file) and users must require the gem manually — often
+# in an initializer, which is too late for the Rails Railtie to install
+# auto-instrumentation during boot.
+require_relative 'launchdarkly_observability'

--- a/sdk/@launchdarkly/observability-ruby/lib/launchdarkly_observability.rb
+++ b/sdk/@launchdarkly/observability-ruby/lib/launchdarkly_observability.rb
@@ -13,7 +13,13 @@ require_relative 'launchdarkly_observability/source_context'
 
 require_relative 'launchdarkly_observability/middleware'
 require_relative 'launchdarkly_observability/otel_log_bridge'
-require_relative 'launchdarkly_observability/rails'
+
+# NOTE: rails.rb is required at the *bottom* of this file, after the
+# LaunchDarklyObservability module body has been fully defined. Its Railtie
+# registers a `config.after_initialize` hook that runs synchronously when the
+# gem is required lazily after Rails has booted. That hook references module
+# constants and `class << self` methods, so they must already exist when the
+# require runs. See the require at the end of this file.
 
 module LaunchDarklyObservability
   # Default OTLP endpoint for LaunchDarkly Observability
@@ -179,3 +185,9 @@ module LaunchDarklyObservability
     end
   end
 end
+
+# Required last, on purpose: the Rails Railtie's `config.after_initialize` hook
+# can run synchronously during this require (lazy require after Rails has
+# booted), and it depends on the fully-defined LaunchDarklyObservability module
+# above. See the note next to the other require_relative calls at the top.
+require_relative 'launchdarkly_observability/rails'

--- a/sdk/@launchdarkly/observability-ruby/lib/launchdarkly_observability.rb
+++ b/sdk/@launchdarkly/observability-ruby/lib/launchdarkly_observability.rb
@@ -176,6 +176,60 @@ module LaunchDarklyObservability
       @instance = nil
     end
 
+    # @return [Boolean] whether auto-instrumentation was installed during Rails
+    #   boot by {.install_rails_instrumentation}. When true, the plugin attaches
+    #   exporters to the existing tracer provider at register time instead of
+    #   reconfiguring it.
+    def instrumentation_installed_at_boot?
+      @instrumentation_installed_at_boot == true
+    end
+
+    # Install OpenTelemetry auto-instrumentation during Rails boot.
+    #
+    # The OTel Rails-family instrumentations (ActionPack, ActiveRecord, ...) patch
+    # via ActiveSupport.on_load hooks that fire while Rails is booting. If the
+    # LaunchDarkly client is created lazily (e.g. from a model on first request),
+    # the plugin's #register runs after those hooks have fired and the
+    # instrumentations report "failed to install". The Rails Railtie calls this
+    # during boot so instrumentation attaches regardless of when the client is
+    # created. Exporters are still configured later, when the client registers
+    # the plugin.
+    #
+    # The project_id needed for the resource is resolved from the
+    # LAUNCHDARKLY_SDK_KEY environment variable, which is present at boot in the
+    # common case even when the client object is created lazily. If it cannot be
+    # resolved, instrumentation is left to #register (which warns if it then runs
+    # after boot).
+    #
+    # @param project_id [String, nil] explicit project id; falls back to ENV
+    # @param otlp_endpoint [String] OTLP endpoint (only relevant for exporters)
+    # @param options [Hash] additional OpenTelemetryConfig options
+    # @return [Boolean] whether instrumentation was installed
+    def install_rails_instrumentation(project_id: nil, otlp_endpoint: DEFAULT_ENDPOINT, **options)
+      return false if @instrumentation_installed_at_boot
+
+      project_id ||= ENV.fetch('LAUNCHDARKLY_SDK_KEY', nil)
+      return false if project_id.nil? || project_id.empty?
+
+      # If something already configured an SDK tracer provider (e.g. the client
+      # was created in a config/initializer during boot), don't reconfigure —
+      # that would replace the provider and drop its exporters.
+      return false if OpenTelemetry.tracer_provider.is_a?(OpenTelemetry::SDK::Trace::TracerProvider)
+
+      OpenTelemetryConfig.new(project_id: project_id, otlp_endpoint: otlp_endpoint, **options)
+                         .install_instrumentation_only
+      @instrumentation_installed_at_boot = true
+    rescue StandardError => e
+      warn "[LaunchDarklyObservability] Could not install Rails auto-instrumentation at boot: #{e.message}"
+      false
+    end
+
+    # Reset boot-instrumentation state. Intended for tests only.
+    # @api private
+    def reset_instrumentation_state!
+      @instrumentation_installed_at_boot = false
+    end
+
     private
 
     def otel_logger_provider_available?

--- a/sdk/@launchdarkly/observability-ruby/lib/launchdarkly_observability/hook.rb
+++ b/sdk/@launchdarkly/observability-ruby/lib/launchdarkly_observability/hook.rb
@@ -91,12 +91,23 @@ module LaunchDarklyObservability
         FEATURE_FLAG_PROVIDER_NAME => 'LaunchDarkly'
       }
 
-      context = series_context.context
-      if context
-        attrs[FEATURE_FLAG_CONTEXT_ID] = context.fully_qualified_key
-      end
+      attrs[FEATURE_FLAG_CONTEXT_ID] = context_id_for(series_context)
 
-      attrs
+      # OpenTelemetry rejects nil attribute values and logs an error for each
+      # one. Drop nils centrally so individual call sites cannot reintroduce the
+      # "invalid attribute value type NilClass" noise (e.g. an invalid context
+      # whose fully_qualified_key is nil).
+      attrs.compact
+    end
+
+    # Returns the fully-qualified context key, or nil if unavailable.
+    #
+    # An invalid context (e.g. a non-string context kind) is still a non-nil
+    # object but yields a nil fully_qualified_key. OpenTelemetry rejects nil
+    # attribute values ("invalid attribute value type NilClass"), so callers
+    # must omit the attribute entirely when this returns nil.
+    def context_id_for(series_context)
+      series_context.context&.fully_qualified_key
     end
 
     def serialize_value(value)
@@ -127,10 +138,7 @@ module LaunchDarklyObservability
         FEATURE_FLAG_PROVIDER_NAME => 'LaunchDarkly'
       }
 
-      context = series_context.context
-      if context
-        event_attributes[FEATURE_FLAG_CONTEXT_ID] = context.fully_qualified_key
-      end
+      event_attributes[FEATURE_FLAG_CONTEXT_ID] = context_id_for(series_context)
 
       if detail.variation_index
         event_attributes[FEATURE_FLAG_RESULT_VARIANT] = detail.variation_index.to_s
@@ -146,7 +154,9 @@ module LaunchDarklyObservability
         add_reason_event_details(event_attributes, reason)
       end
 
-      span.add_event(FEATURE_FLAG_EVENT_NAME, attributes: event_attributes)
+      # See build_before_attributes: drop nil values so a missing context id (or
+      # any future optional attribute) cannot emit a nil-attribute OTel error.
+      span.add_event(FEATURE_FLAG_EVENT_NAME, attributes: event_attributes.compact)
     end
 
     def add_reason_event_details(event_attributes, reason)

--- a/sdk/@launchdarkly/observability-ruby/lib/launchdarkly_observability/opentelemetry_config.rb
+++ b/sdk/@launchdarkly/observability-ruby/lib/launchdarkly_observability/opentelemetry_config.rb
@@ -70,6 +70,20 @@ module LaunchDarklyObservability
       @configured = true
     end
 
+    # Install the SDK tracer provider and auto-instrumentation WITHOUT exporters.
+    #
+    # Called from the Rails Railtie during boot so the Rails-family
+    # instrumentations (which patch via ActiveSupport.on_load hooks that fire
+    # during boot) attach even when the LaunchDarkly client — and therefore
+    # #register / #configure — is created lazily afterward. Exporters are added
+    # later by #configure_traces when the client registers the plugin.
+    def install_instrumentation_only
+      OpenTelemetry::SDK.configure do |c|
+        c.resource = create_resource
+        configure_instrumentations(c)
+      end
+    end
+
     # Flush all pending telemetry data
     def flush
       OpenTelemetry.tracer_provider&.force_flush
@@ -90,8 +104,20 @@ module LaunchDarklyObservability
 
     private
 
-    # Configure OpenTelemetry traces with OTLP exporter
+    # Configure OpenTelemetry traces with OTLP exporter.
+    #
+    # If auto-instrumentation was already installed during Rails boot (see
+    # LaunchDarklyObservability.install_rails_instrumentation), the SDK tracer
+    # provider already exists with instrumentation attached — so we only add the
+    # OTLP span exporter. Re-running OpenTelemetry::SDK.configure here would
+    # replace that provider and, in the lazy-init case, drop the Rails-family
+    # instrumentation that can only attach during boot.
     def configure_traces
+      if LaunchDarklyObservability.instrumentation_installed_at_boot?
+        OpenTelemetry.tracer_provider.add_span_processor(create_batch_span_processor)
+        return
+      end
+
       OpenTelemetry::SDK.configure do |c|
         c.resource = create_resource
         c.add_span_processor(create_batch_span_processor)
@@ -99,6 +125,23 @@ module LaunchDarklyObservability
         # Enable auto-instrumentation
         configure_instrumentations(c)
       end
+
+      warn_if_rails_instrumentation_missed
+    end
+
+    # Emit a single actionable warning when the plugin is registered after Rails
+    # has finished booting and boot-time instrumentation install did not run
+    # (e.g. LAUNCHDARKLY_SDK_KEY was not set in the environment at boot). In that
+    # case the OTel Rails-family instrumentations log a flurry of
+    # "failed to install" warnings because their load hooks have already fired.
+    def warn_if_rails_instrumentation_missed
+      return unless defined?(::Rails) && ::Rails.respond_to?(:application)
+      return unless ::Rails.application.respond_to?(:initialized?) && ::Rails.application.initialized?
+
+      warn '[LaunchDarklyObservability] The LaunchDarkly client was created after Rails finished ' \
+           'booting, so the Rails auto-instrumentation (ActionPack, ActiveRecord, ...) could not be ' \
+           'installed. To enable it, set LAUNCHDARKLY_SDK_KEY in the environment before Rails boots, ' \
+           'or create the LaunchDarkly client from a config/initializer.'
     end
 
     # Configure auto-instrumentations with sensible defaults.

--- a/sdk/@launchdarkly/observability-ruby/lib/launchdarkly_observability/opentelemetry_config.rb
+++ b/sdk/@launchdarkly/observability-ruby/lib/launchdarkly_observability/opentelemetry_config.rb
@@ -105,9 +105,16 @@ module LaunchDarklyObservability
     # User-provided instrumentation config is merged on top of defaults,
     # so users only need to specify the instrumentations they want to override.
     def configure_instrumentations(config)
+      # Only pass options that the instrumentations actually accept. Unknown
+      # options are not fatal but emit a warning on every boot ("ignored the
+      # following unknown configuration options [...]"):
+      # - `enable_recognize_route` is not an option on the Rails, Rack, or
+      #   ActionPack instrumentations; route-based span naming (http.route) is
+      #   handled automatically by the ActionPack instrumentation.
+      # - ActiveRecord has no `db_statement` option; SQL capture comes from the
+      #   database adapter instrumentations (Mysql2, PG, ...) which default to
+      #   obfuscating statements.
       defaults = {
-        'OpenTelemetry::Instrumentation::Rails' => { enable_recognize_route: true },
-        'OpenTelemetry::Instrumentation::ActiveRecord' => { db_statement: :include },
         'OpenTelemetry::Instrumentation::Net::HTTP' => { untraced_hosts: [] },
         'OpenTelemetry::Instrumentation::Rack' => { untraced_endpoints: ['/health', '/healthz', '/ready'] }
       }

--- a/sdk/@launchdarkly/observability-ruby/lib/launchdarkly_observability/rails.rb
+++ b/sdk/@launchdarkly/observability-ruby/lib/launchdarkly_observability/rails.rb
@@ -146,6 +146,20 @@ module LaunchDarklyObservability
         app.middleware.insert_before(0, LaunchDarklyObservability::Middleware)
       end
 
+      # Install OpenTelemetry auto-instrumentation during boot so the Rails-family
+      # instrumentations attach even when the LaunchDarkly client is created
+      # lazily (after boot) rather than in an initializer.
+      #
+      # Runs `after: :load_config_initializers` on purpose: if the client was
+      # created in a config/initializer during boot, it has already configured
+      # OpenTelemetry (with the user's options), so `install_rails_instrumentation`
+      # detects the existing provider and no-ops. Otherwise it installs the
+      # default instrumentation now — still during boot, before eager loading and
+      # the ActiveSupport.on_load hooks that the instrumentations depend on.
+      initializer 'launchdarkly_observability.install_instrumentation', after: :load_config_initializers do
+        LaunchDarklyObservability.install_rails_instrumentation
+      end
+
       config.after_initialize do
         if defined?(ActionController::Base)
           ActionController::Base.include(LaunchDarklyObservability::ControllerHelpers)

--- a/sdk/@launchdarkly/observability-ruby/lib/launchdarkly_observability/rails.rb
+++ b/sdk/@launchdarkly/observability-ruby/lib/launchdarkly_observability/rails.rb
@@ -127,8 +127,18 @@ module LaunchDarklyObservability
           warn "[LaunchDarklyObservability] Could not attach log bridge to Rails.logger: #{e.message}"
         end
 
+        # The availability check is inlined here rather than delegating to
+        # LaunchDarklyObservability.otel_logger_provider_available? on purpose.
+        # rails.rb is required from launchdarkly_observability.rb *before* that
+        # file's `class << self` block (which defines the module method) has run.
+        # When the gem is lazily required after Rails has booted, the
+        # `config.after_initialize` hook above executes synchronously while this
+        # file is still loading, so the module method does not exist yet and the
+        # delegation raised "undefined method `otel_logger_provider_available?'".
         def otel_logger_provider_available?
-          LaunchDarklyObservability.send(:otel_logger_provider_available?)
+          defined?(OpenTelemetry::SDK::Logs::LoggerProvider) &&
+            OpenTelemetry.respond_to?(:logger_provider) &&
+            OpenTelemetry.logger_provider.is_a?(OpenTelemetry::SDK::Logs::LoggerProvider)
         end
       end
 

--- a/sdk/@launchdarkly/observability-ruby/test/boot_instrumentation_test.rb
+++ b/sdk/@launchdarkly/observability-ruby/test/boot_instrumentation_test.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+# Tests for boot-time auto-instrumentation install
+# (LaunchDarklyObservability.install_rails_instrumentation), which lets the OTel
+# Rails-family instrumentations attach during Rails boot even when the LD client
+# is created lazily afterward. See the Railtie in rails.rb.
+class BootInstrumentationTest < Minitest::Test
+  include TestHelper
+
+  def setup
+    LaunchDarklyObservability.reset_instrumentation_state!
+    @saved_key = ENV.fetch('LAUNCHDARKLY_SDK_KEY', nil)
+  end
+
+  def teardown
+    LaunchDarklyObservability.reset_instrumentation_state!
+    if @saved_key.nil?
+      ENV.delete('LAUNCHDARKLY_SDK_KEY')
+    else
+      ENV['LAUNCHDARKLY_SDK_KEY'] = @saved_key
+    end
+  end
+
+  def test_not_installed_at_boot_by_default
+    refute LaunchDarklyObservability.instrumentation_installed_at_boot?
+  end
+
+  def test_returns_false_without_project_id_or_env_key
+    ENV.delete('LAUNCHDARKLY_SDK_KEY')
+    refute LaunchDarklyObservability.install_rails_instrumentation(project_id: nil)
+    refute LaunchDarklyObservability.instrumentation_installed_at_boot?
+  end
+
+  def test_skips_when_sdk_provider_already_configured
+    # Mirrors a boot-time init: the client already configured OpenTelemetry in a
+    # config/initializer, so the Railtie must not reconfigure (which would drop
+    # the existing exporters).
+    reset_opentelemetry
+    assert_kind_of OpenTelemetry::SDK::Trace::TracerProvider, OpenTelemetry.tracer_provider
+
+    refute LaunchDarklyObservability.install_rails_instrumentation(project_id: 'my-project'),
+           'should skip install when an SDK tracer provider is already configured'
+    refute LaunchDarklyObservability.instrumentation_installed_at_boot?
+  end
+
+  def test_reset_clears_flag
+    LaunchDarklyObservability.instance_variable_set(:@instrumentation_installed_at_boot, true)
+    assert LaunchDarklyObservability.instrumentation_installed_at_boot?
+    LaunchDarklyObservability.reset_instrumentation_state!
+    refute LaunchDarklyObservability.instrumentation_installed_at_boot?
+  end
+
+  def test_configure_does_not_replace_provider_when_installed_at_boot
+    # When boot already installed instrumentation, registering the plugin must
+    # only attach exporters to the existing provider — not reconfigure it, which
+    # would drop the boot-time Rails instrumentation in the lazy-init case.
+    reset_opentelemetry
+    provider_before = OpenTelemetry.tracer_provider
+
+    config = LaunchDarklyObservability::OpenTelemetryConfig.new(
+      project_id: 'my-project',
+      otlp_endpoint: 'http://localhost:4318',
+      enable_logs: false,
+      enable_metrics: false
+    )
+
+    LaunchDarklyObservability.stub(:instrumentation_installed_at_boot?, true) do
+      config.configure
+    end
+
+    assert_same provider_before, OpenTelemetry.tracer_provider,
+                'configure must attach to the existing provider, not replace it, when installed at boot'
+  end
+end

--- a/sdk/@launchdarkly/observability-ruby/test/hook_test.rb
+++ b/sdk/@launchdarkly/observability-ruby/test/hook_test.rb
@@ -192,6 +192,47 @@ class HookTest < Minitest::Test
     assert_equal 'org:org-1:user:user-1', span.attributes['feature_flag.context.id']
   end
 
+  # Regression: an invalid context (e.g. a non-string kind) is a non-nil
+  # object whose fully_qualified_key is nil. Setting a nil OTel attribute
+  # raised "OpenTelemetry error: invalid attribute value type NilClass for
+  # key 'feature_flag.context.id'" on every evaluation. The attribute must be
+  # omitted instead.
+  def test_invalid_context_omits_context_id_attribute
+    invalid_context = LaunchDarkly::LDContext.create({ key: 'k', kind: 123 })
+    refute invalid_context.valid?
+    assert_nil invalid_context.fully_qualified_key
+
+    series_context = LaunchDarkly::Interfaces::Hooks::EvaluationSeriesContext.new(
+      'my-flag', invalid_context, false, :variation
+    )
+
+    # Capture OpenTelemetry's error channel. Setting an attribute to nil does not
+    # raise and does not set the attribute (OTel drops it) — the only observable
+    # symptom is an "invalid attribute value type NilClass" error logged here,
+    # which is exactly the noise the customer saw on every evaluation.
+    captured = StringIO.new
+    original_logger = OpenTelemetry.logger
+    OpenTelemetry.logger = ::Logger.new(captured)
+    begin
+      data = @hook.before_evaluation(series_context, {})
+      @hook.after_evaluation(series_context, data, create_evaluation_detail)
+    ensure
+      OpenTelemetry.logger = original_logger
+    end
+
+    refute_match(/invalid .*attribute value type NilClass/, captured.string,
+                 'must not emit an OTel nil-attribute error for an invalid context')
+    refute_match(/feature_flag\.context\.id/, captured.string)
+
+    span = @exporter.finished_spans.first
+    refute_nil span
+    refute span.attributes.key?('feature_flag.context.id')
+
+    flag_event = span.events.find { |e| e.name == 'feature_flag' }
+    refute_nil flag_event
+    refute flag_event.attributes.key?('feature_flag.context.id')
+  end
+
   def test_nil_context_does_not_raise_and_still_records_event
     series_context = LaunchDarkly::Interfaces::Hooks::EvaluationSeriesContext.new(
       'my-flag', nil, false, :variation

--- a/sdk/@launchdarkly/observability-ruby/test/rails_railtie_test.rb
+++ b/sdk/@launchdarkly/observability-ruby/test/rails_railtie_test.rb
@@ -114,5 +114,30 @@ class RailsRailtieTest < Minitest::Test
            'ViewHelpers should be defined after loading rails.rb'
     assert defined?(LaunchDarklyObservability::Railtie),
            'Railtie should be defined after loading rails.rb'
+
+    # Regression: the Railtie's `attach_otel_log_bridge` runs from the synchronous
+    # `config.after_initialize` block *during* the require of launchdarkly_observability.rb,
+    # before that file's `class << self` block (which defines the module-level
+    # `otel_logger_provider_available?`) has executed. The Railtie used to delegate to
+    # that not-yet-defined method, so the bridge attach failed with:
+    #
+    #   Could not attach log bridge to Rails.logger: undefined method
+    #   `otel_logger_provider_available?' for module LaunchDarklyObservability
+    #
+    # The Railtie's check must be self-contained. Simulate the load-order state by
+    # removing the module method, then assert the Railtie check still works.
+    sc = LaunchDarklyObservability.singleton_class
+    saved = sc.instance_method(:otel_logger_provider_available?)
+    sc.send(:remove_method, :otel_logger_provider_available?)
+    begin
+      result = nil
+      assert_silent do
+        result = LaunchDarklyObservability::Railtie.send(:otel_logger_provider_available?)
+      end
+      assert_includes [true, false], result
+    ensure
+      sc.send(:define_method, :otel_logger_provider_available?, saved)
+      sc.send(:private, :otel_logger_provider_available?)
+    end
   end
 end


### PR DESCRIPTION
## Summary

Follow-up to #581 (stacked on it — base will retarget to `main` after #581 merges). This fixes the remaining issue from the customer report: when the LaunchDarkly client is created **lazily** (e.g. from a model on first request, after Rails has booted), the OpenTelemetry Rails-family instrumentations log a flood of:

```
Instrumentation: OpenTelemetry::Instrumentation::ActionPack failed to install
Instrumentation: OpenTelemetry::Instrumentation::ActiveRecord failed to install
...
```

**Root cause:** those instrumentations patch via `ActiveSupport.on_load` hooks that fire during boot. We configured OpenTelemetry from `Plugin#register` (at `LDClient.new`), so a lazily-created client runs `use_all` *after* the hooks have fired → nothing attaches.

## Fix (two parts)

1. **Auto-require at boot.** The gem shipped only `launchdarkly_observability.rb` (underscore), so `Bundler.require` (which tries the hyphenated gem name) couldn't load it — users had to `require` it manually in an initializer, too late for the Railtie. Added `lib/launchdarkly-observability.rb` so `Bundler.require` loads the gem (and its Railtie) during boot.
2. **Install instrumentation at boot.** A Railtie initializer installs auto-instrumentation during boot, decoupled from the client. `project_id` for the resource is resolved from `LAUNCHDARKLY_SDK_KEY` (present in the env at boot in the common case, even when the client object is built lazily). At `register`, the plugin then only attaches exporters to the existing provider instead of reconfiguring it.

It runs `after: :load_config_initializers` and no-ops if a provider is already configured, so **boot-time-init apps keep their own configuration untouched**. When the client registers after boot *and* boot-install didn't run (no SDK key in env at boot), the plugin logs **one actionable warning** instead of the upstream flood.

## Verification

I confirmed the mechanism empirically: installing instrumentation before `Rails.application.initialize!` attaches everything (`installed? == true`); doing it after boot is the failure. In the demo app, boot-time-init installs at `load_config_initializers` (position 105/289) — so a Railtie initializer is comfortably early enough.

## Tests

- **Gem unit tests** (`boot_instrumentation_test.rb`): boot-flag default, no-op without a project id, no-op when a provider is already configured, and that `configure` attaches to the existing provider (doesn't replace it) when installed at boot. 120 runs, 0 failures; rubocop clean.
- **e2e lazy-init variant**: the Rails demo app gains an `LD_LAZY_INIT=1` mode (client created from `LazyLdClient` on first use, not at boot). A new integration test boots a separate Rails process in that mode and asserts the Rails instrumentations install anyway. Verified it **fails** ("failed to install") when the boot-time install is removed.

## Docs

README now documents lazy-client init (and the `LAUNCHDARKLY_SDK_KEY`-at-boot requirement), and the instrumentation-options example no longer shows options the pinned versions reject.

## Known limitation

In the lazy case, resource attributes that come from `Plugin.new` options (e.g. `service_name`) aren't applied at boot since the plugin instance doesn't exist yet — `service_name` can still be set via `OTEL_SERVICE_NAME`. Boot-time-init apps are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes global OpenTelemetry setup timing and tracer-provider lifecycle in Rails; incorrect no-op or reconfigure logic could drop instrumentation or duplicate exporters, though guards and tests target the lazy-init and boot-init cases.
> 
> **Overview**
> Fixes **lazy LaunchDarkly client** setups where OpenTelemetry Rails instrumentations previously logged "failed to install" because OTel was configured only when `LDClient.new` ran, after `ActiveSupport.on_load` hooks had already fired.
> 
> **Boot-time path:** Adds `lib/launchdarkly-observability.rb` so `Bundler.require` loads the Railtie early. The Railtie runs `install_rails_instrumentation` after `load_config_initializers` (uses `LAUNCHDARKLY_SDK_KEY` from ENV, no-ops if an SDK tracer provider already exists). `OpenTelemetryConfig#install_instrumentation_only` sets up the provider and instrumentations without exporters; when the plugin registers later, `configure_traces` only **adds OTLP span processors** instead of re-running `OpenTelemetry::SDK.configure`. If registration happens after boot without a prior boot install, the gem emits **one** actionable warning instead of upstream noise.
> 
> **Verification:** Unit tests for boot flags and provider reuse; Rails demo **`LD_LAZY_INIT=1`** mode with a subprocess integration test asserting Rack/ActionPack/ActiveRecord/etc. stay installed when the client is created on first use. README documents lazy init and updates instrumentation option examples.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d3bf0aa95ae8ab6024998acc66fd3f890af763f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->