### PR TITLE
fix(ci): only run pkg.go.dev sync for Go module releases

### DIFF
--- a/.github/workflows/force-go-release.yml
+++ b/.github/workflows/force-go-release.yml
@@ -4,14 +4,18 @@ on:
     release:
         types:
             - created
-        tags:
-            - 'v[0-9]+.[0-9]+.[0-9]+'
-            - '**/v[0-9]+.[0-9]+.[0-9]+'
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
     build:
         name: Renew documentation
+        # The `release: created` event fires for every package release in this
+        # monorepo (a `tags` filter is only honored for `push` events, not
+        # `release`). Only the Go module is published to pkg.go.dev, and
+        # release-please tags it as `go/vX.Y.Z`. Other tags (e.g.
+        # `highlight.run-10.3.4`) break the go-proxy-pull action's version
+        # parsing, so restrict this job to Go module releases.
+        if: startsWith(github.event.release.tag_name, 'go/v')
         runs-on: ubuntu-22.04-8core-32gb
         steps:
             - name: Pull new module version


### PR DESCRIPTION
## Summary

The **Force pkg.go.dev release sync** workflow (`force-go-release.yml`) has been failing on *every* release with:

```
/entrypoint.sh: line 17: arithmetic syntax error
```

**Root cause:** The `release: created` trigger fires for every package release in this monorepo. The `tags:` filter under `on.release` is silently ignored (tag filters are only honored for `push` events), so releases like `highlight.run-10.3.4`, `session-replay-1.1.13`, etc. all invoke `andrewslotin/go-proxy-pull-action`. That action's `entrypoint.sh` derives the major version from the tag and runs `$((10#${MAJOR_VERSION}))`; for a non-Go tag, `MAJOR_VERSION` becomes a non-numeric string (e.g. `highlight`), which crashes the arithmetic expansion.

Only the `go` package is published to pkg.go.dev. Per `release-please-config.json` (`release-type: go`, `tag-separator: "/"`, `include-v-in-tag: true`), it is tagged as `go/vX.Y.Z`, which the action parses correctly.

## Changes

- Gate the job with `if: startsWith(github.event.release.tag_name, 'go/v')` so it only runs for Go module releases (non-Go releases are skipped instead of failing).
- Remove the inert `tags:` filter under `on.release` (it never had any effect).

## Test plan

- [x] Confirmed via `gh run list --workflow=force-go-release.yml` that all recent runs failed on non-Go tags (`highlight.run-*`, `session-replay-*`, `observability-*`, etc.)
- [x] Verified the Go release tag format is `go/vX.Y.Z` (release-please config) — the only case the action handles correctly
- [ ] Next Go release (`go/v*`) runs the sync; non-Go releases skip the job

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow gating with no application, auth, or data-path changes.
> 
> **Overview**
> Fixes **Force pkg.go.dev release sync** so it no longer runs (and fails) on every monorepo release.
> 
> The workflow still triggers on `release: created`, but the job is now gated with **`if: startsWith(github.event.release.tag_name, 'go/v')`**, so only Go module releases (`go/vX.Y.Z`) run `go-proxy-pull-action`. Non-Go tags (e.g. `highlight.run-*`) are skipped instead of hitting the action’s broken version parsing.
> 
> The **`tags:`** entries under **`on.release`** were removed because GitHub ignores tag filters for release events (they only apply to **`push`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1491bb5a109407e250fbea66c2ca7b53b1be2db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->