### PR TITLE
feat: Android - emit Track custom events in session replay

### DIFF
--- a/e2e/android/app/src/main/java/com/example/androidobservability/ViewModel.kt
+++ b/e2e/android/app/src/main/java/com/example/androidobservability/ViewModel.kt
@@ -10,6 +10,7 @@ import com.launchdarkly.observability.interfaces.Metric
 import com.launchdarkly.observability.sdk.LDObserve
 import com.launchdarkly.sdk.ContextKind
 import com.launchdarkly.sdk.LDContext
+import com.launchdarkly.sdk.LDValue
 import com.launchdarkly.sdk.android.LDClient
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.common.Attributes
@@ -170,15 +171,29 @@ class ViewModel(application: Application) : AndroidViewModel(application) {
 
     fun trackViaLdClient() {
         // Records a `track` span automatically via the Observability afterTrack hook.
-        LDClient.get().track("track-via-ld-client")
+        LDClient.get().trackData(
+            "track-via-ld-client",
+            LDValue.buildObject()
+                .put("test-string", "android")
+                .put("test-true", true)
+                .put("test-false", false)
+                .put("test-integer", 42)
+                .put("test-double", 3.14)
+                .build()
+        )
     }
 
     fun trackViaLdObserve() {
         // Records a `track` span directly through the Observability API.
         LDObserve.track(
             "track-via-ld-observe",
-            value = 7.0,
-            attributes = Attributes.of(AttributeKey.stringKey("source"), "ld-observe")
+            data = LDValue.buildObject()
+                .put("test-string", "android")
+                .put("test-true", true)
+                .put("test-false", false)
+                .put("test-integer", 42)
+                .put("test-double", 3.14)
+                .build()
         )
     }
 

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/bridge/LDValueAttributes.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/bridge/LDValueAttributes.kt
@@ -1,0 +1,28 @@
+package com.launchdarkly.observability.bridge
+
+import com.launchdarkly.sdk.LDValue
+import com.launchdarkly.sdk.LDValueType
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.api.common.Attributes
+
+/**
+ * Converts an object payload (e.g. a `track` event's `data`) into OTel [Attributes].
+ *
+ * Only object payloads have key/value members; scalar/array payloads map to empty
+ * attributes. Mirrors the web SDK: nested arrays/objects are skipped because OTel
+ * [Attributes] is a flat scalar map.
+ */
+internal fun LDValue.toAttributes(): Attributes {
+    if (type != LDValueType.OBJECT) return Attributes.empty()
+    val builder = Attributes.builder()
+    for (key in keys()) {
+        val value = get(key)
+        when (value.type) {
+            LDValueType.BOOLEAN -> builder.put(AttributeKey.booleanKey(key), value.booleanValue())
+            LDValueType.NUMBER -> builder.put(AttributeKey.doubleKey(key), value.doubleValue())
+            LDValueType.STRING -> builder.put(AttributeKey.stringKey(key), value.stringValue())
+            else -> {} // skip null/array/object
+        }
+    }
+    return builder.build()
+}

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/client/ObservabilityService.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/client/ObservabilityService.kt
@@ -6,6 +6,7 @@ import android.view.ViewConfiguration
 import com.launchdarkly.observability.context.ObserveLogger
 import com.launchdarkly.observability.api.ObservabilityOptions
 import com.launchdarkly.observability.bridge.emitLog
+import com.launchdarkly.observability.bridge.toAttributes
 import com.launchdarkly.observability.coroutines.DispatcherProviderHolder
 import com.launchdarkly.observability.interfaces.Metric
 import com.launchdarkly.observability.interfaces.Observe
@@ -27,6 +28,7 @@ import com.launchdarkly.observability.sampling.SamplingLogProcessor
 import com.launchdarkly.observability.traces.EventSpanProcessor
 import com.launchdarkly.observability.traces.OtlpTraceExporter
 import com.launchdarkly.observability.util.requireMainThread
+import com.launchdarkly.sdk.LDValue
 import io.opentelemetry.android.OpenTelemetryRum
 import io.opentelemetry.android.OpenTelemetryRumBuilder
 import io.opentelemetry.android.config.OtelRumConfig
@@ -448,8 +450,8 @@ class ObservabilityService(
             .startSpan()
     }
 
-    override fun track(name: String, value: Double?, attributes: Attributes) {
-        track(name, value, attributes, contextKeyAttributes = null)
+    override fun track(key: String, data: LDValue?, metricValue: Double?) {
+        track(key, metricValue, data?.toAttributes() ?: Attributes.empty(), contextKeyAttributes = null)
     }
 
     /**
@@ -458,7 +460,7 @@ class ObservabilityService(
      */
     override fun track(
         name: String,
-        value: Double?,
+        metricValue: Double?,
         attributes: Attributes,
         contextKeyAttributes: Attributes?
     ) {
@@ -472,7 +474,7 @@ class ObservabilityService(
         // Fresh context keys from the hook take precedence; otherwise use the cached identify keys.
         attrBuilder.putAll(contextKeyAttributes ?: cachedContextKeyAttributes)
         attrBuilder.put(AttributeKey.stringKey("key"), name)
-        value?.let { attrBuilder.put(AttributeKey.doubleKey("value"), it) }
+        metricValue?.let { attrBuilder.put(AttributeKey.doubleKey("value"), it) }
 
         otelTracer.spanBuilder(TRACK_SPAN_NAME)
             .setAllAttributes(attrBuilder.build())

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/interfaces/Observe.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/interfaces/Observe.kt
@@ -1,5 +1,6 @@
 package com.launchdarkly.observability.interfaces
 
+import com.launchdarkly.sdk.LDValue
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.logs.Severity
 import io.opentelemetry.api.trace.Span
@@ -79,9 +80,14 @@ interface Observe : MetricsApi, LogsApi, TracesApi {
 
     /**
      * Record a custom track event as a `track` span.
-     * @param name The event key/name.
-     * @param value An optional metric value associated with the event.
-     * @param attributes Additional attributes to record with the event.
+     *
+     * Mirrors `LDClient.track(key, data, metricValue)` so the same call shape works
+     * whether the event is recorded through the LaunchDarkly client (via the
+     * `afterTrack` hook) or directly through this API.
+     * @param key The key for the event.
+     * @param data The data associated with the event, if any.
+     * @param metricValue A numeric value used by LaunchDarkly experimentation for
+     *   numeric custom metrics, if any.
      */
-    fun track(name: String, value: Double? = null, attributes: Attributes = Attributes.empty())
+    fun track(key: String, data: LDValue? = null, metricValue: Double? = null)
 }

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/plugin/ObservabilityHook.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/plugin/ObservabilityHook.kt
@@ -1,14 +1,13 @@
 package com.launchdarkly.observability.plugin
 
+import com.launchdarkly.observability.bridge.toAttributes
 import com.launchdarkly.sdk.EvaluationDetail
 import com.launchdarkly.sdk.LDValue
-import com.launchdarkly.sdk.LDValueType
 import com.launchdarkly.sdk.android.integrations.EvaluationSeriesContext
 import com.launchdarkly.sdk.android.integrations.Hook
 import com.launchdarkly.sdk.android.integrations.IdentifySeriesContext
 import com.launchdarkly.sdk.android.integrations.IdentifySeriesResult
 import com.launchdarkly.sdk.android.integrations.TrackSeriesContext
-import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.common.Attributes
 import java.util.UUID
 
@@ -36,7 +35,7 @@ interface ObservabilityHookExporting {
  * `track` spans and cache context keys.
  */
 interface TrackEmitting {
-    fun track(name: String, value: Double?, attributes: Attributes, contextKeyAttributes: Attributes?)
+    fun track(name: String, metricValue: Double?, attributes: Attributes, contextKeyAttributes: Attributes?)
     fun updateCachedContextKeys(contextKeys: Map<String, String>)
 }
 
@@ -109,25 +108,11 @@ class ObservabilityHook internal constructor() : Hook(HOOK_NAME) {
     }
 
     override fun afterTrack(seriesContext: TrackSeriesContext) {
-        val attrBuilder = Attributes.builder()
-        val data = seriesContext.data
-        if (data != null && data.type == LDValueType.OBJECT) {
-            for (key in data.keys()) {
-                val value = data.get(key)
-                when (value.type) {
-                    LDValueType.BOOLEAN -> attrBuilder.put(AttributeKey.booleanKey(key), value.booleanValue())
-                    LDValueType.NUMBER -> attrBuilder.put(AttributeKey.doubleKey(key), value.doubleValue())
-                    LDValueType.STRING -> attrBuilder.put(AttributeKey.stringKey(key), value.stringValue())
-                    else -> {} // skip null/array/object
-                }
-            }
-        }
-
         val contextKeys = buildContextKeys(seriesContext.context)
         delegate?.afterTrack(
             eventKey = seriesContext.key,
             metricValue = seriesContext.metricValue,
-            attributes = attrBuilder.build(),
+            attributes = seriesContext.data?.toAttributes() ?: Attributes.empty(),
             contextKeys = contextKeys
         )
     }

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/RRWebTypes.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/RRWebTypes.kt
@@ -59,4 +59,5 @@ enum class RRWebCustomDataTag(val wireValue: String) {
     VIEWPORT("Viewport"),
     RELOAD("Reload"),
     IDENTIFY("Identify"),
+    TRACK("Track"),
 }

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/SessionReplayService.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/SessionReplayService.kt
@@ -15,12 +15,14 @@ import com.launchdarkly.observability.replay.exporter.IdentifyItemPayload
 import com.launchdarkly.observability.replay.exporter.ImageItemPayload
 import com.launchdarkly.observability.replay.exporter.InteractionItemPayload
 import com.launchdarkly.observability.replay.exporter.SessionReplayExporter
+import com.launchdarkly.observability.replay.exporter.TrackItemPayload
 import com.launchdarkly.observability.replay.transport.BatchWorker
 import com.launchdarkly.observability.replay.transport.EventQueue
 import com.launchdarkly.observability.context.LDObserveContext
 import com.launchdarkly.observability.sdk.SessionReplayServicing
 import com.launchdarkly.observability.util.requireMainThread
 import io.opentelemetry.android.session.SessionManager
+import io.opentelemetry.api.common.Attributes
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
@@ -350,6 +352,25 @@ class SessionReplayService(
         val observeContext = buildObserveContext(contextKeys)
         instrumentationScope.launch {
             identifySession(observeContext, canonicalKeyOverride = canonicalKey)
+        }
+    }
+
+    override fun afterTrack(name: String, value: Double?, attributes: Attributes) {
+        if (!this::sessionManager.isInitialized || exporter == null) {
+            logger.warn("afterTrack called before SessionReplayService was installed; skipping.")
+            return
+        }
+        // Track events are timeline indicators on an active recording; skip when replay is disabled.
+        if (!_isEnabled.value) return
+
+        val event = TrackItemPayload.from(
+            eventKey = name,
+            metricValue = value,
+            attributes = attributes,
+            sessionId = sessionManager.getSessionId()
+        )
+        instrumentationScope.launch {
+            eventQueue.send(event)
         }
     }
 

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/SessionReplayService.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/SessionReplayService.kt
@@ -355,7 +355,7 @@ class SessionReplayService(
         }
     }
 
-    override fun afterTrack(name: String, value: Double?, attributes: Attributes) {
+    override fun afterTrack(name: String, metricValue: Double?, attributes: Attributes) {
         if (!this::sessionManager.isInitialized || exporter == null) {
             logger.warn("afterTrack called before SessionReplayService was installed; skipping.")
             return
@@ -365,7 +365,7 @@ class SessionReplayService(
 
         val event = TrackItemPayload.from(
             eventKey = name,
-            metricValue = value,
+            metricValue = metricValue,
             attributes = attributes,
             sessionId = sessionManager.getSessionId()
         )

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/exporter/RRWebEventGenerator.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/exporter/RRWebEventGenerator.kt
@@ -421,7 +421,7 @@ class RRWebEventGenerator(
         val payloadJSONString = try {
             buildJsonObject {
                 put("event", track.name)
-                track.value?.let { put("value", it) }
+                track.metricValue?.let { put("value", it) }
                 putJsonObject("data") {
                     track.attributes.forEach { (k, v) -> put(k, v) }
                 }

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/exporter/RRWebEventGenerator.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/exporter/RRWebEventGenerator.kt
@@ -414,6 +414,37 @@ class RRWebEventGenerator(
     }
 
     /**
+     * Generates a "Track" custom event. Mirrors the web SDK, where the payload is a JSON string
+     * of `{ event, value, data }` (`value` omitted when null).
+     */
+    fun generateTrackEvent(track: TrackItemPayload): Event? {
+        val payloadJSONString = try {
+            buildJsonObject {
+                put("event", track.name)
+                track.value?.let { put("value", it) }
+                putJsonObject("data") {
+                    track.attributes.forEach { (k, v) -> put(k, v) }
+                }
+            }.toString()
+        } catch (_: Exception) {
+            return null
+        }
+
+        val customData = buildJsonObject {
+            put("tag", JsonPrimitive(RRWebCustomDataTag.TRACK.wireValue))
+            // Payload must be a JSON string per rrweb Custom event contract used by web / Swift.
+            put("payload", JsonPrimitive(payloadJSONString))
+        }
+
+        return Event(
+            type = EventType.CUSTOM,
+            timestamp = track.timestamp,
+            sid = nextSid(),
+            data = EventDataUnion.CustomEventDataWrapper(customData)
+        )
+    }
+
+    /**
      * Generates a "Reload" custom event and a sequence of "wake-up" interaction events.
      * Used by [SessionReplayExporter] to re-trigger player playback after session resumption.
      */

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/exporter/SessionReplayExporter.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/exporter/SessionReplayExporter.kt
@@ -103,6 +103,15 @@ class SessionReplayExporter(
                             }
                         }
 
+                        is TrackItemPayload -> {
+                            val sessionId = payload.sessionId ?: lastCaptureSnapshot.sessionId
+                            sessionId?.let { sessionId ->
+                                eventGenerator.generateTrackEvent(payload)?.let { trackEvent ->
+                                    eventsBySession.getOrPut(sessionId) { mutableListOf() }.add(trackEvent)
+                                }
+                            }
+                        }
+
                         else -> {
                             // Noop
                         }

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/exporter/TrackItemPayload.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/exporter/TrackItemPayload.kt
@@ -1,0 +1,63 @@
+package com.launchdarkly.observability.replay.exporter
+
+import com.launchdarkly.observability.replay.transport.EventExporting
+import com.launchdarkly.observability.replay.transport.EventQueueItemPayload
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.api.common.Attributes
+
+/**
+ * Session-replay queue item for a custom analytics `track` event.
+ *
+ * Mirrors the web SDK, where `LDClient.track` -> `afterTrack` hook -> `record.track`
+ * emits an rrweb `Custom` event tagged `"Track"`. On Android the LD `afterTrack` hook
+ * routes here so the same timeline event is produced in the replay.
+ */
+data class TrackItemPayload(
+    val name: String,
+    val value: Double?,
+    val attributes: Map<String, String>,
+    override val timestamp: Long,
+    val sessionId: String?
+) : EventQueueItemPayload {
+
+    override val exporterClass: Class<out EventExporting>
+        get() = SessionReplayExporter::class.java
+
+    /**
+     * Queue cost heuristic: each attribute adds a fixed 100 cost units, plus the event itself.
+     */
+    override fun cost(): Int = (attributes.size + 1) * 100
+
+    companion object {
+        private fun flattenAttributes(source: Attributes, into: MutableMap<String, String>) {
+            source.asMap().forEach { (key: AttributeKey<*>, value: Any) ->
+                when (value) {
+                    is String -> into[key.key] = value
+                    is Boolean, is Int, is Long, is Double, is Float -> into[key.key] = value.toString()
+                    is Iterable<*> -> { /* skip arrays/collections */ }
+                    is Array<*> -> { /* skip arrays */ }
+                    is BooleanArray, is IntArray, is LongArray, is DoubleArray, is FloatArray -> { /* skip primitive arrays */ }
+                    else -> { /* skip unknown types to mirror Swift compactMapValues behavior */ }
+                }
+            }
+        }
+
+        fun from(
+            eventKey: String,
+            metricValue: Double?,
+            attributes: Attributes,
+            timestamp: Long = System.currentTimeMillis(),
+            sessionId: String?
+        ): TrackItemPayload {
+            val flat: MutableMap<String, String> = mutableMapOf()
+            flattenAttributes(attributes, flat)
+            return TrackItemPayload(
+                name = eventKey,
+                value = metricValue,
+                attributes = flat,
+                timestamp = timestamp,
+                sessionId = sessionId
+            )
+        }
+    }
+}

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/exporter/TrackItemPayload.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/exporter/TrackItemPayload.kt
@@ -14,7 +14,7 @@ import io.opentelemetry.api.common.Attributes
  */
 data class TrackItemPayload(
     val name: String,
-    val value: Double?,
+    val metricValue: Double?,
     val attributes: Map<String, String>,
     override val timestamp: Long,
     val sessionId: String?
@@ -53,7 +53,7 @@ data class TrackItemPayload(
             flattenAttributes(attributes, flat)
             return TrackItemPayload(
                 name = eventKey,
-                value = metricValue,
+                metricValue = metricValue,
                 attributes = flat,
                 timestamp = timestamp,
                 sessionId = sessionId

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/plugin/SessionReplayHook.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/plugin/SessionReplayHook.kt
@@ -1,12 +1,11 @@
 package com.launchdarkly.observability.replay.plugin
 
+import com.launchdarkly.observability.bridge.toAttributes
 import com.launchdarkly.observability.sdk.SessionReplayServicing
-import com.launchdarkly.sdk.LDValueType
 import com.launchdarkly.sdk.android.integrations.Hook
 import com.launchdarkly.sdk.android.integrations.IdentifySeriesContext
 import com.launchdarkly.sdk.android.integrations.IdentifySeriesResult
 import com.launchdarkly.sdk.android.integrations.TrackSeriesContext
-import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.common.Attributes
 
 /**
@@ -56,24 +55,10 @@ class SessionReplayHook internal constructor() : Hook(HOOK_NAME) {
     override fun afterTrack(seriesContext: TrackSeriesContext) {
         val delegate = delegate ?: return
 
-        val attrBuilder = Attributes.builder()
-        val data = seriesContext.data
-        if (data != null && data.type == LDValueType.OBJECT) {
-            for (key in data.keys()) {
-                val value = data.get(key)
-                when (value.type) {
-                    LDValueType.BOOLEAN -> attrBuilder.put(AttributeKey.booleanKey(key), value.booleanValue())
-                    LDValueType.NUMBER -> attrBuilder.put(AttributeKey.doubleKey(key), value.doubleValue())
-                    LDValueType.STRING -> attrBuilder.put(AttributeKey.stringKey(key), value.stringValue())
-                    else -> {} // skip null/array/object
-                }
-            }
-        }
-
         delegate.afterTrack(
             name = seriesContext.key,
-            value = seriesContext.metricValue,
-            attributes = attrBuilder.build()
+            metricValue = seriesContext.metricValue,
+            attributes = seriesContext.data?.toAttributes() ?: Attributes.empty()
         )
     }
 

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/plugin/SessionReplayHook.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/plugin/SessionReplayHook.kt
@@ -1,9 +1,13 @@
 package com.launchdarkly.observability.replay.plugin
 
 import com.launchdarkly.observability.sdk.SessionReplayServicing
+import com.launchdarkly.sdk.LDValueType
 import com.launchdarkly.sdk.android.integrations.Hook
 import com.launchdarkly.sdk.android.integrations.IdentifySeriesContext
 import com.launchdarkly.sdk.android.integrations.IdentifySeriesResult
+import com.launchdarkly.sdk.android.integrations.TrackSeriesContext
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.api.common.Attributes
 
 /**
  * Hook protocol adapter for the native Android SDK.
@@ -47,6 +51,30 @@ class SessionReplayHook internal constructor() : Hook(HOOK_NAME) {
             completed = result.status == IdentifySeriesResult.IdentifySeriesStatus.COMPLETED
         )
         return seriesData
+    }
+
+    override fun afterTrack(seriesContext: TrackSeriesContext) {
+        val delegate = delegate ?: return
+
+        val attrBuilder = Attributes.builder()
+        val data = seriesContext.data
+        if (data != null && data.type == LDValueType.OBJECT) {
+            for (key in data.keys()) {
+                val value = data.get(key)
+                when (value.type) {
+                    LDValueType.BOOLEAN -> attrBuilder.put(AttributeKey.booleanKey(key), value.booleanValue())
+                    LDValueType.NUMBER -> attrBuilder.put(AttributeKey.doubleKey(key), value.doubleValue())
+                    LDValueType.STRING -> attrBuilder.put(AttributeKey.stringKey(key), value.stringValue())
+                    else -> {} // skip null/array/object
+                }
+            }
+        }
+
+        delegate.afterTrack(
+            name = seriesContext.key,
+            value = seriesContext.metricValue,
+            attributes = attrBuilder.build()
+        )
     }
 
     companion object {

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/plugin/SessionReplayHookProxy.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/plugin/SessionReplayHookProxy.kt
@@ -19,9 +19,9 @@ class SessionReplayHookProxy internal constructor(
         sessionReplayService.afterIdentify(contextKeys, canonicalKey, completed)
     }
 
-    fun afterTrack(name: String, value: Double?, attributes: Map<String, String>) {
+    fun afterTrack(name: String, metricValue: Double?, attributes: Map<String, String>) {
         val builder = Attributes.builder()
         attributes.forEach { (k, v) -> builder.put(AttributeKey.stringKey(k), v) }
-        sessionReplayService.afterTrack(name, value, builder.build())
+        sessionReplayService.afterTrack(name, metricValue, builder.build())
     }
 }

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/plugin/SessionReplayHookProxy.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/plugin/SessionReplayHookProxy.kt
@@ -1,6 +1,8 @@
 package com.launchdarkly.observability.replay.plugin
 
 import com.launchdarkly.observability.sdk.SessionReplayServicing
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.api.common.Attributes
 
 /**
  * JVM adapter for cross-platform bridges (C# / MAUI, React Native, etc.).
@@ -15,5 +17,11 @@ class SessionReplayHookProxy internal constructor(
 ) {
     fun afterIdentify(contextKeys: Map<String, String>, canonicalKey: String, completed: Boolean) {
         sessionReplayService.afterIdentify(contextKeys, canonicalKey, completed)
+    }
+
+    fun afterTrack(name: String, value: Double?, attributes: Map<String, String>) {
+        val builder = Attributes.builder()
+        attributes.forEach { (k, v) -> builder.put(AttributeKey.stringKey(k), v) }
+        sessionReplayService.afterTrack(name, value, builder.build())
     }
 }

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/sdk/LDObserve.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/sdk/LDObserve.kt
@@ -14,6 +14,7 @@ import com.launchdarkly.observability.replay.ReplayOptions
 import com.launchdarkly.observability.replay.capture.ImageCaptureServicing
 import com.launchdarkly.observability.replay.plugin.SessionReplayPluginImpl
 import com.launchdarkly.observability.util.runOnMainThread
+import com.launchdarkly.sdk.LDValue
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.logs.Severity
 import io.opentelemetry.api.trace.Span
@@ -70,8 +71,8 @@ class LDObserve(private val client: Observe) : Observe {
         client.flush()
     }
 
-    override fun track(name: String, value: Double?, attributes: Attributes) {
-        client.track(name, value, attributes)
+    override fun track(key: String, data: LDValue?, metricValue: Double?) {
+        client.track(key, data, metricValue)
     }
 
     companion object : Observe {
@@ -90,7 +91,7 @@ class LDObserve(private val client: Observe) : Observe {
                 return Span.getInvalid()
             }
             override fun flush() {}
-            override fun track(name: String, value: Double?, attributes: Attributes) {}
+            override fun track(key: String, data: LDValue?, metricValue: Double?) {}
         }
 
         /**
@@ -221,7 +222,7 @@ class LDObserve(private val client: Observe) : Observe {
         override fun recordLog(message: String, severity: Severity, attributes: Attributes, spanContext: SpanContext?) = delegate.recordLog(message, severity, attributes, spanContext)
         override fun startSpan(name: String, attributes: Attributes): Span = delegate.startSpan(name, attributes)
         override fun flush() = delegate.flush()
-        override fun track(name: String, value: Double?, attributes: Attributes) = delegate.track(name, value, attributes)
+        override fun track(key: String, data: LDValue?, metricValue: Double?) = delegate.track(key, data, metricValue)
 
         /**
          * Bridge-friendly overloads that avoid exposing OpenTelemetry types

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/sdk/LDReplay.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/sdk/LDReplay.kt
@@ -123,6 +123,6 @@ internal interface SessionReplayServicing {
 
     fun flush()
     fun afterIdentify(contextKeys: Map<String, String>, canonicalKey: String, completed: Boolean)
-    fun afterTrack(name: String, value: Double?, attributes: Attributes)
+    fun afterTrack(name: String, metricValue: Double?, attributes: Attributes)
     fun registerActivity(activity: Activity) {}
 }

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/sdk/LDReplay.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/sdk/LDReplay.kt
@@ -2,6 +2,7 @@ package com.launchdarkly.observability.sdk
 
 import android.app.Activity
 import com.launchdarkly.observability.replay.plugin.SessionReplayHookProxy
+import io.opentelemetry.api.common.Attributes
 
 /**
  * LDReplay is the singleton entry point for controlling Session Replay capture.
@@ -122,5 +123,6 @@ internal interface SessionReplayServicing {
 
     fun flush()
     fun afterIdentify(contextKeys: Map<String, String>, canonicalKey: String, completed: Boolean)
+    fun afterTrack(name: String, value: Double?, attributes: Attributes)
     fun registerActivity(activity: Activity) {}
 }

--- a/sdk/@launchdarkly/observability-android/lib/src/test/kotlin/com/launchdarkly/observability/replay/exporter/RRWebEventGeneratorTest.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/test/kotlin/com/launchdarkly/observability/replay/exporter/RRWebEventGeneratorTest.kt
@@ -10,7 +10,12 @@ import com.launchdarkly.observability.replay.capture.ImageSignature
 import com.launchdarkly.observability.replay.capture.IntRect
 import com.launchdarkly.observability.replay.capture.IntSize
 import com.launchdarkly.observability.replay.capture.TileSignature
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.double
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
@@ -131,6 +136,51 @@ class RRWebEventGeneratorTest {
         val rollbackToAData = mutationData(rollbackToA)
         assertTrue(rollbackToAData.adds.isNullOrEmpty())
         assertEquals(setOf(bAddId), rollbackToAData.removes!!.map { it.id }.toSet())
+    }
+
+    @Test
+    fun `generateTrackEvent emits Track custom event with stringified payload`() {
+        val generator = RRWebEventGenerator(canvasDrawEntourage = 1, title = "test")
+        val payload = TrackItemPayload(
+            name = "purchase",
+            value = 9.99,
+            attributes = mapOf("currency" to "USD", "count" to "2"),
+            timestamp = 42L,
+            sessionId = "session",
+        )
+
+        val event = generator.generateTrackEvent(payload)!!
+
+        assertEquals(EventType.CUSTOM, event.type)
+        val custom = event.data as EventDataUnion.CustomEventDataWrapper
+        val obj = custom.data.jsonObject
+        assertEquals("Track", obj["tag"]!!.jsonPrimitive.content)
+        // payload is a stringified JSON, matching the web `addCustomEvent('Track', stringify(...))`
+        val payloadJson = Json.parseToJsonElement(obj["payload"]!!.jsonPrimitive.content).jsonObject
+        assertEquals("purchase", payloadJson["event"]!!.jsonPrimitive.content)
+        assertEquals(9.99, payloadJson["value"]!!.jsonPrimitive.double)
+        val data = payloadJson["data"]!!.jsonObject
+        assertEquals("USD", data["currency"]!!.jsonPrimitive.content)
+        assertEquals("2", data["count"]!!.jsonPrimitive.content)
+    }
+
+    @Test
+    fun `generateTrackEvent omits value when null`() {
+        val generator = RRWebEventGenerator(canvasDrawEntourage = 1, title = "test")
+        val payload = TrackItemPayload(
+            name = "login",
+            value = null,
+            attributes = emptyMap(),
+            timestamp = 1L,
+            sessionId = "session",
+        )
+
+        val event = generator.generateTrackEvent(payload)!!
+
+        val custom = event.data as EventDataUnion.CustomEventDataWrapper
+        val payloadJson = Json.parseToJsonElement(custom.data.jsonObject["payload"]!!.jsonPrimitive.content).jsonObject
+        assertEquals("login", payloadJson["event"]!!.jsonPrimitive.content)
+        assertFalse(payloadJson.containsKey("value"))
     }
 
     private fun exportFrame(

--- a/sdk/@launchdarkly/observability-android/lib/src/test/kotlin/com/launchdarkly/observability/replay/exporter/RRWebEventGeneratorTest.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/test/kotlin/com/launchdarkly/observability/replay/exporter/RRWebEventGeneratorTest.kt
@@ -143,7 +143,7 @@ class RRWebEventGeneratorTest {
         val generator = RRWebEventGenerator(canvasDrawEntourage = 1, title = "test")
         val payload = TrackItemPayload(
             name = "purchase",
-            value = 9.99,
+            metricValue = 9.99,
             attributes = mapOf("currency" to "USD", "count" to "2"),
             timestamp = 42L,
             sessionId = "session",
@@ -169,7 +169,7 @@ class RRWebEventGeneratorTest {
         val generator = RRWebEventGenerator(canvasDrawEntourage = 1, title = "test")
         val payload = TrackItemPayload(
             name = "login",
-            value = null,
+            metricValue = null,
             attributes = emptyMap(),
             timestamp = 1L,
             sessionId = "session",

--- a/sdk/@launchdarkly/observability-android/lib/src/test/kotlin/com/launchdarkly/observability/sdk/LDReplayTest.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/test/kotlin/com/launchdarkly/observability/sdk/LDReplayTest.kt
@@ -33,6 +33,13 @@ class LDReplayTest {
             identifyCalls += IdentifyCall(contextKeys, canonicalKey, completed)
         }
 
+        override fun afterTrack(
+            name: String,
+            value: Double?,
+            attributes: io.opentelemetry.api.common.Attributes
+        ) {
+        }
+
         override fun registerActivity(activity: Activity) {
             registeredActivities += activity
         }

--- a/sdk/@launchdarkly/observability-android/lib/src/test/kotlin/com/launchdarkly/observability/sdk/LDReplayTest.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/test/kotlin/com/launchdarkly/observability/sdk/LDReplayTest.kt
@@ -35,7 +35,7 @@ class LDReplayTest {
 
         override fun afterTrack(
             name: String,
-            value: Double?,
+            metricValue: Double?,
             attributes: io.opentelemetry.api.common.Attributes
         ) {
         }


### PR DESCRIPTION
## Summary

Wires the LaunchDarkly `afterTrack` hook into Android Session Replay so that calling `LDClient.track(...)` produces a **Track** custom event on the replay timeline, matching the web and iOS SDKs (iOS: launchdarkly/swift-launchdarkly-observability#209).

In the web SDK, the `afterTrack` hook emits an rrweb Custom event (`EventType.CUSTOM = 5`) with `tag: "Track"` and a stringified-JSON payload `{ data, value, event }`. This PR reproduces that on Android, reusing the existing Identify flow as the template.

### Changes (all under `sdk/@launchdarkly/observability-android`)
- `replay/RRWebTypes.kt` — new `RRWebCustomDataTag.TRACK("Track")`.
- `replay/exporter/TrackItemPayload.kt` (new) — an `EventQueueItemPayload` carrying name/value/attributes, routed to `SessionReplayExporter` (mirrors `IdentifyItemPayload`; flattens OTel `Attributes` to a `Map<String,String>`).
- `replay/exporter/RRWebEventGenerator.kt` — `generateTrackEvent(...)` builds the CUSTOM event with tag `Track` and a stringified-JSON payload (`value` omitted when null).
- `replay/exporter/SessionReplayExporter.kt` — handles `TrackItemPayload` in the export `when`, resolving the session id like identify.
- `replay/plugin/SessionReplayHook.kt` — overrides the LD `afterTrack(TrackSeriesContext)` hook (same attribute extraction as `ObservabilityHook`).
- `replay/SessionReplayService.kt` + `sdk/LDReplay.kt` (`SessionReplayServicing`) — `afterTrack(name, value, attributes)` builds a `TrackItemPayload` and enqueues it (skipped when replay is disabled / not yet installed).
- `replay/plugin/SessionReplayHookProxy.kt` — `afterTrack` forwarding for RN / MAUI bridges (parity with identify).

### Payload contract
Custom event `type = 5`, `data.tag = "Track"`, `data.payload` = string containing JSON `{ "event": "<key>", "value": <number?>, "data": { ...string attrs } }`.

### Notes
- Track is added to the **Session Replay** hook (`SessionReplayHook`), separate from the existing Observability `track` span path — same separation used on iOS.
- Track events are only enqueued while replay is enabled, matching the web "only while recording" semantics.

## Test plan
- [x] Added `generateTrackEvent emits Track custom event with stringified payload` and `generateTrackEvent omits value when null` to `RRWebEventGeneratorTest.kt`.
- [x] Updated `LDReplayTest` fake to implement the new interface method.
- [x] `./gradlew :lib:testDebugUnitTest` passes (full suite).

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Public `LDObserve.track` signature change breaks callers using the old `value`/`attributes` parameters; replay and span emission paths are new integration surface but gated by replay enabled and existing analytics flags.
> 
> **Overview**
> **Session replay** now surfaces LaunchDarkly `track` calls on the replay timeline: `SessionReplayHook` handles `afterTrack`, `SessionReplayService` enqueues `TrackItemPayload`, and the exporter emits rrweb **Custom** events with tag `"Track"` and a stringified `{ event, value?, data }` payload (aligned with web/iOS). Events are only sent while replay is enabled; `SessionReplayHookProxy` exposes `afterTrack` for RN/MAUI bridges.
> 
> **Observability track API** is reshaped to match `LDClient.track(key, data, metricValue)`: `LDObserve.track` / `Observe.track` take `LDValue?` data instead of OTel `Attributes`, with a shared `LDValue.toAttributes()` helper used by both `ObservabilityHook` and replay hooks. The e2e app uses `trackData` with a sample object payload.
> 
> Unit tests cover `generateTrackEvent` payload shape (including omitting `value` when null).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce0cccad594ed530403eb6daccde155d73c6557d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->