### PR TITLE
feat(dotnet): support .NET Framework 4.6.2 (lower floor from net471)

### DIFF
--- a/sdk/@launchdarkly/observability-dotnet/src/LaunchDarkly.Observability/LaunchDarkly.Observability.csproj
+++ b/sdk/@launchdarkly/observability-dotnet/src/LaunchDarkly.Observability/LaunchDarkly.Observability.csproj
@@ -8,7 +8,7 @@
              single framework that we are testing; this allows us to test with older SDK
              versions that would error out if they saw any newer target frameworks listed
              here, even if we weren't running those. -->
-        <BuildFrameworks Condition="'$(BUILDFRAMEWORKS)' == ''">netstandard2.0;net471;net8.0</BuildFrameworks>
+        <BuildFrameworks Condition="'$(BUILDFRAMEWORKS)' == ''">netstandard2.0;net462;net8.0</BuildFrameworks>
         <TargetFrameworks>$(BUILDFRAMEWORKS)</TargetFrameworks>
         <LangVersion>7.3</LangVersion>
 


### PR DESCRIPTION
## What

Lowers the `LaunchDarkly.Observability` .NET SDK's minimum .NET Framework target from **net471 → net462**, to support customers pinned to .NET Framework 4.6.2.

```diff
- <BuildFrameworks ...>netstandard2.0;net471;net8.0</BuildFrameworks>
+ <BuildFrameworks ...>netstandard2.0;net462;net8.0</BuildFrameworks>
```

## Why this is safe

- **net462 is the lowest reachable floor.** Every dependency ships a net462 (or netstandard2.0) asset: OpenTelemetry 1.12.x core + all contrib instrumentation, `LaunchDarkly.ServerSdk` 8.10.0, `ServerSdk.Telemetry` 1.3.0, and `System.Diagnostics.DiagnosticSource` 9.0.0 (the binding constraint — OTel dropped net452/46 back in 1.2.0). net45–net461 are not reachable.
- **Existing 4.7.x / 4.8 customers are unaffected.** .NET Framework is roll-forward compatible, so a net462 assembly runs unchanged on 4.7.x/4.8. NuGet simply serves them `lib/net462/` instead of `lib/net471/` — same source, same dependencies, no API or behavioral change.

## Verification

- `netstandard2.0`, `net462`, and `net8.0` all build clean (`dotnet build`, net4x via reference assemblies).
- `dotnet pack` produces the nupkg with `lib/net462/`, `lib/netstandard2.0/`, `lib/net8.0/`.
- All **132** unit tests pass.

## Still recommended before relying on it

A real **4.6.2 runtime** smoke test (Windows). Linux can verify compile/pack/tests but not the net462 runtime, where netstandard2.0 facade / binding-redirect issues would surface. Low risk given the net471→net462 step is small and most deps ship explicit net462 assets — but worth one confirmation. CI builds the net4x target on `windows-latest` via msbuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single TFM change with no application logic edits; main residual risk is untested net462 runtime binding/facade behavior on Windows, not compile-time breakage.
> 
> **Overview**
> **LaunchDarkly.Observability** now targets **net462** instead of **net471** in `BuildFrameworks`, so the NuGet package supports apps on **.NET Framework 4.6.2** while still building **netstandard2.0** and **net8.0**.
> 
> Published assemblies move from `lib/net471/` to `lib/net462/` for the Framework slice; there are no source or dependency version changes in this diff—only the minimum Framework TFM.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit caafd195b010a09875aea1c3921fee3c105d5c16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->