### PR TITLE
fix: record session replay Click events in capture phase

### DIFF
--- a/sdk/highlight-run/src/client/listeners/click-listener/click-listener.ts
+++ b/sdk/highlight-run/src/client/listeners/click-listener/click-listener.ts
@@ -11,6 +11,11 @@ export const ClickListener = (
 			callback(targetSelector, event)
 		}
 	}
-	window.addEventListener('click', recordClick)
-	return () => window.removeEventListener('click', recordClick)
+	// Listen in the capture phase so clicks are still recorded when app code
+	// calls event.stopPropagation() before the event bubbles back up to window.
+	// This mirrors how rrweb records mouse interactions (capture phase) and
+	// prevents the custom `Click` event from being silently dropped.
+	const options: AddEventListenerOptions = { capture: true }
+	window.addEventListener('click', recordClick, options)
+	return () => window.removeEventListener('click', recordClick, options)
 }


### PR DESCRIPTION
## Summary

The custom `Click` session replay event (`addCustomEvent('Click', ...)`, surfaced in the SR timeline/events list) is produced by `ClickListener`, which attached to `window` in the **bubble phase**:

```js
window.addEventListener('click', recordClick)
```

Because this is a bubble-phase listener on `window` (the last node in the bubble chain), any handler anywhere in the page that calls `event.stopPropagation()` prevents the click from ever reaching it. This is extremely common in real apps (React component libraries, dropdowns, modals, menus, custom widgets). Navigations/unloads triggered by a click can also tear down the page before the bubble reaches `window`.

The result: `Click` events end up **super rare**, even though rrweb's native mouse interactions — which listen on `document` with `{ capture: true }` — still show the click visually during playback.

This PR switches `ClickListener` to the **capture phase**, matching rrweb's behavior, so Click events are recorded reliably regardless of `stopPropagation`.

## Changes

- `sdk/highlight-run/src/client/listeners/click-listener/click-listener.ts`: add `{ capture: true }` to the click listener (and matching `removeEventListener`).

## Test plan

- [ ] Verify Click custom events are emitted on a page where click handlers call `stopPropagation()` (e.g. MUI/Radix menus, dropdowns).
- [ ] Confirm Click events still record on normal buttons/links.
- [ ] Confirm listener teardown still removes the listener (options passed to `removeEventListener`).

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small event-listener option change in session replay instrumentation; no auth, data, or API surface changes.
> 
> **Overview**
> Session replay **`Click`** custom events were often missing when page code called **`stopPropagation()`** on clicks, because **`ClickListener`** only listened on **`window`** in the bubble phase.
> 
> **`ClickListener`** now registers the click handler with **`{ capture: true }`** (and passes the same options to **`removeEventListener`**), aligning with rrweb’s capture-phase mouse recording so **`Click`** timeline events are emitted reliably.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d56e695086729a572ef1ce1a29450aa5d5ec68b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->