### PR TITLE
feat(flutter): propagate more native-only observability options and update readme

### DIFF
--- a/sdk/@launchdarkly/flutter/packages/observability/README.md
+++ b/sdk/@launchdarkly/flutter/packages/observability/README.md
@@ -138,6 +138,49 @@ runZonedGuarded(
 );
 ```
 
+## Native-only options
+
+The following options are forwarded to the native Android and iOS SDKs. They are **no-ops on web**, where the Dart OpenTelemetry pipeline is used instead.
+
+On `ObservabilityOptions`:
+
+- `customHeaders` (`Map<String, String>`): extra HTTP headers added to OTLP exports (e.g. for proxies or auth). Defaults to `{}`.
+- `sessionBackgroundTimeout` (`Duration`): how long the app may stay backgrounded before the session ends. Defaults to 15 minutes.
+- `logsApiLevel` (`ObservabilityLogLevel`): minimum severity of logs forwarded to the logs pipeline. Use `ObservabilityLogLevel.none` to disable logs. Defaults to `ObservabilityLogLevel.info`.
+- `traces` (`TracesOptions`): toggles `includeErrors` and `includeSpans` for automatic trace generation. Both default to `true`.
+- `metricsEnabled` (`bool`): whether metrics are exported. Defaults to `true`.
+- `productAnalytics` (`ProductAnalyticsOptions`): product-analytics telemetry. Mirrors Android's `ProductAnalytics`:
+  - `taps` (`bool`): emit a span for each user tap. Supported on Android and iOS. Defaults to `false`.
+  - `pageViews` (`bool`): emit spans for screen/page view lifecycle events. **Android-only** (no-op on iOS/web). Defaults to `true`.
+  - `trackEvents` (`bool`): emit a span when a custom event is tracked. **Android-only** (no-op on iOS/web). Defaults to `true`.
+- `instrumentation.crashReporting` (`bool`): report uncaught exceptions as errors. Defaults to `true`.
+
+On `SessionReplayOptions`:
+
+- `frameRate` (`double`): target capture rate in frames per second. Defaults to `1.0`.
+
+```dart
+LDObserve.init(
+  client,
+  observability: const ObservabilityOptions(
+    customHeaders: {'x-proxy-token': 'secret'},
+    sessionBackgroundTimeout: Duration(minutes: 5),
+    logsApiLevel: ObservabilityLogLevel.warn,
+    traces: TracesOptions(includeErrors: true, includeSpans: true),
+    metricsEnabled: true,
+    productAnalytics: ProductAnalyticsOptions(
+      taps: true,
+      pageViews: true,
+      trackEvents: true,
+    ),
+    instrumentation: InstrumentationOptions(
+      crashReporting: true,
+    ),
+  ),
+  replay: const SessionReplayOptions(isEnabled: true, frameRate: 2.0),
+);
+```
+
 ## Recording observability data
 
 Use `LDObserve` to record spans, logs, and errors from your Dart code.

--- a/sdk/@launchdarkly/flutter/packages/observability/android/build.gradle
+++ b/sdk/@launchdarkly/flutter/packages/observability/android/build.gradle
@@ -50,7 +50,7 @@ dependencies {
     // Native dependencies mirrored from the LaunchDarkly mobile SDKs (the same
     // stack used by sdk/@launchdarkly/react-native-ld-session-replay and the
     // .NET MAUI bridge in sdk/@launchdarkly/mobile-dotnet).
-    implementation "com.launchdarkly:launchdarkly-observability-android:0.46.0"
+    implementation "com.launchdarkly:launchdarkly-observability-android:0.50.0"
     implementation "com.launchdarkly:launchdarkly-android-client-sdk:5.12.0"
     // OTel Attributes appears in ObservabilityOptions parameter types; provided
     // at runtime transitively through launchdarkly-observability-android.

--- a/sdk/@launchdarkly/flutter/packages/observability/android/src/main/kotlin/com/launchdarkly/launchdarkly_flutter_observability/LDNativeApiImpl.kt
+++ b/sdk/@launchdarkly/flutter/packages/observability/android/src/main/kotlin/com/launchdarkly/launchdarkly_flutter_observability/LDNativeApiImpl.kt
@@ -13,6 +13,8 @@ import com.launchdarkly.observability.sdk.LDReplay
 import io.flutter.plugin.common.MethodChannel
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.common.Attributes
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.minutes
 
 /**
  * Pigeon [LDNativeApi] implementation. Ported (line-for-line where it makes
@@ -72,16 +74,29 @@ internal class LDNativeApiImpl(
             serviceName = observability.serviceName ?: DEFAULT_SERVICE_NAME,
             serviceVersion = observability.serviceVersion ?: DEFAULT_SERVICE_VERSION,
             resourceAttributes = resourceAttributes,
+            customHeaders = observability.customHeaders ?: emptyMap(),
+            sessionBackgroundTimeout = observability.sessionBackgroundTimeoutMillis
+                ?.milliseconds ?: 15.minutes,
             debug = false,
             otlpEndpoint = observability.otlpEndpoint ?: DEFAULT_OTLP_ENDPOINT,
             backendUrl = observability.backendUrl ?: DEFAULT_BACKEND_URL,
+            logsApiLevel = mapLogLevel(observability.logsApiLevel),
             tracesApi = ObservabilityOptions.TracesApi(
-                includeErrors = true,
-                includeSpans = true,
+                includeErrors = observability.traces?.includeErrors ?: true,
+                includeSpans = observability.traces?.includeSpans ?: true,
             ),
-            metricsApi = ObservabilityOptions.MetricsApi.enabled(),
+            metricsApi = if (observability.metricsEnabled ?: true) {
+                ObservabilityOptions.MetricsApi.enabled()
+            } else {
+                ObservabilityOptions.MetricsApi.disabled()
+            },
+            productAnalytics = ObservabilityOptions.ProductAnalytics(
+                taps = observability.productAnalytics?.taps ?: false,
+                pageViews = observability.productAnalytics?.pageViews ?: true,
+                trackEvents = observability.productAnalytics?.trackEvents ?: true,
+            ),
             instrumentations = ObservabilityOptions.Instrumentations(
-                crashReporting = false,
+                crashReporting = observability.instrumentation?.crashReporting ?: true,
                 launchTime = observability.instrumentation?.launchTimes ?: true,
                 activityLifecycle = true,
             ),
@@ -91,6 +106,7 @@ internal class LDNativeApiImpl(
         val maskTextInputs = privacy?.maskTextInputs ?: true
         val nativeReplayOptions = ReplayOptions(
             enabled = replay.isEnabled ?: true,
+            frameRate = replay.frameRate ?: 1.0,
             privacyProfile = PrivacyProfile(
                 maskTextInputs = maskTextInputs,
                 maskText = privacy?.maskLabels ?: false,
@@ -120,6 +136,17 @@ internal class LDNativeApiImpl(
         // register it so the view tree starts being captured — without this, the
         // session replay shows a black screen.
         activity?.let { LDReplay.registerActivity(it) }
+    }
+
+    /**
+     * Maps the OpenTelemetry log-severity number sent across the bridge onto the
+     * native [ObservabilityOptions.LogLevel]. Defaults to [ObservabilityOptions.LogLevel.INFO]
+     * when null or unrecognized.
+     */
+    private fun mapLogLevel(severity: Int?): ObservabilityOptions.LogLevel {
+        if (severity == null) return ObservabilityOptions.LogLevel.INFO
+        return ObservabilityOptions.LogLevel.entries.firstOrNull { it.level == severity }
+            ?: ObservabilityOptions.LogLevel.INFO
     }
 
     private fun buildResourceAttributes(

--- a/sdk/@launchdarkly/flutter/packages/observability/android/src/main/kotlin/com/launchdarkly/launchdarkly_flutter_observability/Messages.g.kt
+++ b/sdk/@launchdarkly/flutter/packages/observability/android/src/main/kotlin/com/launchdarkly/launchdarkly_flutter_observability/Messages.g.kt
@@ -81,24 +81,92 @@ class FlutterError (
 /** Generated class from Pigeon that represents data sent in messages. */
 data class LDInstrumentationOptions (
   val networkRequests: Boolean? = null,
-  val launchTimes: Boolean? = null
+  val launchTimes: Boolean? = null,
+  val crashReporting: Boolean? = null
 )
  {
   companion object {
     fun fromList(pigeonVar_list: List<Any?>): LDInstrumentationOptions {
       val networkRequests = pigeonVar_list[0] as Boolean?
       val launchTimes = pigeonVar_list[1] as Boolean?
-      return LDInstrumentationOptions(networkRequests, launchTimes)
+      val crashReporting = pigeonVar_list[2] as Boolean?
+      return LDInstrumentationOptions(networkRequests, launchTimes, crashReporting)
     }
   }
   fun toList(): List<Any?> {
     return listOf(
       networkRequests,
       launchTimes,
+      crashReporting,
     )
   }
   override fun equals(other: Any?): Boolean {
     if (other !is LDInstrumentationOptions) {
+      return false
+    }
+    if (this === other) {
+      return true
+    }
+    return MessagesPigeonUtils.deepEquals(toList(), other.toList())  }
+
+  override fun hashCode(): Int = toList().hashCode()
+}
+
+/** Generated class from Pigeon that represents data sent in messages. */
+data class LDTracesOptions (
+  val includeErrors: Boolean? = null,
+  val includeSpans: Boolean? = null
+)
+ {
+  companion object {
+    fun fromList(pigeonVar_list: List<Any?>): LDTracesOptions {
+      val includeErrors = pigeonVar_list[0] as Boolean?
+      val includeSpans = pigeonVar_list[1] as Boolean?
+      return LDTracesOptions(includeErrors, includeSpans)
+    }
+  }
+  fun toList(): List<Any?> {
+    return listOf(
+      includeErrors,
+      includeSpans,
+    )
+  }
+  override fun equals(other: Any?): Boolean {
+    if (other !is LDTracesOptions) {
+      return false
+    }
+    if (this === other) {
+      return true
+    }
+    return MessagesPigeonUtils.deepEquals(toList(), other.toList())  }
+
+  override fun hashCode(): Int = toList().hashCode()
+}
+
+/** Generated class from Pigeon that represents data sent in messages. */
+data class LDProductAnalyticsOptions (
+  val taps: Boolean? = null,
+  val pageViews: Boolean? = null,
+  val trackEvents: Boolean? = null
+)
+ {
+  companion object {
+    fun fromList(pigeonVar_list: List<Any?>): LDProductAnalyticsOptions {
+      val taps = pigeonVar_list[0] as Boolean?
+      val pageViews = pigeonVar_list[1] as Boolean?
+      val trackEvents = pigeonVar_list[2] as Boolean?
+      return LDProductAnalyticsOptions(taps, pageViews, trackEvents)
+    }
+  }
+  fun toList(): List<Any?> {
+    return listOf(
+      taps,
+      pageViews,
+      trackEvents,
+    )
+  }
+  override fun equals(other: Any?): Boolean {
+    if (other !is LDProductAnalyticsOptions) {
       return false
     }
     if (this === other) {
@@ -118,6 +186,12 @@ data class LDObservabilityOptions (
   val backendUrl: String? = null,
   val contextFriendlyName: String? = null,
   val attributes: Map<String, Any?>? = null,
+  val customHeaders: Map<String, String>? = null,
+  val sessionBackgroundTimeoutMillis: Long? = null,
+  val logsApiLevel: Long? = null,
+  val traces: LDTracesOptions? = null,
+  val metricsEnabled: Boolean? = null,
+  val productAnalytics: LDProductAnalyticsOptions? = null,
   val instrumentation: LDInstrumentationOptions? = null
 )
  {
@@ -130,8 +204,14 @@ data class LDObservabilityOptions (
       val backendUrl = pigeonVar_list[4] as String?
       val contextFriendlyName = pigeonVar_list[5] as String?
       val attributes = pigeonVar_list[6] as Map<String, Any?>?
-      val instrumentation = pigeonVar_list[7] as LDInstrumentationOptions?
-      return LDObservabilityOptions(isEnabled, serviceName, serviceVersion, otlpEndpoint, backendUrl, contextFriendlyName, attributes, instrumentation)
+      val customHeaders = pigeonVar_list[7] as Map<String, String>?
+      val sessionBackgroundTimeoutMillis = pigeonVar_list[8] as Long?
+      val logsApiLevel = pigeonVar_list[9] as Long?
+      val traces = pigeonVar_list[10] as LDTracesOptions?
+      val metricsEnabled = pigeonVar_list[11] as Boolean?
+      val productAnalytics = pigeonVar_list[12] as LDProductAnalyticsOptions?
+      val instrumentation = pigeonVar_list[13] as LDInstrumentationOptions?
+      return LDObservabilityOptions(isEnabled, serviceName, serviceVersion, otlpEndpoint, backendUrl, contextFriendlyName, attributes, customHeaders, sessionBackgroundTimeoutMillis, logsApiLevel, traces, metricsEnabled, productAnalytics, instrumentation)
     }
   }
   fun toList(): List<Any?> {
@@ -143,6 +223,12 @@ data class LDObservabilityOptions (
       backendUrl,
       contextFriendlyName,
       attributes,
+      customHeaders,
+      sessionBackgroundTimeoutMillis,
+      logsApiLevel,
+      traces,
+      metricsEnabled,
+      productAnalytics,
       instrumentation,
     )
   }
@@ -202,6 +288,7 @@ data class LDPrivacyOptions (
 data class LDSessionReplayOptions (
   val isEnabled: Boolean? = null,
   val serviceName: String? = null,
+  val frameRate: Double? = null,
   val privacy: LDPrivacyOptions? = null
 )
  {
@@ -209,14 +296,16 @@ data class LDSessionReplayOptions (
     fun fromList(pigeonVar_list: List<Any?>): LDSessionReplayOptions {
       val isEnabled = pigeonVar_list[0] as Boolean?
       val serviceName = pigeonVar_list[1] as String?
-      val privacy = pigeonVar_list[2] as LDPrivacyOptions?
-      return LDSessionReplayOptions(isEnabled, serviceName, privacy)
+      val frameRate = pigeonVar_list[2] as Double?
+      val privacy = pigeonVar_list[3] as LDPrivacyOptions?
+      return LDSessionReplayOptions(isEnabled, serviceName, frameRate, privacy)
     }
   }
   fun toList(): List<Any?> {
     return listOf(
       isEnabled,
       serviceName,
+      frameRate,
       privacy,
     )
   }
@@ -269,20 +358,30 @@ private open class MessagesPigeonCodec : StandardMessageCodec() {
       }
       130.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          LDObservabilityOptions.fromList(it)
+          LDTracesOptions.fromList(it)
         }
       }
       131.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          LDPrivacyOptions.fromList(it)
+          LDProductAnalyticsOptions.fromList(it)
         }
       }
       132.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          LDSessionReplayOptions.fromList(it)
+          LDObservabilityOptions.fromList(it)
         }
       }
       133.toByte() -> {
+        return (readValue(buffer) as? List<Any?>)?.let {
+          LDPrivacyOptions.fromList(it)
+        }
+      }
+      134.toByte() -> {
+        return (readValue(buffer) as? List<Any?>)?.let {
+          LDSessionReplayOptions.fromList(it)
+        }
+      }
+      135.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
           LDStartResult.fromList(it)
         }
@@ -296,20 +395,28 @@ private open class MessagesPigeonCodec : StandardMessageCodec() {
         stream.write(129)
         writeValue(stream, value.toList())
       }
-      is LDObservabilityOptions -> {
+      is LDTracesOptions -> {
         stream.write(130)
         writeValue(stream, value.toList())
       }
-      is LDPrivacyOptions -> {
+      is LDProductAnalyticsOptions -> {
         stream.write(131)
         writeValue(stream, value.toList())
       }
-      is LDSessionReplayOptions -> {
+      is LDObservabilityOptions -> {
         stream.write(132)
         writeValue(stream, value.toList())
       }
-      is LDStartResult -> {
+      is LDPrivacyOptions -> {
         stream.write(133)
+        writeValue(stream, value.toList())
+      }
+      is LDSessionReplayOptions -> {
+        stream.write(134)
+        writeValue(stream, value.toList())
+      }
+      is LDStartResult -> {
+        stream.write(135)
         writeValue(stream, value.toList())
       }
       else -> super.writeValue(stream, value)

--- a/sdk/@launchdarkly/flutter/packages/observability/ios/launchdarkly_flutter_observability/Sources/launchdarkly_flutter_observability/LDNativeApiImpl.swift
+++ b/sdk/@launchdarkly/flutter/packages/observability/ios/launchdarkly_flutter_observability/Sources/launchdarkly_flutter_observability/LDNativeApiImpl.swift
@@ -59,16 +59,29 @@ final class LDNativeApiImpl: NSObject, LDNativeApi {
         )
         config.startOnline = false
 
+        let crashReportingEnabled = observability.instrumentation?.crashReporting ?? true
+        // iOS currently only supports taps from ProductAnalytics; pageViews and
+        // trackEvents are Android-only and ignored here.
+        let tapsEnabled = observability.productAnalytics?.taps ?? false
         let observabilityPlugin = Observability(options: .init(
             serviceName: observability.serviceName ?? Defaults.serviceName,
             serviceVersion: observability.serviceVersion ?? Defaults.serviceVersion,
             otlpEndpoint: observability.otlpEndpoint ?? Defaults.otlpEndpoint,
             backendUrl: observability.backendUrl ?? Defaults.backendUrl,
             resourceAttributes: buildResourceAttributes(observability.attributes),
-            crashReporting: .init(source: .none),
+            customHeaders: observability.customHeaders ?? [:],
+            sessionBackgroundTimeout: observability.sessionBackgroundTimeoutMillis
+                .map { TimeInterval($0) / 1000.0 } ?? 15 * 60,
+            logsApiLevel: mapLogLevel(observability.logsApiLevel),
+            tracesApi: .init(
+                includeErrors: observability.traces?.includeErrors ?? true,
+                includeSpans: observability.traces?.includeSpans ?? true
+            ),
+            metricsApi: (observability.metricsEnabled ?? true) ? .enabled : .disabled,
+            crashReporting: .init(source: crashReportingEnabled ? .KSCrash : .none),
             instrumentation: .init(
                 urlSession: .disabled,
-                userTaps: .enabled,
+                userTaps: tapsEnabled ? .enabled : .disabled,
                 memory: .disabled,
                 memoryWarnings: .disabled,
                 cpu: .disabled,
@@ -110,8 +123,19 @@ final class LDNativeApiImpl: NSObject, LDNativeApi {
                 maskWebViews: privacy?.maskWebViews ?? false,
                 maskLabels: privacy?.maskLabels ?? false,
                 maskImages: privacy?.maskImages ?? false
-            )
+            ),
+            frameRate: replay.frameRate ?? 1.0
         )
+    }
+
+    /// Maps the OpenTelemetry log-severity number sent across the bridge onto the
+    /// native `ObservabilityOptions.LogLevel`. The `none` sentinel
+    /// (`Int.max` / `0x7fffffff`) maps to `.none`; otherwise the severity number
+    /// is the matching raw value. Defaults to `.info` when nil or unrecognized.
+    private func mapLogLevel(_ severity: Int64?) -> ObservabilityOptions.LogLevel {
+        guard let severity = severity else { return .info }
+        if severity >= Int64(Int32.max) { return .none }
+        return ObservabilityOptions.LogLevel(rawValue: Int(severity)) ?? .info
     }
 
     private func makeAnonymousContext() throws -> LDContext {

--- a/sdk/@launchdarkly/flutter/packages/observability/ios/launchdarkly_flutter_observability/Sources/launchdarkly_flutter_observability/Messages.g.swift
+++ b/sdk/@launchdarkly/flutter/packages/observability/ios/launchdarkly_flutter_observability/Sources/launchdarkly_flutter_observability/Messages.g.swift
@@ -132,25 +132,91 @@ func deepHashMessages(value: Any?, hasher: inout Hasher) {
 struct LDInstrumentationOptions: Hashable {
   var networkRequests: Bool? = nil
   var launchTimes: Bool? = nil
+  var crashReporting: Bool? = nil
 
 
   // swift-format-ignore: AlwaysUseLowerCamelCase
   static func fromList(_ pigeonVar_list: [Any?]) -> LDInstrumentationOptions? {
     let networkRequests: Bool? = nilOrValue(pigeonVar_list[0])
     let launchTimes: Bool? = nilOrValue(pigeonVar_list[1])
+    let crashReporting: Bool? = nilOrValue(pigeonVar_list[2])
 
     return LDInstrumentationOptions(
       networkRequests: networkRequests,
-      launchTimes: launchTimes
+      launchTimes: launchTimes,
+      crashReporting: crashReporting
     )
   }
   func toList() -> [Any?] {
     return [
       networkRequests,
       launchTimes,
+      crashReporting,
     ]
   }
   static func == (lhs: LDInstrumentationOptions, rhs: LDInstrumentationOptions) -> Bool {
+    return deepEqualsMessages(lhs.toList(), rhs.toList())  }
+  func hash(into hasher: inout Hasher) {
+    deepHashMessages(value: toList(), hasher: &hasher)
+  }
+}
+
+/// Generated class from Pigeon that represents data sent in messages.
+struct LDTracesOptions: Hashable {
+  var includeErrors: Bool? = nil
+  var includeSpans: Bool? = nil
+
+
+  // swift-format-ignore: AlwaysUseLowerCamelCase
+  static func fromList(_ pigeonVar_list: [Any?]) -> LDTracesOptions? {
+    let includeErrors: Bool? = nilOrValue(pigeonVar_list[0])
+    let includeSpans: Bool? = nilOrValue(pigeonVar_list[1])
+
+    return LDTracesOptions(
+      includeErrors: includeErrors,
+      includeSpans: includeSpans
+    )
+  }
+  func toList() -> [Any?] {
+    return [
+      includeErrors,
+      includeSpans,
+    ]
+  }
+  static func == (lhs: LDTracesOptions, rhs: LDTracesOptions) -> Bool {
+    return deepEqualsMessages(lhs.toList(), rhs.toList())  }
+  func hash(into hasher: inout Hasher) {
+    deepHashMessages(value: toList(), hasher: &hasher)
+  }
+}
+
+/// Generated class from Pigeon that represents data sent in messages.
+struct LDProductAnalyticsOptions: Hashable {
+  var taps: Bool? = nil
+  var pageViews: Bool? = nil
+  var trackEvents: Bool? = nil
+
+
+  // swift-format-ignore: AlwaysUseLowerCamelCase
+  static func fromList(_ pigeonVar_list: [Any?]) -> LDProductAnalyticsOptions? {
+    let taps: Bool? = nilOrValue(pigeonVar_list[0])
+    let pageViews: Bool? = nilOrValue(pigeonVar_list[1])
+    let trackEvents: Bool? = nilOrValue(pigeonVar_list[2])
+
+    return LDProductAnalyticsOptions(
+      taps: taps,
+      pageViews: pageViews,
+      trackEvents: trackEvents
+    )
+  }
+  func toList() -> [Any?] {
+    return [
+      taps,
+      pageViews,
+      trackEvents,
+    ]
+  }
+  static func == (lhs: LDProductAnalyticsOptions, rhs: LDProductAnalyticsOptions) -> Bool {
     return deepEqualsMessages(lhs.toList(), rhs.toList())  }
   func hash(into hasher: inout Hasher) {
     deepHashMessages(value: toList(), hasher: &hasher)
@@ -166,6 +232,12 @@ struct LDObservabilityOptions: Hashable {
   var backendUrl: String? = nil
   var contextFriendlyName: String? = nil
   var attributes: [String: Any?]? = nil
+  var customHeaders: [String: String]? = nil
+  var sessionBackgroundTimeoutMillis: Int64? = nil
+  var logsApiLevel: Int64? = nil
+  var traces: LDTracesOptions? = nil
+  var metricsEnabled: Bool? = nil
+  var productAnalytics: LDProductAnalyticsOptions? = nil
   var instrumentation: LDInstrumentationOptions? = nil
 
 
@@ -178,7 +250,13 @@ struct LDObservabilityOptions: Hashable {
     let backendUrl: String? = nilOrValue(pigeonVar_list[4])
     let contextFriendlyName: String? = nilOrValue(pigeonVar_list[5])
     let attributes: [String: Any?]? = nilOrValue(pigeonVar_list[6])
-    let instrumentation: LDInstrumentationOptions? = nilOrValue(pigeonVar_list[7])
+    let customHeaders: [String: String]? = nilOrValue(pigeonVar_list[7])
+    let sessionBackgroundTimeoutMillis: Int64? = nilOrValue(pigeonVar_list[8])
+    let logsApiLevel: Int64? = nilOrValue(pigeonVar_list[9])
+    let traces: LDTracesOptions? = nilOrValue(pigeonVar_list[10])
+    let metricsEnabled: Bool? = nilOrValue(pigeonVar_list[11])
+    let productAnalytics: LDProductAnalyticsOptions? = nilOrValue(pigeonVar_list[12])
+    let instrumentation: LDInstrumentationOptions? = nilOrValue(pigeonVar_list[13])
 
     return LDObservabilityOptions(
       isEnabled: isEnabled,
@@ -188,6 +266,12 @@ struct LDObservabilityOptions: Hashable {
       backendUrl: backendUrl,
       contextFriendlyName: contextFriendlyName,
       attributes: attributes,
+      customHeaders: customHeaders,
+      sessionBackgroundTimeoutMillis: sessionBackgroundTimeoutMillis,
+      logsApiLevel: logsApiLevel,
+      traces: traces,
+      metricsEnabled: metricsEnabled,
+      productAnalytics: productAnalytics,
       instrumentation: instrumentation
     )
   }
@@ -200,6 +284,12 @@ struct LDObservabilityOptions: Hashable {
       backendUrl,
       contextFriendlyName,
       attributes,
+      customHeaders,
+      sessionBackgroundTimeoutMillis,
+      logsApiLevel,
+      traces,
+      metricsEnabled,
+      productAnalytics,
       instrumentation,
     ]
   }
@@ -255,6 +345,7 @@ struct LDPrivacyOptions: Hashable {
 struct LDSessionReplayOptions: Hashable {
   var isEnabled: Bool? = nil
   var serviceName: String? = nil
+  var frameRate: Double? = nil
   var privacy: LDPrivacyOptions? = nil
 
 
@@ -262,11 +353,13 @@ struct LDSessionReplayOptions: Hashable {
   static func fromList(_ pigeonVar_list: [Any?]) -> LDSessionReplayOptions? {
     let isEnabled: Bool? = nilOrValue(pigeonVar_list[0])
     let serviceName: String? = nilOrValue(pigeonVar_list[1])
-    let privacy: LDPrivacyOptions? = nilOrValue(pigeonVar_list[2])
+    let frameRate: Double? = nilOrValue(pigeonVar_list[2])
+    let privacy: LDPrivacyOptions? = nilOrValue(pigeonVar_list[3])
 
     return LDSessionReplayOptions(
       isEnabled: isEnabled,
       serviceName: serviceName,
+      frameRate: frameRate,
       privacy: privacy
     )
   }
@@ -274,6 +367,7 @@ struct LDSessionReplayOptions: Hashable {
     return [
       isEnabled,
       serviceName,
+      frameRate,
       privacy,
     ]
   }
@@ -315,12 +409,16 @@ private class MessagesPigeonCodecReader: FlutterStandardReader {
     case 129:
       return LDInstrumentationOptions.fromList(self.readValue() as! [Any?])
     case 130:
-      return LDObservabilityOptions.fromList(self.readValue() as! [Any?])
+      return LDTracesOptions.fromList(self.readValue() as! [Any?])
     case 131:
-      return LDPrivacyOptions.fromList(self.readValue() as! [Any?])
+      return LDProductAnalyticsOptions.fromList(self.readValue() as! [Any?])
     case 132:
-      return LDSessionReplayOptions.fromList(self.readValue() as! [Any?])
+      return LDObservabilityOptions.fromList(self.readValue() as! [Any?])
     case 133:
+      return LDPrivacyOptions.fromList(self.readValue() as! [Any?])
+    case 134:
+      return LDSessionReplayOptions.fromList(self.readValue() as! [Any?])
+    case 135:
       return LDStartResult.fromList(self.readValue() as! [Any?])
     default:
       return super.readValue(ofType: type)
@@ -333,17 +431,23 @@ private class MessagesPigeonCodecWriter: FlutterStandardWriter {
     if let value = value as? LDInstrumentationOptions {
       super.writeByte(129)
       super.writeValue(value.toList())
-    } else if let value = value as? LDObservabilityOptions {
+    } else if let value = value as? LDTracesOptions {
       super.writeByte(130)
       super.writeValue(value.toList())
-    } else if let value = value as? LDPrivacyOptions {
+    } else if let value = value as? LDProductAnalyticsOptions {
       super.writeByte(131)
       super.writeValue(value.toList())
-    } else if let value = value as? LDSessionReplayOptions {
+    } else if let value = value as? LDObservabilityOptions {
       super.writeByte(132)
       super.writeValue(value.toList())
-    } else if let value = value as? LDStartResult {
+    } else if let value = value as? LDPrivacyOptions {
       super.writeByte(133)
+      super.writeValue(value.toList())
+    } else if let value = value as? LDSessionReplayOptions {
+      super.writeByte(134)
+      super.writeValue(value.toList())
+    } else if let value = value as? LDStartResult {
+      super.writeByte(135)
       super.writeValue(value.toList())
     } else {
       super.writeValue(value)

--- a/sdk/@launchdarkly/flutter/packages/observability/lib/src/options/observability_options.dart
+++ b/sdk/@launchdarkly/flutter/packages/observability/lib/src/options/observability_options.dart
@@ -3,6 +3,61 @@
 
 import '../plugin/observability_config.dart';
 
+/// Severity threshold for exported logs. Mirrors the `LogLevel` enums in the
+/// Android (`ObservabilityOptions.LogLevel`) and iOS (`ObservabilityOptions.LogLevel`)
+/// SDKs. The [severity] values match the OpenTelemetry log severity numbers so
+/// they can be forwarded across the native bridge unchanged.
+///
+/// Native-only: the web/Dart pipeline currently ignores this value.
+enum ObservabilityLogLevel {
+  trace(1),
+  trace2(2),
+  trace3(3),
+  trace4(4),
+  debug(5),
+  debug2(6),
+  debug3(7),
+  debug4(8),
+  info(9),
+  info2(10),
+  info3(11),
+  info4(12),
+  warn(13),
+  warn2(14),
+  warn3(15),
+  warn4(16),
+  error(17),
+  error2(18),
+  error3(19),
+  error4(20),
+  fatal(21),
+  fatal2(22),
+  fatal3(23),
+  fatal4(24),
+
+  /// Disables log exporting entirely.
+  none(0x7fffffff);
+
+  /// The OpenTelemetry log severity number for this level.
+  final int severity;
+
+  const ObservabilityLogLevel(this.severity);
+}
+
+/// Controls automatic trace generation. Mirrors `TracesApi` (Android) and
+/// `AppTracing` (iOS).
+///
+/// Native-only: the web/Dart pipeline currently ignores these values.
+class TracesOptions {
+  /// Whether to automatically record errors and exceptions as spans.
+  final bool includeErrors;
+
+  /// Whether to automatically record UI performance and other events as spans.
+  final bool includeSpans;
+
+  const TracesOptions({this.includeErrors = true, this.includeSpans = true});
+}
+
 /// Toggles for SDK-side instrumentation. Mirrors `InstrumentationOptions` in
 /// the .NET MAUI bridge, extended with the Dart-only [debugPrint] control.
 class InstrumentationOptions {
@@ -12,6 +67,12 @@ class InstrumentationOptions {
   /// Whether to instrument launch times (native bridge only).
   final bool launchTimes;
 
+  /// Whether to automatically report uncaught exceptions as errors. Mirrors
+  /// Android `Instrumentations.crashReporting` and iOS `CrashReporting`.
+  ///
+  /// Native-only. Defaults to `true` to match the native SDK defaults.
+  final bool crashReporting;
+
   /// Controls instrumentation of `debugPrint` in the Dart OpenTelemetry
   /// pipeline. Defaults to [DebugPrintSetting.releaseOnly].
   final DebugPrintSetting debugPrint;
@@ -19,7 +80,33 @@ class InstrumentationOptions {
   const InstrumentationOptions({
     this.networkRequests = true,
     this.launchTimes = true,
+    this.crashReporting = true,
     this.debugPrint = const DebugPrintReleaseOnly(),
+  });
+}
+
+/// Product-analytics telemetry emitted as OpenTelemetry spans. Mirrors Android
+/// `ObservabilityOptions.ProductAnalytics`, which is currently ahead of iOS.
+///
+/// Native-only. On iOS only [taps] is supported (mapped to
+/// `Instrumentation.userTaps`); [pageViews] and [trackEvents] are Android-only
+/// and are no-ops elsewhere.
+class ProductAnalyticsOptions {
+  /// Whether to emit a `click` span for each tap. Defaults to `false`.
+  final bool taps;
+
+  /// Whether to start spans for screen/page view lifecycle events. Android-only.
+  /// Defaults to `true`.
+  final bool pageViews;
+
+  /// Whether to emit a `launchdarkly.track` span when a custom event is tracked.
+  /// Android-only. Defaults to `true`.
+  final bool trackEvents;
+
+  const ProductAnalyticsOptions({
+    this.taps = false,
+    this.pageViews = true,
+    this.trackEvents = true,
   });
 }
 
@@ -45,6 +132,33 @@ class ObservabilityOptions {
   final String backendUrl;
   final String? contextFriendlyName;
   final Map<String, Object?>? attributes;
+
+  /// Extra HTTP headers added to OTLP exports (e.g. for proxies or auth).
+  /// Mirrors Android/iOS `customHeaders`. Native-only.
+  final Map<String, String> customHeaders;
+
+  /// How long the app may stay in the background before the current session is
+  /// ended. Mirrors Android/iOS `sessionBackgroundTimeout`. Native-only.
+  /// Defaults to 15 minutes.
+  final Duration sessionBackgroundTimeout;
+
+  /// Minimum severity of logs forwarded to the OpenTelemetry logs pipeline.
+  /// Use [ObservabilityLogLevel.none] to disable logs. Mirrors Android/iOS
+  /// `logsApiLevel`. Native-only. Defaults to [ObservabilityLogLevel.info].
+  final ObservabilityLogLevel logsApiLevel;
+
+  /// Controls automatic trace generation. Mirrors Android `tracesApi` and iOS
+  /// `tracesApi`. Native-only.
+  final TracesOptions traces;
+
+  /// Whether to export metrics. Mirrors Android `metricsApi` and iOS
+  /// `metricsApi`. Native-only. Defaults to `true`.
+  final bool metricsEnabled;
+
+  /// Product-analytics telemetry configuration. Mirrors Android
+  /// `ObservabilityOptions.productAnalytics`. Native-only.
+  final ProductAnalyticsOptions productAnalytics;
+
   final InstrumentationOptions instrumentation;
 
   const ObservabilityOptions({
@@ -55,6 +169,12 @@ class ObservabilityOptions {
     String? backendUrl,
     this.contextFriendlyName,
     this.attributes,
+    this.customHeaders = const {},
+    this.sessionBackgroundTimeout = const Duration(minutes: 15),
+    this.logsApiLevel = ObservabilityLogLevel.info,
+    this.traces = const TracesOptions(),
+    this.metricsEnabled = true,
+    this.productAnalytics = const ProductAnalyticsOptions(),
     this.instrumentation = const InstrumentationOptions(),
   }) : otlpEndpoint = otlpEndpoint ?? defaultOtlpEndpoint,
        backendUrl = backendUrl ?? defaultBackendUrl;

--- a/sdk/@launchdarkly/flutter/packages/observability/lib/src/options/session_replay_options.dart
+++ b/sdk/@launchdarkly/flutter/packages/observability/lib/src/options/session_replay_options.dart
@@ -9,11 +9,17 @@
 class SessionReplayOptions {
   final bool isEnabled;
   final String serviceName;
+
+  /// Target capture rate in frames per second. Mirrors Android/iOS
+  /// `frameRate`. Native-only. Defaults to `1.0`.
+  final double frameRate;
+
   final PrivacyOptions privacy;
 
   const SessionReplayOptions({
     this.isEnabled = true,
     this.serviceName = 'sessionreplay-flutter',
+    this.frameRate = 1.0,
     this.privacy = const PrivacyOptions(),
   });
 }

--- a/sdk/@launchdarkly/flutter/packages/observability/lib/src/platform/io/messages.g.dart
+++ b/sdk/@launchdarkly/flutter/packages/observability/lib/src/platform/io/messages.g.dart
@@ -34,14 +34,20 @@ bool _deepEquals(Object? a, Object? b) {
 }
 
 class LDInstrumentationOptions {
-  LDInstrumentationOptions({this.networkRequests, this.launchTimes});
+  LDInstrumentationOptions({
+    this.networkRequests,
+    this.launchTimes,
+    this.crashReporting,
+  });
 
   bool? networkRequests;
 
   bool? launchTimes;
 
+  bool? crashReporting;
+
   List<Object?> _toList() {
-    return <Object?>[networkRequests, launchTimes];
+    return <Object?>[networkRequests, launchTimes, crashReporting];
   }
 
   Object encode() {
@@ -53,6 +59,7 @@ class LDInstrumentationOptions {
     return LDInstrumentationOptions(
       networkRequests: result[0] as bool?,
       launchTimes: result[1] as bool?,
+      crashReporting: result[2] as bool?,
     );
   }
 
@@ -60,6 +67,90 @@ class LDInstrumentationOptions {
   // ignore: avoid_equals_and_hash_code_on_mutable_classes
   bool operator ==(Object other) {
     if (other is! LDInstrumentationOptions ||
+        other.runtimeType != runtimeType) {
+      return false;
+    }
+    if (identical(this, other)) {
+      return true;
+    }
+    return _deepEquals(encode(), other.encode());
+  }
+
+  @override
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
+  int get hashCode => Object.hashAll(_toList());
+}
+
+class LDTracesOptions {
+  LDTracesOptions({this.includeErrors, this.includeSpans});
+
+  bool? includeErrors;
+
+  bool? includeSpans;
+
+  List<Object?> _toList() {
+    return <Object?>[includeErrors, includeSpans];
+  }
+
+  Object encode() {
+    return _toList();
+  }
+
+  static LDTracesOptions decode(Object result) {
+    result as List<Object?>;
+    return LDTracesOptions(
+      includeErrors: result[0] as bool?,
+      includeSpans: result[1] as bool?,
+    );
+  }
+
+  @override
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
+  bool operator ==(Object other) {
+    if (other is! LDTracesOptions || other.runtimeType != runtimeType) {
+      return false;
+    }
+    if (identical(this, other)) {
+      return true;
+    }
+    return _deepEquals(encode(), other.encode());
+  }
+
+  @override
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
+  int get hashCode => Object.hashAll(_toList());
+}
+
+class LDProductAnalyticsOptions {
+  LDProductAnalyticsOptions({this.taps, this.pageViews, this.trackEvents});
+
+  bool? taps;
+
+  bool? pageViews;
+
+  bool? trackEvents;
+
+  List<Object?> _toList() {
+    return <Object?>[taps, pageViews, trackEvents];
+  }
+
+  Object encode() {
+    return _toList();
+  }
+
+  static LDProductAnalyticsOptions decode(Object result) {
+    result as List<Object?>;
+    return LDProductAnalyticsOptions(
+      taps: result[0] as bool?,
+      pageViews: result[1] as bool?,
+      trackEvents: result[2] as bool?,
+    );
+  }
+
+  @override
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
+  bool operator ==(Object other) {
+    if (other is! LDProductAnalyticsOptions ||
         other.runtimeType != runtimeType) {
       return false;
     }
@@ -83,6 +174,12 @@ class LDObservabilityOptions {
     this.backendUrl,
     this.contextFriendlyName,
     this.attributes,
+    this.customHeaders,
+    this.sessionBackgroundTimeoutMillis,
+    this.logsApiLevel,
+    this.traces,
+    this.metricsEnabled,
+    this.productAnalytics,
     this.instrumentation,
   });
 
@@ -100,6 +197,18 @@ class LDObservabilityOptions {
 
   Map<String, Object?>? attributes;
 
+  Map<String, String>? customHeaders;
+
+  int? sessionBackgroundTimeoutMillis;
+
+  int? logsApiLevel;
+
+  LDTracesOptions? traces;
+
+  bool? metricsEnabled;
+
+  LDProductAnalyticsOptions? productAnalytics;
+
   LDInstrumentationOptions? instrumentation;
 
   List<Object?> _toList() {
@@ -111,6 +220,12 @@ class LDObservabilityOptions {
       backendUrl,
       contextFriendlyName,
       attributes,
+      customHeaders,
+      sessionBackgroundTimeoutMillis,
+      logsApiLevel,
+      traces,
+      metricsEnabled,
+      productAnalytics,
       instrumentation,
     ];
   }
@@ -130,7 +245,14 @@ class LDObservabilityOptions {
       contextFriendlyName: result[5] as String?,
       attributes: (result[6] as Map<Object?, Object?>?)
           ?.cast<String, Object?>(),
-      instrumentation: result[7] as LDInstrumentationOptions?,
+      customHeaders: (result[7] as Map<Object?, Object?>?)
+          ?.cast<String, String>(),
+      sessionBackgroundTimeoutMillis: result[8] as int?,
+      logsApiLevel: result[9] as int?,
+      traces: result[10] as LDTracesOptions?,
+      metricsEnabled: result[11] as bool?,
+      productAnalytics: result[12] as LDProductAnalyticsOptions?,
+      instrumentation: result[13] as LDInstrumentationOptions?,
     );
   }
 
@@ -213,16 +335,23 @@ class LDPrivacyOptions {
 }
 
 class LDSessionReplayOptions {
-  LDSessionReplayOptions({this.isEnabled, this.serviceName, this.privacy});
+  LDSessionReplayOptions({
+    this.isEnabled,
+    this.serviceName,
+    this.frameRate,
+    this.privacy,
+  });
 
   bool? isEnabled;
 
   String? serviceName;
 
+  double? frameRate;
+
   LDPrivacyOptions? privacy;
 
   List<Object?> _toList() {
-    return <Object?>[isEnabled, serviceName, privacy];
+    return <Object?>[isEnabled, serviceName, frameRate, privacy];
   }
 
   Object encode() {
@@ -234,7 +363,8 @@ class LDSessionReplayOptions {
     return LDSessionReplayOptions(
       isEnabled: result[0] as bool?,
       serviceName: result[1] as String?,
-      privacy: result[2] as LDPrivacyOptions?,
+      frameRate: result[2] as double?,
+      privacy: result[3] as LDPrivacyOptions?,
     );
   }
 
@@ -300,17 +430,23 @@ class _PigeonCodec extends StandardMessageCodec {
     } else if (value is LDInstrumentationOptions) {
       buffer.putUint8(129);
       writeValue(buffer, value.encode());
-    } else if (value is LDObservabilityOptions) {
+    } else if (value is LDTracesOptions) {
       buffer.putUint8(130);
       writeValue(buffer, value.encode());
-    } else if (value is LDPrivacyOptions) {
+    } else if (value is LDProductAnalyticsOptions) {
       buffer.putUint8(131);
       writeValue(buffer, value.encode());
-    } else if (value is LDSessionReplayOptions) {
+    } else if (value is LDObservabilityOptions) {
       buffer.putUint8(132);
       writeValue(buffer, value.encode());
-    } else if (value is LDStartResult) {
+    } else if (value is LDPrivacyOptions) {
       buffer.putUint8(133);
+      writeValue(buffer, value.encode());
+    } else if (value is LDSessionReplayOptions) {
+      buffer.putUint8(134);
+      writeValue(buffer, value.encode());
+    } else if (value is LDStartResult) {
+      buffer.putUint8(135);
       writeValue(buffer, value.encode());
     } else {
       super.writeValue(buffer, value);
@@ -323,12 +459,16 @@ class _PigeonCodec extends StandardMessageCodec {
       case 129:
         return LDInstrumentationOptions.decode(readValue(buffer)!);
       case 130:
-        return LDObservabilityOptions.decode(readValue(buffer)!);
+        return LDTracesOptions.decode(readValue(buffer)!);
       case 131:
-        return LDPrivacyOptions.decode(readValue(buffer)!);
+        return LDProductAnalyticsOptions.decode(readValue(buffer)!);
       case 132:
-        return LDSessionReplayOptions.decode(readValue(buffer)!);
+        return LDObservabilityOptions.decode(readValue(buffer)!);
       case 133:
+        return LDPrivacyOptions.decode(readValue(buffer)!);
+      case 134:
+        return LDSessionReplayOptions.decode(readValue(buffer)!);
+      case 135:
         return LDStartResult.decode(readValue(buffer)!);
       default:
         return super.readValueOfType(type, buffer);

--- a/sdk/@launchdarkly/flutter/packages/observability/lib/src/platform/io/native_options_codec.dart
+++ b/sdk/@launchdarkly/flutter/packages/observability/lib/src/platform/io/native_options_codec.dart
@@ -15,7 +15,28 @@ extension ObservabilityOptionsWire on ObservabilityOptions {
     backendUrl: backendUrl,
     contextFriendlyName: contextFriendlyName,
     attributes: attributes,
+    customHeaders: customHeaders,
+    sessionBackgroundTimeoutMillis: sessionBackgroundTimeout.inMilliseconds,
+    logsApiLevel: logsApiLevel.severity,
+    traces: traces.toWire(),
+    metricsEnabled: metricsEnabled,
+    productAnalytics: productAnalytics.toWire(),
     instrumentation: instrumentation.toWire(),
+  );
+}
+
+extension TracesOptionsWire on TracesOptions {
+  wire.LDTracesOptions toWire() => wire.LDTracesOptions(
+    includeErrors: includeErrors,
+    includeSpans: includeSpans,
+  );
+}
+
+extension ProductAnalyticsOptionsWire on ProductAnalyticsOptions {
+  wire.LDProductAnalyticsOptions toWire() => wire.LDProductAnalyticsOptions(
+    taps: taps,
+    pageViews: pageViews,
+    trackEvents: trackEvents,
   );
 }
 
@@ -23,6 +44,7 @@ extension InstrumentationOptionsWire on InstrumentationOptions {
   wire.LDInstrumentationOptions toWire() => wire.LDInstrumentationOptions(
     networkRequests: networkRequests,
     launchTimes: launchTimes,
+    crashReporting: crashReporting,
   );
 }
 
@@ -30,6 +52,7 @@ extension SessionReplayOptionsWire on SessionReplayOptions {
   wire.LDSessionReplayOptions toWire() => wire.LDSessionReplayOptions(
     isEnabled: isEnabled,
     serviceName: serviceName,
+    frameRate: frameRate,
     privacy: privacy.toWire(),
   );
 }

--- a/sdk/@launchdarkly/flutter/packages/observability/pigeons/messages.dart
+++ b/sdk/@launchdarkly/flutter/packages/observability/pigeons/messages.dart
@@ -26,6 +26,18 @@ import 'package:pigeon/pigeon.dart';
 class LDInstrumentationOptions {
   bool? networkRequests;
   bool? launchTimes;
+  bool? crashReporting;
+}
+
+class LDTracesOptions {
+  bool? includeErrors;
+  bool? includeSpans;
+}
+
+class LDProductAnalyticsOptions {
+  bool? taps;
+  bool? pageViews;
+  bool? trackEvents;
 }
 
 class LDObservabilityOptions {
@@ -36,6 +48,12 @@ class LDObservabilityOptions {
   String? backendUrl;
   String? contextFriendlyName;
   Map<String, Object?>? attributes;
+  Map<String, String>? customHeaders;
+  int? sessionBackgroundTimeoutMillis;
+  int? logsApiLevel;
+  LDTracesOptions? traces;
+  bool? metricsEnabled;
+  LDProductAnalyticsOptions? productAnalytics;
   LDInstrumentationOptions? instrumentation;
 }
 
@@ -50,6 +68,7 @@ class LDPrivacyOptions {
 class LDSessionReplayOptions {
   bool? isEnabled;
   String? serviceName;
+  double? frameRate;
   LDPrivacyOptions? privacy;
 }
 

--- a/sdk/@launchdarkly/flutter/packages/observability/test/native_options_codec_test.dart
+++ b/sdk/@launchdarkly/flutter/packages/observability/test/native_options_codec_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:launchdarkly_flutter_observability/src/options/observability_options.dart';
+import 'package:launchdarkly_flutter_observability/src/options/session_replay_options.dart';
+import 'package:launchdarkly_flutter_observability/src/platform/io/native_options_codec.dart';
+
+void main() {
+  group('ObservabilityOptions.toWire', () {
+    test('maps native-parity defaults', () {
+      final wire = const ObservabilityOptions().toWire();
+
+      expect(wire.customHeaders, isEmpty);
+      expect(wire.sessionBackgroundTimeoutMillis, 15 * 60 * 1000);
+      expect(wire.logsApiLevel, ObservabilityLogLevel.info.severity);
+      expect(wire.traces?.includeErrors, isTrue);
+      expect(wire.traces?.includeSpans, isTrue);
+      expect(wire.metricsEnabled, isTrue);
+      expect(wire.productAnalytics?.taps, isFalse);
+      expect(wire.productAnalytics?.pageViews, isTrue);
+      expect(wire.productAnalytics?.trackEvents, isTrue);
+      expect(wire.instrumentation?.crashReporting, isTrue);
+    });
+
+    test('propagates custom values', () {
+      final wire = const ObservabilityOptions(
+        customHeaders: {'x-proxy': 'value'},
+        sessionBackgroundTimeout: Duration(minutes: 5),
+        logsApiLevel: ObservabilityLogLevel.none,
+        traces: TracesOptions(includeErrors: false, includeSpans: false),
+        metricsEnabled: false,
+        productAnalytics: ProductAnalyticsOptions(
+          taps: true,
+          pageViews: false,
+          trackEvents: false,
+        ),
+        instrumentation: InstrumentationOptions(crashReporting: false),
+      ).toWire();
+
+      expect(wire.customHeaders, {'x-proxy': 'value'});
+      expect(wire.sessionBackgroundTimeoutMillis, 5 * 60 * 1000);
+      expect(wire.logsApiLevel, 0x7fffffff);
+      expect(wire.traces?.includeErrors, isFalse);
+      expect(wire.traces?.includeSpans, isFalse);
+      expect(wire.metricsEnabled, isFalse);
+      expect(wire.productAnalytics?.taps, isTrue);
+      expect(wire.productAnalytics?.pageViews, isFalse);
+      expect(wire.productAnalytics?.trackEvents, isFalse);
+      expect(wire.instrumentation?.crashReporting, isFalse);
+    });
+
+    test('maps a non-default log level to its OTel severity', () {
+      final wire = const ObservabilityOptions(
+        logsApiLevel: ObservabilityLogLevel.warn,
+      ).toWire();
+
+      expect(wire.logsApiLevel, 13);
+    });
+  });
+
+  group('SessionReplayOptions.toWire', () {
+    test('uses default frame rate', () {
+      final wire = const SessionReplayOptions().toWire();
+
+      expect(wire.frameRate, 1.0);
+    });
+
+    test('propagates a custom frame rate', () {
+      final wire = const SessionReplayOptions(frameRate: 4.0).toWire();
+
+      expect(wire.frameRate, 4.0);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Expose cross-platform observability/session-replay options present in **both** the Android and iOS SDKs but missing from Flutter:
  - `ObservabilityOptions`: `customHeaders`, `sessionBackgroundTimeout`, `logsApiLevel`, `traces`, `metricsEnabled`
  - `InstrumentationOptions`: `crashReporting`
  - `SessionReplayOptions`: `frameRate`
- Model the tap option after Android's `ProductAnalytics` (which is ahead of iOS) via a new `ProductAnalyticsOptions` on `ObservabilityOptions` with `taps`, `pageViews`, `trackEvents`.
  - Android wires all three.
  - iOS maps `taps` -> `Instrumentation.userTaps`; `pageViews`/`trackEvents` are Android-only no-ops.
- Plumbed through the Pigeon schema (regenerated Dart/Kotlin/Swift bindings), the native options codec, and both native implementations.

## Test plan
- [x] `flutter analyze` clean
- [x] `flutter test test/native_options_codec_test.dart` passes (codec mapping for defaults + custom values)
- [x] `dart format` clean
- [ ] Manual smoke test on Android/iOS example app

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes native init defaults (crash reporting on, iOS tap spans off by default) and expands the Pigeon contract plus a native SDK version bump; web path is unchanged but mobile telemetry behavior can differ without explicit config.
> 
> **Overview**
> Adds **native-only** configuration to the Flutter observability package so Dart `ObservabilityOptions` / `SessionReplayOptions` can drive the Android and iOS SDKs (no-ops on web). New public fields include OTLP **customHeaders**, **sessionBackgroundTimeout**, **logsApiLevel** (`ObservabilityLogLevel`), **traces**, **metricsEnabled**, **productAnalytics** (taps / pageViews / trackEvents), **instrumentation.crashReporting**, and replay **frameRate**, plus supporting types (`TracesOptions`, `ProductAnalyticsOptions`).
> 
> The Pigeon schema and generated Dart/Kotlin/Swift messages are extended; **native_options_codec** maps the new fields onto the wire DTOs. **LDNativeApiImpl** on Android and iOS stops hardcoding several native settings (traces, metrics, crash reporting, tap analytics, log level, headers, session timeout, replay frame rate) and forwards bridge values instead. Android bumps **launchdarkly-observability-android** from 0.46.0 to **0.50.0**. README documents the native-only options, and **native_options_codec_test** covers default and custom wire mapping.
> 
> **Notable default shifts on native init:** crash reporting is now wired and defaults to **on** (Android previously forced off; iOS used no crash source). iOS **user taps** instrumentation now follows **productAnalytics.taps** (default **off**) instead of always enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2247526fdbcf102980b402fa33b02059d1a7ec89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->