### PR TITLE
fix(highlight.run): stub blob: workers in tests to fix flaky CI teardown

### DIFF
--- a/sdk/highlight-run/src/__tests__/index.test.tsx
+++ b/sdk/highlight-run/src/__tests__/index.test.tsx
@@ -148,10 +148,7 @@ describe('LD integration', () => {
 	})
 
 	it('should handle register', () => {
-		const worker = (globalThis.Worker as unknown as typeof Worker).prototype
-		worker.postMessage = vi.fn(
-			(_message: unknown, _options?: unknown) => null,
-		)
+		const worker = vi.spyOn(highlight._worker, 'postMessage')
 
 		const client = {
 			track: vi.fn(),
@@ -163,7 +160,7 @@ describe('LD integration', () => {
 		expect(client.addHook).not.toHaveBeenCalled()
 		expect(client.identify).not.toHaveBeenCalled()
 		expect(client.track).not.toHaveBeenCalled()
-		expect(worker.postMessage).not.toHaveBeenCalled()
+		expect(worker).not.toHaveBeenCalled()
 
 		highlight.identify('123', {})
 		highlight.addProperties('test', {})
@@ -187,7 +184,7 @@ describe('LD integration', () => {
 		)
 		// should call buffered calls
 		expect(client.track).toHaveBeenCalled()
-		expect(worker.postMessage).toHaveBeenCalled()
+		expect(worker).toHaveBeenCalled()
 	})
 })
 

--- a/sdk/highlight-run/src/__tests__/setup.ts
+++ b/sdk/highlight-run/src/__tests__/setup.ts
@@ -2,6 +2,37 @@ import { vi } from 'vitest'
 import '@vitest/web-worker'
 import 'vitest-canvas-mock'
 
+// `@vitest/web-worker` polyfills Web Workers by loading the worker's source
+// module, but it cannot resolve workers constructed from a `blob:` URL. Such
+// workers are produced both by Vite's `?worker&inline` output and by bundled
+// dependencies (e.g. rrweb's CanvasManager, which spins up a canvas worker the
+// moment `Highlight.initialize` calls `record`). Loading a blob URL throws
+// `Cannot find package 'blob:...'`; because these workers are created eagerly,
+// the rejection is logged via `console.error` and races vitest's environment
+// teardown, surfacing as
+// `EnvironmentTeardownError: Closing rpc while "onUserConsoleLog" was pending`
+// and failing the whole suite. The unit tests don't exercise these workers, so
+// swap blob-backed workers for an inert stub while leaving module-URL workers
+// (used by highlight-client-worker.test.ts) on the real implementation.
+const RealWorker = globalThis.Worker
+
+class InertWorker extends EventTarget implements Worker {
+	onmessage: ((this: Worker, ev: MessageEvent) => unknown) | null = null
+	onmessageerror: ((this: Worker, ev: MessageEvent) => unknown) | null = null
+	onerror: ((this: AbstractWorker, ev: ErrorEvent) => unknown) | null = null
+	postMessage(): void {}
+	terminate(): void {}
+}
+
+globalThis.Worker = new Proxy(RealWorker, {
+	construct(target, args) {
+		if (String(args[0] ?? '').startsWith('blob:')) {
+			return new InertWorker()
+		}
+		return Reflect.construct(target, args)
+	},
+}) as typeof Worker
+
 vi.mock('import.meta.env.REACT_APP_PUBLIC_GRAPH_URI', () => ({
 	default: 'localhost:8082',
 }))

--- a/sdk/highlight-run/src/client/workers/highlight-client-worker.test.ts
+++ b/sdk/highlight-run/src/client/workers/highlight-client-worker.test.ts
@@ -129,9 +129,17 @@ describe('highlight-client-worker', () => {
 	beforeEach(async () => {
 		vi.resetModules()
 
-		const { default: HighlightClientWorker } =
-			await import('./highlight-client-worker?worker&inline')
-		worker = new HighlightClientWorker() as unknown as TestWorker
+		// Construct the worker from its source module rather than the
+		// `?worker&inline` build output: the inline build compiles to a `blob:`
+		// URL that @vitest/web-worker cannot resolve (and which the test setup
+		// replaces with an inert stub). Loading the source via
+		// `new URL(..., import.meta.url)` produces a module-URL worker that
+		// @vitest/web-worker runs for real, so this suite exercises the actual
+		// worker code.
+		worker = new Worker(
+			new URL('./highlight-client-worker.ts', import.meta.url),
+			{ type: 'module' },
+		) as unknown as TestWorker
 	})
 
 	afterEach(() => {


### PR DESCRIPTION
## Summary

The `highlight.run` test suite intermittently failed in CI with:

```
Error: Cannot find package 'blob:nodedata:...'
EnvironmentTeardownError: [vitest-worker]: Closing rpc while "onUserConsoleLog" was pending
```

**Root cause:** `Highlight.initialize()` triggers rrweb's `CanvasManager`, which constructs its canvas worker from an inline `blob:` URL. `@vitest/web-worker` polyfills workers by importing their *source module* and cannot resolve a `blob:` URL back to a module, so the eagerly-created worker load rejects, is logged via `console.error`, and races vitest's environment teardown. This only reproduces on a cold cache (i.e. CI), which is why it was flaky. The errors pointing at `console-listener.tsx` / `highlight-client-worker` were red herrings — stack traces confirmed every `blob:` worker originated from `rrweb.js → CanvasManager → record → Highlight.initialize`.

## Changes

- **`src/__tests__/setup.ts`**: Wrap `globalThis.Worker` in a `Proxy` that replaces any `blob:`-backed worker (which `@vitest/web-worker` fundamentally can't load) with an inert no-op worker. Module-URL workers keep using the real implementation. The unit tests don't exercise these workers, so an inert stub is sufficient.
- **`src/client/workers/highlight-client-worker.test.ts`**: Construct the real worker from its source module via `new URL('./highlight-client-worker.ts', import.meta.url)` instead of `?worker&inline` (which compiles to a blob and would be stubbed), so this suite keeps exercising the real worker code.
- **`src/__tests__/index.test.tsx`**: Spy on `highlight._worker.postMessage` directly rather than patching the global `Worker` prototype.

## Test plan

- [x] Ran the full `highlight.run` suite 3x with a cold cache (`rm -rf node_modules/.vite node_modules/.vitest` before each), matching CI conditions:
  - All runs: `exit=0`, `blobErrors=0`, `teardownErrors=0`, **437/437 tests passing across 22 files**
- [x] Confirmed the dedicated `highlight-client-worker.test.ts` still runs the real worker (not the inert stub)

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to Vitest setup and assertions; no production SDK behavior is modified.
> 
> **Overview**
> Fixes flaky CI failures in the `highlight.run` Vitest suite caused by `@vitest/web-worker` failing to load workers built from `blob:` URLs (e.g. rrweb canvas workers during `Highlight.initialize`), which triggered `EnvironmentTeardownError` on cold-cache runs.
> 
> **`setup.ts`** proxies `globalThis.Worker` so `blob:` URLs get an inert no-op worker; module-URL workers still use the real polyfill.
> 
> **`highlight-client-worker.test.ts`** instantiates the worker via `new URL('./highlight-client-worker.ts', import.meta.url)` instead of `?worker&inline` (blob), so that suite still runs the real worker logic.
> 
> **`index.test.tsx`** spies on `highlight._worker.postMessage` instead of patching the global `Worker` prototype.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b999820390cdc6b8d07c52bd196fd42bef7baf5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->