### PR TITLE
feat: Flutter track API (LDObserve.track + afterTrack hook)

### DIFF
--- a/analytics-taxonomy.md
+++ b/analytics-taxonomy.md
@@ -113,18 +113,23 @@ Click (web) or tap (mobile) on an interactive element. One event for all element
 
 ### 4.2 `track` — generic custom & domain events
 
-`track` is the escape hatch for **arbitrary, domain-specific events** that fall outside the standard UI events in this section. It is emitted through the track channel (`track`, event key `$ld:telemetry:track:<event>`); the supplied payload travels under `event.*`.
+`track` is the escape hatch for **arbitrary, domain-specific events** that fall outside the standard UI events in this section. It is emitted through the track channel (`track`, event key `$ld:telemetry:track:<key>`); the supplied payload travels under `event.*`.
 
 **Rules for `track` events**
-- Use a clear `event.name`; per Segment's spec the canonical names are Title-Case `Object Action` (e.g. `Product Added`).
+- Every `track` event **MUST** carry a **root `key`** attribute that encodes the meaning of the product event. This is the developer-supplied `key` from the `track(key:, data:)` API (e.g. `track(key: "checkout-started", data: …)`); it is the canonical identifier downstream tools group on. Use `snake_case` (or `kebab-case`) `object_action`, base-form verb — never past tense (e.g. `checkout-started`, `product-added`).
+- The root `key` lives alongside `span_name`/`context`, **not** under `event.*`. The `data` passed to the API is what populates the `event.*` payload.
+- Optionally include a human-readable `event.name` (per Segment's spec, Title-Case `Object Action`, e.g. `Checkout Started`) as a display label inside the payload; it is supplied as part of `data`, while `key` is the machine identifier.
 - Domain properties go under `event.*`. **Do not** repurpose `context` (reserved) and **do not** add these names to the §3 standard catalog.
 - The samples below follow the **Segment E-Commerce Spec** (<https://segment.com/docs/connections/spec/ecommerce/v2/>) so they map cleanly into downstream tools.
 
 #### `Product Viewed`
 
-| `event.*` field | Type | Description |
+Root `key`: `product-viewed`.
+
+| field | Type | Description |
 | --- | --- | --- |
-| `event.name` | string | `Product Viewed`. |
+| `key` (root) | string | `product-viewed`. Developer-supplied event key encoding the meaning. |
+| `event.name` | string | `Product Viewed`. Optional Segment display label. |
 | `event.product_id` | string | Product/SKU id. |
 | `event.name_label` | string | Product name. |
 | `event.category` | string | Product category. |
@@ -134,6 +139,7 @@ Click (web) or tap (mobile) on an interactive element. One event for all element
 ```json
 {
   "span_name": "track",
+  "key": "product-viewed",
   "event": {
     "name": "Product Viewed",
     "product_id": "SKU-1234",
@@ -148,9 +154,12 @@ Click (web) or tap (mobile) on an interactive element. One event for all element
 
 #### `Product Added`
 
-| `event.*` field | Type | Description |
+Root `key`: `product-added`.
+
+| field | Type | Description |
 | --- | --- | --- |
-| `event.name` | string | `Product Added`. |
+| `key` (root) | string | `product-added`. Developer-supplied event key encoding the meaning. |
+| `event.name` | string | `Product Added`. Optional Segment display label. |
 | `event.product_id` | string | Product/SKU id. |
 | `event.quantity` | int | Quantity added. |
 | `event.price` | number | Unit price. |
@@ -159,6 +168,7 @@ Click (web) or tap (mobile) on an interactive element. One event for all element
 ```json
 {
   "span_name": "track",
+  "key": "product-added",
   "event": {
     "name": "Product Added",
     "product_id": "SKU-1234",
@@ -173,9 +183,12 @@ Click (web) or tap (mobile) on an interactive element. One event for all element
 
 #### `Checkout Started`
 
-| `event.*` field | Type | Description |
+Root `key`: `checkout-started`.
+
+| field | Type | Description |
 | --- | --- | --- |
-| `event.name` | string | `Checkout Started`. |
+| `key` (root) | string | `checkout-started`. Developer-supplied event key encoding the meaning. |
+| `event.name` | string | `Checkout Started`. Optional Segment display label. |
 | `event.order_id` | string | Order/transaction id. |
 | `event.value` | number | Total value of the checkout. |
 | `event.currency` | string | ISO-4217 currency. |
@@ -184,6 +197,7 @@ Click (web) or tap (mobile) on an interactive element. One event for all element
 ```json
 {
   "span_name": "track",
+  "key": "checkout-started",
   "event": {
     "name": "Checkout Started",
     "order_id": "ord_5521",
@@ -200,9 +214,12 @@ Click (web) or tap (mobile) on an interactive element. One event for all element
 
 #### `Order Completed`
 
-| `event.*` field | Type | Description |
+Root `key`: `order-completed`.
+
+| field | Type | Description |
 | --- | --- | --- |
-| `event.name` | string | `Order Completed`. |
+| `key` (root) | string | `order-completed`. Developer-supplied event key encoding the meaning. |
+| `event.name` | string | `Order Completed`. Optional Segment display label. |
 | `event.order_id` | string | Order/transaction id. |
 | `event.total` | number | Order total incl. shipping/tax. |
 | `event.revenue` | number | Revenue (excl. shipping/tax). |
@@ -212,6 +229,7 @@ Click (web) or tap (mobile) on an interactive element. One event for all element
 ```json
 {
   "span_name": "track",
+  "key": "order-completed",
   "event": {
     "name": "Order Completed",
     "order_id": "ord_5521",
@@ -595,6 +613,7 @@ Same `event.*` payload as `click`, plus scroll offset. Emit at most ~once/60ms.
 - Event names and `event.*` enum values are a **closed, governed set**; additions require a PR here.
 - No past-tense (`-ed`) event names.
 - Domain/business events use `track` (§4.2) and must not be promoted into the §3 standard catalog.
+- Every `track` event must carry a **root `key`** (the developer-supplied `track(key:, data:)` key) encoding its meaning; the same `object_action`, base-form-verb, no-past-tense rule applies to `key`.
 
 ---
 

--- a/analytics-taxonomy.md
+++ b/analytics-taxonomy.md
@@ -24,8 +24,8 @@ Everything else around it (`context.*`, `url.*`, `user_agent.*`, `viewport.*`, `
 ## 2. Naming convention
 
 - **Event names:** `snake_case`, pattern **`object_action`** with the action in **base (present) form — never past tense / no `-ed`**.
-  - ✅ `page_view`, `screen_view`, `app_open`, `app_foreground`, `notification_open`, `form_submit`
-  - ❌ `page_viewed`, `app_opened`, `notification_opened`, `screenView`
+  - ✅ `page_view`, `screen_view`, `app_launch`, `app_foreground`, `notification_open`, `form_submit`
+  - ❌ `page_viewed`, `app_launched`, `notification_opened`, `screenView`
   - Single-token verbs are allowed where unambiguous: `click`, `scroll`, `identify`, `error`.
 - **`event.*` field names:** keep the existing in-product spelling. Today's interaction fields are camelCase inside `event` (`relativeX`, `classname`, `xpath`); new fields follow the same nested-`event` style.
 - **Enum values:** lowercase strings.
@@ -41,18 +41,16 @@ Everything else around it (`context.*`, `url.*`, `user_agent.*`, `viewport.*`, `
 | 3 | `page_view` | span | web | `Navigate` / `Reload` / `Referrer` | A web page / route was viewed. |
 | 4 | `screen_view` | span | ios, android | `Navigate` | A screen / view controller / activity was viewed. |
 | 5 | `identify` | log | web, ios, android | `Identify` | Identity resolution. **Existing — do not change** (see §4.5). |
-| 6 | `app_open` | span | ios, android | `Open` | App launched or resumed into use. |
-| 7 | `app_foreground` | span | ios, android | `Foreground` | App entered foreground. |
+| 6 | `app_launch` | span | ios, android | `Launch` | App process launched — `relaunch`, or first launch after `install` / `update` (see `event.launch_type`). |
+| 7 | `app_foreground` | span | ios, android | `Foreground` | App entered foreground (includes resume / hot start from background). |
 | 8 | `app_background` | span | ios, android | `Background` | App entered background. |
-| 9 | `app_install` | span | ios, android | - | First launch after install. |
-| 10 | `app_update` | span | ios, android | - | First launch after version change. |
-| 11 | `error` | span | web, ios, android | - | A user-facing error/message was displayed. |
-| 12 | `permission_prompt` | span | web, ios, android | - | An OS/app permission prompt was shown. |
-| 13 | `permission_response` | span | web, ios, android | - | User responded to a permission prompt. |
-| 14 | `notification_open` | span | ios, android | - | User opened a push/local notification. |
-| 15 | `deep_link_open` | span | ios, android | - | App opened via deep/universal link. |
-| 16 | `form_submit` | span | web, ios, android | - | A form was submitted. |
-| 17 | `scroll` | span | web | - | Scroll interaction. |
+| 9 | `error` | span | web, ios, android | - | A user-facing error/message was displayed. |
+| 10 | `permission_prompt` | span | web, ios, android | - | An OS/app permission prompt was shown. |
+| 11 | `permission_response` | span | web, ios, android | - | User responded to a permission prompt. |
+| 12 | `notification_open` | span | ios, android | - | User opened a push/local notification. |
+| 13 | `deep_link_open` | span | ios, android | - | App opened via deep/universal link. |
+| 14 | `form_submit` | span | web, ios, android | - | A form was submitted. |
+| 15 | `scroll` | span | web | - | Scroll interaction. |
 
 > **Breadcrumb column.** "Breadcrumbs" are the **Events** shown on the Session Replay timeline (and, going forward, also surfaced in RUM). On web they are emitted as **rrweb custom events** by the recording SDK (`sdk/highlight-run`); the complete set emitted today is `Navigate`, `Reload`, `Referrer`, `Click`, `Focus`, `Viewport`, `Performance`, `Jank`, `Page Unload`, `TabHidden`, `Stop`, `Track`, `Segment`, `Identify`. The column above lists the corresponding breadcrumb name(s) for each taxonomy event; `-` means there is no equivalent breadcrumb today. Breadcrumbs without a taxonomy event (`Viewport`, `Performance`, `Jank`, `Page Unload`, `Stop`) are internal diagnostics and are intentionally not part of this taxonomy.
 
@@ -325,24 +323,52 @@ Identity resolution is **already implemented** and is out of scope for changes h
 
 ---
 
-### 4.6 `app_open` (mobile)
+### 4.6 `app_launch` (mobile)
 
-App launched, or resumed from background into active use.
+App process launched. `event.launch_type` captures the **product milestone** of the launch — `relaunch` (a normal launch), `install` (first launch after a fresh install), or `update` (first launch after a version change). A return to the foreground from background (a "resume" / hot start) is **not** a launch and is captured by `app_foreground` (§4.7).
+
+The **startup-performance** dimension (cold vs warm) is orthogonal to the product milestone and is recorded as an **OTel span event** on the launch span, not as a `launch_type` value. Emit an `app.start` span event carrying `start.type` (`cold` | `warm`); finer-grained startup phases may be added as additional span events. This aligns with Sentry (`app.start.cold` / `app.start.warm`) and the OpenTelemetry `AppStart` convention.
 
 | `event.*` field | Type | Required | Description |
 | --- | --- | --- | --- |
-| `event.from_background` | bool | ✅ | `true` if resumed from background, `false` for cold start. |
+| `event.launch_type` | enum | ✅ | `relaunch` (normal launch), `install` (first launch after fresh install), `update` (first launch after version change). |
+| `event.version` | string | ✅ | Current app version. |
+| `event.build` | string | ⛔ | Current build number. |
+| `event.previous_version` | string | ✅ for `update` | Version before the update. |
 | `event.referring_source` | string | ⛔ | `push`, `deep_link`, `icon`, `widget`, … |
 | `event.url` | string | ⛔ | Launch URL, if opened via a link. |
 
+> The `start.type` (cold/warm) lives on the `app.start` **span event**, not under `event.*`. `event.launch_type` answers "what kind of launch is this from the product's view"; the span event answers "how did the process start".
+
 ```json
 {
-  "span_name": "app_open",
+  "span_name": "app_launch",
   "event": {
-    "from_background": false,
+    "launch_type": "relaunch",
+    "version": "4.12.0",
+    "build": "4120",
     "referring_source": "icon"
   },
+  "span_events": [
+    { "name": "app.start", "attributes": { "start.type": "cold" } }
+  ],
   "context": { "contextKeys": { "accountId": "64dd…" } }
+}
+```
+
+```json
+{
+  "span_name": "app_launch",
+  "event": {
+    "launch_type": "update",
+    "version": "4.12.0",
+    "build": "4120",
+    "previous_version": "4.11.2"
+  },
+  "span_events": [
+    { "name": "app.start", "attributes": { "start.type": "warm" } }
+  ],
+  "context": { "contextKeys": { "accountId": "64dd…", "userId": "65b8…" } }
 }
 ```
 
@@ -350,7 +376,7 @@ App launched, or resumed from background into active use.
 
 ### 4.7 `app_foreground` / `app_background` (mobile)
 
-App moved to foreground / background. **OTel mapping:** lifecycle state in `event.lifecycle_state` (Android: `foreground`/`background`; iOS: `active`/`inactive`/`foreground`/`background`).
+App moved to foreground / background. Returning to the foreground from background (a "resume" / hot start) is represented here, not as a launch (`app_launch` is for actual process launches; see §4.6). **OTel mapping:** lifecycle state in `event.lifecycle_state` (Android: `foreground`/`background`; iOS: `active`/`inactive`/`foreground`/`background`).
 
 | `event.*` field | Type | Required | Description |
 | --- | --- | --- | --- |
@@ -378,42 +404,7 @@ App moved to foreground / background. **OTel mapping:** lifecycle state in `even
 
 ---
 
-### 4.8 `app_install` / `app_update` (mobile)
-
-First launch after a fresh install / after a version change.
-
-| `event.*` field | Type | Required | Description |
-| --- | --- | --- | --- |
-| `event.version` | string | ✅ | Current app version. |
-| `event.build` | string | ⛔ | Current build number. |
-| `event.previous_version` | string | ✅ for `app_update` | Version before the update. |
-
-```json
-{
-  "span_name": "app_install",
-  "event": {
-    "version": "4.12.0",
-    "build": "4120"
-  },
-  "context": { "contextKeys": { "accountId": "64dd…", "userId": "65b8…" } }
-}
-```
-
-```json
-{
-  "span_name": "app_update",
-  "event": {
-    "version": "4.12.0",
-    "build": "4120",
-    "previous_version": "4.11.2"
-  },
-  "context": { "contextKeys": { "accountId": "64dd…", "userId": "65b8…" } }
-}
-```
-
----
-
-### 4.9 `error` (user-facing)
+### 4.8 `error` (user-facing)
 
 A user-facing error/message was displayed (validation error, toast, error page). This is about **what the user saw**, not an uncaught exception (those go through crash/error reporting). **OTel mapping:** `event.error_type`↔`exception.type`, `event.message`↔`exception.message`.
 
@@ -441,7 +432,7 @@ A user-facing error/message was displayed (validation error, toast, error page).
 
 ---
 
-### 4.10 `permission_prompt` / `permission_response`
+### 4.9 `permission_prompt` / `permission_response`
 
 A permission prompt was shown / responded to.
 
@@ -476,7 +467,7 @@ A permission prompt was shown / responded to.
 
 ---
 
-### 4.11 `notification_open` (mobile)
+### 4.10 `notification_open` (mobile)
 
 User opened/tapped a push or local notification. **Standard:** GA4 `notification_open`.
 
@@ -502,7 +493,7 @@ User opened/tapped a push or local notification. **Standard:** GA4 `notification
 
 ---
 
-### 4.12 `deep_link_open` (mobile)
+### 4.11 `deep_link_open` (mobile)
 
 App opened/routed via a deep link / universal link / app link. **Standard:** Segment `Deep Link Opened`.
 
@@ -526,7 +517,7 @@ App opened/routed via a deep link / universal link / app link. **Standard:** Seg
 
 ---
 
-### 4.13 `form_submit`
+### 4.12 `form_submit`
 
 A form submission attempt. Domain-agnostic: identify the form, not its business meaning. **Standard:** GA4 `form_submit`.
 
@@ -554,7 +545,7 @@ A form submission attempt. Domain-agnostic: identify the form, not its business 
 
 ---
 
-### 4.14 `scroll` (existing)
+### 4.13 `scroll` (existing)
 
 Same `event.*` payload as `click`, plus scroll offset. Emit at most ~once/60ms.
 
@@ -592,7 +583,7 @@ Same `event.*` payload as `click`, plus scroll offset. Emit at most ~once/60ms.
 | Forms | `form_submit` | `form_submit` |
 | Notifications | — | `notification_open` |
 | Deep links | (link target) | `deep_link_open` |
-| App lifecycle | — | `app_open` / `app_foreground` / `app_background` / `app_install` / `app_update` |
+| App lifecycle | — | `app_launch` (`launch_type`: relaunch/install/update; cold/warm via `app.start` span event) / `app_foreground` / `app_background` |
 | Identity | `identify` (existing) | `identify` (existing) |
 | Domain events | `track` | `track` |
 
@@ -622,9 +613,10 @@ Same `event.*` payload as `click`, plus scroll offset. Emit at most ~once/60ms.
 
 | Standard | What we borrow | Reference |
 | --- | --- | --- |
-| **Google Analytics 4 / Firebase** | Present-tense names; `page_view` (web) vs `screen_view` (mobile); `app_open`, `notification_open`, `form_submit`. | <https://support.google.com/analytics/answer/9234069> |
+| **Google Analytics 4 / Firebase** | Present-tense names; `page_view` (web) vs `screen_view` (mobile); `notification_open`, `form_submit`. We intentionally diverge on launch: GA4's `app_open` is the foreground/resume event and `first_open`/`app_update` are separate; we use a single `app_launch` with a product `launch_type` (relaunch/install/update) and let `app_foreground` carry resume. | <https://support.google.com/analytics/answer/9234069> |
 | **OpenTelemetry app events** | `event.*` click payload, screen/widget identifiers, click coordinates. | <https://opentelemetry.io/docs/specs/semconv/app/app-events/> |
-| **OpenTelemetry mobile events** | App lifecycle states (`foreground`/`background`/`active`/`inactive`/…). | <https://opentelemetry.io/docs/specs/semconv/mobile/mobile-events/> |
+| **OpenTelemetry mobile events** | App lifecycle states (`foreground`/`background`/`active`/`inactive`/…); `AppStart` `start.type` (cold/warm) recorded as the `app.start` span event on `app_launch`. | <https://opentelemetry.io/docs/specs/semconv/mobile/mobile-events/> |
+| **Sentry mobile vitals** | Cold/warm startup split (`app.start.cold` / `app.start.warm`), modeled as a span event under `app_launch` rather than a separate event. | <https://docs.sentry.io/product/insights/mobile/mobile-vitals/> |
 | **Segment Spec** | The `identify`/`track` call model and the reserved e-commerce event names used in §4.2. | <https://segment.com/docs/connections/spec/> |
 
 > **On OpenTelemetry.** OTel is an observability convention, not a product-analytics one, but it does **not contradict** the web/mobile product taxonomies. We adopt its **attribute names and enum values** (lifecycle states, screen/widget identifiers, click coordinates) and map them into our `event.*` namespace; we keep short, human-readable **event names** that product tools expect.

--- a/e2e/android/app/src/compose/java/com/example/androidobservability/MainActivity.kt
+++ b/e2e/android/app/src/compose/java/com/example/androidobservability/MainActivity.kt
@@ -65,7 +65,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        val viewModel: ViewModel by viewModels()
+        val viewModel: MainActivityViewModel by viewModels()
 
         enableEdgeToEdge()
         setContent {
@@ -106,7 +106,7 @@ class MainActivity : ComponentActivity() {
 }
 
 @Composable
-private fun MainScreen(viewModel: ViewModel, innerPadding: PaddingValues) {
+private fun MainScreen(viewModel: MainActivityViewModel, innerPadding: PaddingValues) {
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -171,7 +171,7 @@ private fun SessionReplayHeader() {
 
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
-private fun MetricButtons(viewModel: ViewModel) {
+private fun MetricButtons(viewModel: MainActivityViewModel) {
     Text(
         text = "Metric",
         style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
@@ -252,7 +252,7 @@ private fun MetricButtons(viewModel: ViewModel) {
 }
 
 @Composable
-private fun InstrumentationButtons(viewModel: ViewModel) {
+private fun InstrumentationButtons(viewModel: MainActivityViewModel) {
     Text(
         text = "Instrumentation",
         style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
@@ -373,7 +373,7 @@ private fun goToActivity(ctx: Context, activity: Class<out Activity>?){
 }
 
 @Composable
-private fun IdentifyButtons(viewModel: ViewModel) {
+private fun IdentifyButtons(viewModel: MainActivityViewModel) {
     Spacer(modifier = Modifier.height(16.dp))
 
     Text(
@@ -419,7 +419,7 @@ private fun IdentifyButtons(viewModel: ViewModel) {
 }
 
 @Composable
-private fun ErrorButtons(viewModel: ViewModel) {
+private fun ErrorButtons(viewModel: MainActivityViewModel) {
     Text(
         text = "Error",
         style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
@@ -440,7 +440,7 @@ private fun ErrorButtons(viewModel: ViewModel) {
 }
 
 @Composable
-private fun LogsButtons(viewModel: ViewModel) {
+private fun LogsButtons(viewModel: MainActivityViewModel) {
     var customLogText by remember { mutableStateOf("Log Message") }
 
     Text(
@@ -485,7 +485,7 @@ private fun LogsButtons(viewModel: ViewModel) {
 }
 
 @Composable
-private fun TracesButtons(viewModel: ViewModel) {
+private fun TracesButtons(viewModel: MainActivityViewModel) {
     var customSpanText by remember { mutableStateOf("Span Name") }
     var flagKey by remember { mutableStateOf("my-feature") }
 

--- a/e2e/android/app/src/compose/java/com/example/androidobservability/MainActivity.kt
+++ b/e2e/android/app/src/compose/java/com/example/androidobservability/MainActivity.kt
@@ -241,6 +241,13 @@ private fun MetricButtons(viewModel: ViewModel) {
         ) {
             Text("Track Screen View")
         }
+        Button(
+            onClick = {
+                viewModel.trackNested()
+            }
+        ) {
+            Text("Track (Nested)")
+        }
     }
 }
 

--- a/e2e/android/app/src/compose/java/com/example/androidobservability/MainActivityViewModel.kt
+++ b/e2e/android/app/src/compose/java/com/example/androidobservability/MainActivityViewModel.kt
@@ -205,7 +205,7 @@ class MainActivityViewModel(application: Application) : AndroidViewModel(applica
         // example from analytics-taxonomy.md (§4.2): scalar fields plus a
         // `products` array of line-item objects.
         LDObserve.track(
-            "Checkout Started",
+            "checkout-started",
             data = mapOf(
                 "name" to "Checkout Started",
                 "order_id" to "ord_5521",

--- a/e2e/android/app/src/compose/java/com/example/androidobservability/MainActivityViewModel.kt
+++ b/e2e/android/app/src/compose/java/com/example/androidobservability/MainActivityViewModel.kt
@@ -58,18 +58,19 @@ class MainActivityViewModel(application: Application) : AndroidViewModel(applica
     }
 
     fun triggerLog() {
+        // `recordLog` takes a plain map via `properties`, so no need to build OTel attributes.
         LDObserve.recordLog(
             "Test Log",
             Severity.INFO,
-            Attributes.builder()
-                .put(AttributeKey.stringKey("test-string"), "maui")
-                .put(AttributeKey.booleanKey("test-true"), true)
-                .put(AttributeKey.booleanKey("test-false"), false)
-                .put(AttributeKey.longKey("test-integer"), 42L)
-                .put(AttributeKey.doubleKey("test-double"), 3.14)
-                .put(AttributeKey.doubleArrayKey("test-array"), listOf(3.14))
-                .put(AttributeKey.longArrayKey("test-nested.array"), listOf(1L))
-                .build()
+            properties = mapOf(
+                "test-string" to "maui",
+                "test-true" to true,
+                "test-false" to false,
+                "test-integer" to 42,
+                "test-double" to 3.14,
+                "test-array" to listOf(3.14),
+                "test-nested" to mapOf("array" to listOf(1))
+            )
         )
     }
 
@@ -141,9 +142,7 @@ class MainActivityViewModel(application: Application) : AndroidViewModel(applica
             viewModelScope.launch(Dispatchers.IO) {
                 val customSpan = LDObserve.startSpan(
                     name = spanName,
-                    attributes = Attributes.of(
-                        AttributeKey.stringKey("custom_span"), "true"
-                    )
+                    properties = mapOf("custom_span" to "true")
                 )
                 customSpan.end()
             }
@@ -190,7 +189,7 @@ class MainActivityViewModel(application: Application) : AndroidViewModel(applica
         // takes a map so callers need not depend on `LDValue`.
         LDObserve.track(
             "track-via-ld-observe",
-            data = mapOf(
+            properties = mapOf(
                 "test-string" to "android",
                 "test-true" to true,
                 "test-false" to false,
@@ -206,7 +205,7 @@ class MainActivityViewModel(application: Application) : AndroidViewModel(applica
         // `products` array of line-item objects.
         LDObserve.track(
             "checkout-started",
-            data = mapOf(
+            properties = mapOf(
                 "name" to "Checkout Started",
                 "order_id" to "ord_5521",
                 "value" to 72.0,
@@ -227,7 +226,11 @@ class MainActivityViewModel(application: Application) : AndroidViewModel(applica
             name = "Manual Screen $count",
             screenClass = "MainActivity",
             screenId = "manual-screen-$count",
-            category = "Demo"
+            category = "Demo",
+            properties = mapOf(
+                "source" to "manual-demo",
+                "index" to count
+            )
         )
     }
 

--- a/e2e/android/app/src/compose/java/com/example/androidobservability/MainActivityViewModel.kt
+++ b/e2e/android/app/src/compose/java/com/example/androidobservability/MainActivityViewModel.kt
@@ -26,7 +26,7 @@ import java.net.HttpURLConnection
 import java.net.URL
 
 
-class ViewModel(application: Application) : AndroidViewModel(application) {
+class MainActivityViewModel(application: Application) : AndroidViewModel(application) {
 
     private var screenViewCounter = 0
 

--- a/e2e/android/app/src/compose/java/com/example/androidobservability/MainActivityViewModel.kt
+++ b/e2e/android/app/src/compose/java/com/example/androidobservability/MainActivityViewModel.kt
@@ -67,6 +67,7 @@ class MainActivityViewModel(application: Application) : AndroidViewModel(applica
                 "test-true" to true,
                 "test-false" to false,
                 "test-integer" to 42,
+                "test-long" to 9_000_000_000L,
                 "test-double" to 3.14,
                 "test-array" to listOf(3.14),
                 "test-nested" to mapOf("array" to listOf(1))
@@ -179,6 +180,7 @@ class MainActivityViewModel(application: Application) : AndroidViewModel(applica
                 .put("test-true", true)
                 .put("test-false", false)
                 .put("test-integer", 42)
+                .put("test-long", 9_000_000_000_123)
                 .put("test-double", 3.14)
                 .build()
         )
@@ -194,6 +196,9 @@ class MainActivityViewModel(application: Application) : AndroidViewModel(applica
                 "test-true" to true,
                 "test-false" to false,
                 "test-integer" to 42,
+                // A 64-bit value beyond Int32 range (e.g. epoch nanoseconds):
+                // the direct LDObserve APIs keep it as a long, unlike LDClient.track.
+                "test-long" to 9_000_000_000_123,
                 "test-double" to 3.14
             )
         )

--- a/e2e/android/app/src/compose/java/com/example/androidobservability/ViewModel.kt
+++ b/e2e/android/app/src/compose/java/com/example/androidobservability/ViewModel.kt
@@ -186,16 +186,36 @@ class ViewModel(application: Application) : AndroidViewModel(application) {
     }
 
     fun trackViaLdObserve() {
-        // Records a `track` span directly through the Observability API.
+        // Records a `track` span directly through the Observability API. `track`
+        // takes a map so callers need not depend on `LDValue`.
         LDObserve.track(
             "track-via-ld-observe",
-            data = LDValue.buildObject()
-                .put("test-string", "android")
-                .put("test-true", true)
-                .put("test-false", false)
-                .put("test-integer", 42)
-                .put("test-double", 3.14)
-                .build()
+            data = mapOf(
+                "test-string" to "android",
+                "test-true" to true,
+                "test-false" to false,
+                "test-integer" to 42,
+                "test-double" to 3.14
+            )
+        )
+    }
+
+    fun trackNested() {
+        // A nested `track` payload following the Segment "Checkout Started"
+        // example from analytics-taxonomy.md (§4.2): scalar fields plus a
+        // `products` array of line-item objects.
+        LDObserve.track(
+            "Checkout Started",
+            data = mapOf(
+                "name" to "Checkout Started",
+                "order_id" to "ord_5521",
+                "value" to 72.0,
+                "currency" to "USD",
+                "products" to listOf(
+                    mapOf("product_id" to "SKU-1234", "quantity" to 2, "price" to 24.0),
+                    mapOf("product_id" to "SKU-9876", "quantity" to 1, "price" to 24.0)
+                )
+            )
         )
     }
 

--- a/e2e/android/app/src/java/java/com/example/androidobservability/MainActivity.java
+++ b/e2e/android/app/src/java/java/com/example/androidobservability/MainActivity.java
@@ -20,14 +20,14 @@ import com.launchdarkly.observability.sdk.LDReplay;
 
 public class MainActivity extends AppCompatActivity {
 
-    private ViewModel viewModel;
+    private MainActivityViewModel viewModel;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
 
-        viewModel = new ViewModelProvider(this).get(ViewModel.class);
+        viewModel = new ViewModelProvider(this).get(MainActivityViewModel.class);
 
         setupToolbarSubtitle();
         setupMaskingButtons();

--- a/e2e/android/app/src/java/java/com/example/androidobservability/MainActivityViewModel.java
+++ b/e2e/android/app/src/java/java/com/example/androidobservability/MainActivityViewModel.java
@@ -21,6 +21,7 @@ import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.Arrays;
+import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
@@ -37,17 +38,17 @@ import okhttp3.Request;
 import okhttp3.Response;
 
 /**
- * Java counterpart of the Kotlin {@code ViewModel} used by the compose flavor.
+ * Java counterpart of the Kotlin {@code MainActivityViewModel} used by the compose flavor.
  *
  * <p>Kotlin coroutines ({@code viewModelScope.launch(Dispatchers.IO)}) are replaced with a
  * background {@link ExecutorService}; the detached-thread span/context demos still use plain
  * {@link Thread}s, matching the Kotlin original.
  */
-public class ViewModel extends AndroidViewModel {
+public class MainActivityViewModel extends AndroidViewModel {
 
     private final ExecutorService backgroundExecutor = Executors.newCachedThreadPool();
 
-    public ViewModel(@NonNull Application application) {
+    public MainActivityViewModel(@NonNull Application application) {
         super(application);
     }
 
@@ -210,16 +211,17 @@ public class ViewModel extends AndroidViewModel {
     }
 
     public void trackViaLdObserve() {
-        // Records a `track` span directly through the Observability API.
+        // Records a `track` span directly through the Observability API. `track`
+        // takes a map so callers need not depend on `LDValue`.
         LDObserve.Companion.track(
                 "track-via-ld-observe",
-                LDValue.buildObject()
-                        .put("test-string", "android")
-                        .put("test-true", true)
-                        .put("test-false", false)
-                        .put("test-integer", 42)
-                        .put("test-double", 3.14)
-                        .build(),
+                Map.of(
+                        "test-string", "android",
+                        "test-true", true,
+                        "test-false", false,
+                        "test-integer", 42,
+                        "test-double", 3.14
+                ),
                 null
         );
     }

--- a/e2e/android/app/src/java/java/com/example/androidobservability/MainActivityViewModel.java
+++ b/e2e/android/app/src/java/java/com/example/androidobservability/MainActivityViewModel.java
@@ -220,6 +220,9 @@ public class MainActivityViewModel extends AndroidViewModel {
                         "test-true", true,
                         "test-false", false,
                         "test-integer", 42,
+                        // A 64-bit value beyond Int32 range: the direct LDObserve
+                        // APIs keep it as a long, unlike LDClient.track.
+                        "test-long", 9_000_000_000L,
                         "test-double", 3.14
                 ),
                 null

--- a/sdk/@launchdarkly/flutter/example/ios/Podfile.lock
+++ b/sdk/@launchdarkly/flutter/example/ios/Podfile.lock
@@ -33,40 +33,40 @@ PODS:
     - LDSwiftEventSource (= 3.3.0)
   - launchdarkly_flutter_observability (0.0.0):
     - Flutter
-    - LaunchDarklyObservability (~> 0.38.0)
-    - LaunchDarklySessionReplay (~> 0.38.0)
-  - LaunchDarklyObservability (0.38.0):
-    - LaunchDarklyObservability/LaunchDarklyObservability (= 0.38.0)
-  - LaunchDarklyObservability/Common (0.38.0):
+    - LaunchDarklyObservability (~> 0.41.0)
+    - LaunchDarklySessionReplay (~> 0.41.0)
+  - LaunchDarklyObservability (0.41.0):
+    - LaunchDarklyObservability/LaunchDarklyObservability (= 0.41.0)
+  - LaunchDarklyObservability/Common (0.41.0):
     - LaunchDarkly (~> 11.2)
-  - LaunchDarklyObservability/JSONExporters (0.38.0):
+  - LaunchDarklyObservability/JSONExporters (0.41.0):
     - OpenTelemetry-Swift-Api (~> 2.3.0)
     - OpenTelemetry-Swift-Sdk (~> 2.3.0)
-  - LaunchDarklyObservability/LaunchDarklyObservability (0.38.0):
+  - LaunchDarklyObservability/LaunchDarklyObservability (0.41.0):
     - LaunchDarklyObservability/Common
     - LaunchDarklyObservability/JSONExporters
     - LaunchDarklyObservability/Misc
     - LaunchDarklyObservability/OpenTelemetry
     - LaunchDarklyObservability/SDKResourceExtension
     - LaunchDarklyObservability/URLSessionInstrumentation
-  - LaunchDarklyObservability/Misc (0.38.0):
+  - LaunchDarklyObservability/Misc (0.41.0):
     - KSCrash
-  - LaunchDarklyObservability/NetworkStatus (0.38.0):
+  - LaunchDarklyObservability/NetworkStatus (0.41.0):
     - OpenTelemetry-Swift-Api (~> 2.3.0)
-  - LaunchDarklyObservability/OpenTelemetry (0.38.0):
+  - LaunchDarklyObservability/OpenTelemetry (0.41.0):
     - OpenTelemetry-Swift-Api (~> 2.3.0)
     - OpenTelemetry-Swift-Sdk (~> 2.3.0)
-  - LaunchDarklyObservability/SDKResourceExtension (0.38.0):
+  - LaunchDarklyObservability/SDKResourceExtension (0.41.0):
     - LaunchDarklyObservability/OpenTelemetry
-  - LaunchDarklyObservability/URLSessionInstrumentation (0.38.0):
+  - LaunchDarklyObservability/URLSessionInstrumentation (0.41.0):
     - LaunchDarklyObservability/NetworkStatus
     - OpenTelemetry-Swift-Sdk (~> 2.3.0)
-  - LaunchDarklySessionReplay (0.38.0):
-    - LaunchDarklySessionReplay/LaunchDarklySessionReplay (= 0.38.0)
-  - LaunchDarklySessionReplay/LaunchDarklySessionReplay (0.38.0):
+  - LaunchDarklySessionReplay (0.41.0):
+    - LaunchDarklySessionReplay/LaunchDarklySessionReplay (= 0.41.0)
+  - LaunchDarklySessionReplay/LaunchDarklySessionReplay (0.41.0):
     - LaunchDarklyObservability
     - LaunchDarklySessionReplay/SessionReplayC
-  - LaunchDarklySessionReplay/SessionReplayC (0.38.0)
+  - LaunchDarklySessionReplay/SessionReplayC (0.41.0)
   - LDSwiftEventSource (3.3.0)
   - OpenTelemetry-Swift-Api (2.3.0)
   - OpenTelemetry-Swift-Sdk (2.3.0):
@@ -125,9 +125,9 @@ SPEC CHECKSUMS:
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
   KSCrash: 8c4464fd5da7de520f2ce4a00fdf63f169a80f18
   LaunchDarkly: 196f8e6c8b3ae801762fcf328704c495a36bdeee
-  launchdarkly_flutter_observability: 685c33544935b493577cf2730af188ad8b476ad8
-  LaunchDarklyObservability: f05b864c67587418038323a9d859eee893c03194
-  LaunchDarklySessionReplay: d5f831951d746f7d08510ba65e09fcae178cc80f
+  launchdarkly_flutter_observability: 0fcfcea661ac2c2e38f7a3cfbd46e26abd954877
+  LaunchDarklyObservability: 5a4e03887051c549627ef25dff2ee7aaabab10dd
+  LaunchDarklySessionReplay: 1429d8601154256391c214ff0c3d2651f9187fbd
   LDSwiftEventSource: b0826ca826ca890609a9833a05cae1f357fd3b99
   OpenTelemetry-Swift-Api: 3d77582ab6837a63b65bf7d2eacc57d8f2595edd
   OpenTelemetry-Swift-Sdk: 69d60f0242e830366e359481edd575d6776eb983

--- a/sdk/@launchdarkly/flutter/example/lib/my_home_page.dart
+++ b/sdk/@launchdarkly/flutter/example/lib/my_home_page.dart
@@ -139,8 +139,7 @@ class _MyHomePageState extends State<MyHomePage> {
 
   // --- Track ---
 
-  /// Sample `data` payload shared by both track paths, mirroring the Swift
-  /// TestApp's track buttons.
+  /// Sample `data` payload for `LDClient.track`, which takes an `LDValue`.
   LDValue _trackData() => LDValue.buildObject()
       .addString('test-string', 'flutter')
       .addBool('test-true', true)
@@ -148,6 +147,17 @@ class _MyHomePageState extends State<MyHomePage> {
       .addNum('test-integer', 42)
       .addNum('test-double', 3.14)
       .build();
+
+  /// Same payload as [_trackData] but as a plain map, mirroring the Swift
+  /// TestApp's track buttons. `LDObserve.track` takes a map so callers need not
+  /// depend on `LDValue`.
+  Map<String, dynamic> _trackDataMap() => <String, dynamic>{
+    'test-string': 'flutter',
+    'test-true': true,
+    'test-false': false,
+    'test-integer': 42,
+    'test-double': 3.14,
+  };
 
   // Records a `track` span automatically via the observability `afterTrack`
   // hook on the LaunchDarkly client.
@@ -159,7 +169,7 @@ class _MyHomePageState extends State<MyHomePage> {
   // Records a `track` span directly through the observability API, without
   // routing through the LaunchDarkly client.
   void _onTrackViaObserve() {
-    LDObserve.track('track-via-ld-observe', data: _trackData());
+    LDObserve.track('track-via-ld-observe', data: _trackDataMap());
     debugPrint('Track via LDObserve triggered');
   }
 

--- a/sdk/@launchdarkly/flutter/example/lib/my_home_page.dart
+++ b/sdk/@launchdarkly/flutter/example/lib/my_home_page.dart
@@ -159,6 +159,20 @@ class _MyHomePageState extends State<MyHomePage> {
     'test-double': 3.14,
   };
 
+  /// A nested `track` payload following the Segment "Checkout Started" example
+  /// from analytics-taxonomy.md (§4.2): scalar fields plus a `products` array of
+  /// line-item objects.
+  Map<String, dynamic> _trackNestedDataMap() => <String, dynamic>{
+    'name': 'Checkout Started',
+    'order_id': 'ord_5521',
+    'value': 72.0,
+    'currency': 'USD',
+    'products': <Map<String, dynamic>>[
+      {'product_id': 'SKU-1234', 'quantity': 2, 'price': 24.0},
+      {'product_id': 'SKU-9876', 'quantity': 1, 'price': 24.0},
+    ],
+  };
+
   // Records a `track` span automatically via the observability `afterTrack`
   // hook on the LaunchDarkly client.
   void _onTrackViaClient() {
@@ -171,6 +185,13 @@ class _MyHomePageState extends State<MyHomePage> {
   void _onTrackViaObserve() {
     LDObserve.track('track-via-ld-observe', data: _trackDataMap());
     debugPrint('Track via LDObserve triggered');
+  }
+
+  // Records a `track` span with a nested payload (scalars + an array of objects)
+  // through the observability API.
+  void _onTrackNested() {
+    LDObserve.track('Checkout Started', data: _trackNestedDataMap());
+    debugPrint('Nested track via LDObserve triggered');
   }
 
   // --- Error / Logs / Traces ---
@@ -476,6 +497,10 @@ class _MyHomePageState extends State<MyHomePage> {
                 ElevatedButton(
                   onPressed: _onTrackViaObserve,
                   child: const Text('Track (LDObserve)'),
+                ),
+                ElevatedButton(
+                  onPressed: _onTrackNested,
+                  child: const Text('Track (Nested)'),
                 ),
               ],
             ),

--- a/sdk/@launchdarkly/flutter/example/lib/my_home_page.dart
+++ b/sdk/@launchdarkly/flutter/example/lib/my_home_page.dart
@@ -137,6 +137,32 @@ class _MyHomePageState extends State<MyHomePage> {
     throw StateError('Failed to connect to bogus server.');
   }
 
+  // --- Track ---
+
+  /// Sample `data` payload shared by both track paths, mirroring the Swift
+  /// TestApp's track buttons.
+  LDValue _trackData() => LDValue.buildObject()
+      .addString('test-string', 'flutter')
+      .addBool('test-true', true)
+      .addBool('test-false', false)
+      .addNum('test-integer', 42)
+      .addNum('test-double', 3.14)
+      .build();
+
+  // Records a `track` span automatically via the observability `afterTrack`
+  // hook on the LaunchDarkly client.
+  void _onTrackViaClient() {
+    LDSingleton.client?.track('track-via-ld-client', data: _trackData());
+    debugPrint('Track via LDClient triggered');
+  }
+
+  // Records a `track` span directly through the observability API, without
+  // routing through the LaunchDarkly client.
+  void _onTrackViaObserve() {
+    LDObserve.track('track-via-ld-observe', data: _trackData());
+    debugPrint('Track via LDObserve triggered');
+  }
+
   // --- Error / Logs / Traces ---
 
   void _onTriggerError() {
@@ -426,6 +452,22 @@ class _MyHomePageState extends State<MyHomePage> {
               onPressed: _onTriggerCrash,
               style: dangerStyle,
               child: const Text('Trigger Crash'),
+            ),
+
+            const _SubsectionHeader('Track'),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: [
+                ElevatedButton(
+                  onPressed: _onTrackViaClient,
+                  child: const Text('Track (LDClient)'),
+                ),
+                ElevatedButton(
+                  onPressed: _onTrackViaObserve,
+                  child: const Text('Track (LDObserve)'),
+                ),
+              ],
             ),
 
             const _SubsectionHeader('Error'),

--- a/sdk/@launchdarkly/flutter/example/macos/Podfile.lock
+++ b/sdk/@launchdarkly/flutter/example/macos/Podfile.lock
@@ -9,6 +9,9 @@ PODS:
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
+  - webview_flutter_wkwebview (0.0.1):
+    - Flutter
+    - FlutterMacOS
 
 DEPENDENCIES:
   - connectivity_plus (from `Flutter/ephemeral/.symlinks/plugins/connectivity_plus/macos`)
@@ -16,6 +19,7 @@ DEPENDENCIES:
   - FlutterMacOS (from `Flutter/ephemeral`)
   - package_info_plus (from `Flutter/ephemeral/.symlinks/plugins/package_info_plus/macos`)
   - shared_preferences_foundation (from `Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin`)
+  - webview_flutter_wkwebview (from `Flutter/ephemeral/.symlinks/plugins/webview_flutter_wkwebview/darwin`)
 
 EXTERNAL SOURCES:
   connectivity_plus:
@@ -28,6 +32,8 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/package_info_plus/macos
   shared_preferences_foundation:
     :path: Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin
+  webview_flutter_wkwebview:
+    :path: Flutter/ephemeral/.symlinks/plugins/webview_flutter_wkwebview/darwin
 
 SPEC CHECKSUMS:
   connectivity_plus: 4adf20a405e25b42b9c9f87feff8f4b6fde18a4e
@@ -35,6 +41,7 @@ SPEC CHECKSUMS:
   FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
   package_info_plus: f0052d280d17aa382b932f399edf32507174e870
   shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7
+  webview_flutter_wkwebview: 8ebf4fded22593026f7dbff1fbff31ea98573c8d
 
 PODFILE CHECKSUM: 54d867c82ac51cbd61b565781b9fada492027009
 

--- a/sdk/@launchdarkly/flutter/example/pubspec.lock
+++ b/sdk/@launchdarkly/flutter/example/pubspec.lock
@@ -180,10 +180,10 @@ packages:
     dependency: transitive
     description:
       name: launchdarkly_common_client
-      sha256: aeefe7bc4b7bf995fa23a5165846a7320aa1eaa48089f19d150a0144fbf5bfad
+      sha256: "9b2ae5feab033e8d9eaff28b00aeb7c24d4b0269331702c3386dbe356ecbea0b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.0"
   launchdarkly_dart_common:
     dependency: transitive
     description:
@@ -204,17 +204,17 @@ packages:
     dependency: "direct main"
     description:
       name: launchdarkly_flutter_client_sdk
-      sha256: "1c33e7c184f7027adb6a89c1c36e2e31110da9cb92e53cab9c8060ac152fc9c4"
+      sha256: c586d7656a405c73596f2e68f1bebe0ae148db5637818df3bbe6610a78b2cd98
       url: "https://pub.dev"
     source: hosted
-    version: "4.17.0-beta.1"
+    version: "4.18.0"
   launchdarkly_flutter_observability:
     dependency: "direct main"
     description:
       path: "../packages/observability"
       relative: true
     source: path
-    version: "0.6.0"
+    version: "0.7.0"
   leak_tracker:
     dependency: transitive
     description:

--- a/sdk/@launchdarkly/flutter/packages/observability/android/build.gradle
+++ b/sdk/@launchdarkly/flutter/packages/observability/android/build.gradle
@@ -54,4 +54,13 @@ dependencies {
     // OTel Attributes appears in ObservabilityOptions parameter types; provided
     // at runtime transitively through launchdarkly-observability-android.
     implementation "io.opentelemetry:opentelemetry-api:1.62.0"
+    // The observability SDK is compiled against the LaunchDarkly client SDK as
+    // `compileOnly` (hosts opt in via `ldClientSdkProvided`), so it does not
+    // package the com.launchdarkly.sdk model types. The bridge's `track` path
+    // touches LDValue at runtime, so provide the lightweight java-sdk-common
+    // (model types only, NOT the feature-flag client). `runtimeOnly` keeps it off
+    // this plugin's compile classpath so the plugin stays independent of the
+    // flagging SDK. Version mirrors what launchdarkly-android-client-sdk:5.12.2
+    // resolves.
+    runtimeOnly "com.launchdarkly:launchdarkly-java-sdk-common:2.4.0"
 }

--- a/sdk/@launchdarkly/flutter/packages/observability/android/src/main/kotlin/com/launchdarkly/launchdarkly_flutter_observability/LDNativeApiImpl.kt
+++ b/sdk/@launchdarkly/flutter/packages/observability/android/src/main/kotlin/com/launchdarkly/launchdarkly_flutter_observability/LDNativeApiImpl.kt
@@ -193,6 +193,17 @@ internal class LDNativeApiImpl(
         )
     }
 
+    // Forwards a custom track event to the native observability SDK. Native
+    // `track` always broadcasts a Session Replay `Track` timeline event and, when
+    // `analytics.trackEvents` is enabled, emits the `track` span. The Dart side
+    // routes mobile track here instead of through `exportSpans` because only the
+    // native track path reaches Session Replay. The bridge owns the
+    // `Map` -> `LDValue` conversion so this plugin stays independent of the
+    // LaunchDarkly feature-flag SDK.
+    override fun track(key: String, data: Map<String, Any?>?, metricValue: Double?) {
+        LDObserveBridge.track(key, data, metricValue)
+    }
+
     /**
      * Maps the OpenTelemetry log-severity number sent across the bridge onto the
      * native [ObservabilityOptions.LogLevel]. Defaults to [ObservabilityOptions.LogLevel.INFO]

--- a/sdk/@launchdarkly/flutter/packages/observability/android/src/main/kotlin/com/launchdarkly/launchdarkly_flutter_observability/LDNativeApiImpl.kt
+++ b/sdk/@launchdarkly/flutter/packages/observability/android/src/main/kotlin/com/launchdarkly/launchdarkly_flutter_observability/LDNativeApiImpl.kt
@@ -197,11 +197,18 @@ internal class LDNativeApiImpl(
     // `track` always broadcasts a Session Replay `Track` timeline event and, when
     // `analytics.trackEvents` is enabled, emits the `track` span. The Dart side
     // routes mobile track here instead of through `exportSpans` because only the
-    // native track path reaches Session Replay. The bridge owns the
-    // `Map` -> `LDValue` conversion so this plugin stays independent of the
-    // LaunchDarkly feature-flag SDK.
-    override fun track(key: String, data: Map<String, Any?>?, metricValue: Double?) {
-        LDObserveBridge.track(key, data, metricValue)
+    // native track path reaches Session Replay. `contextKeys` (the LD evaluation
+    // context's kind -> key pairs) is applied to the span so it is attributed to
+    // the same context the web SDK records. The bridge owns the `Map` -> `LDValue`
+    // conversion so this plugin stays independent of the LaunchDarkly
+    // feature-flag SDK.
+    override fun track(
+        key: String,
+        data: Map<String, Any?>?,
+        metricValue: Double?,
+        contextKeys: Map<String, String>?,
+    ) {
+        LDObserveBridge.track(key, data, metricValue, contextKeys)
     }
 
     /**

--- a/sdk/@launchdarkly/flutter/packages/observability/android/src/main/kotlin/com/launchdarkly/launchdarkly_flutter_observability/Messages.g.kt
+++ b/sdk/@launchdarkly/flutter/packages/observability/android/src/main/kotlin/com/launchdarkly/launchdarkly_flutter_observability/Messages.g.kt
@@ -615,6 +615,13 @@ interface LDNativeApi {
    * `LogRecord` with `session.id` and trace/span correlation.
    */
   fun recordLog(log: LDLogRecord)
+  /**
+   * Forwards a custom track event to the native observability SDK so it emits
+   * the native `track` span (gated by `analytics.trackEvents`) and the Session
+   * Replay `Track` timeline event (always). `data` carries the optional event
+   * payload as a JSON object.
+   */
+  fun track(key: String, data: Map<String, Any?>?, metricValue: Double?)
 
   companion object {
     /** The codec used by LDNativeApi. */
@@ -674,6 +681,26 @@ interface LDNativeApi {
             val logArg = args[0] as LDLogRecord
             val wrapped: List<Any?> = try {
               api.recordLog(logArg)
+              listOf(null)
+            } catch (exception: Throwable) {
+              MessagesPigeonUtils.wrapError(exception)
+            }
+            reply.reply(wrapped)
+          }
+        } else {
+          channel.setMessageHandler(null)
+        }
+      }
+      run {
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.launchdarkly_flutter_observability.LDNativeApi.track$separatedMessageChannelSuffix", codec)
+        if (api != null) {
+          channel.setMessageHandler { message, reply ->
+            val args = message as List<Any?>
+            val keyArg = args[0] as String
+            val dataArg = args[1] as Map<String, Any?>?
+            val metricValueArg = args[2] as Double?
+            val wrapped: List<Any?> = try {
+              api.track(keyArg, dataArg, metricValueArg)
               listOf(null)
             } catch (exception: Throwable) {
               MessagesPigeonUtils.wrapError(exception)

--- a/sdk/@launchdarkly/flutter/packages/observability/android/src/main/kotlin/com/launchdarkly/launchdarkly_flutter_observability/Messages.g.kt
+++ b/sdk/@launchdarkly/flutter/packages/observability/android/src/main/kotlin/com/launchdarkly/launchdarkly_flutter_observability/Messages.g.kt
@@ -619,9 +619,12 @@ interface LDNativeApi {
    * Forwards a custom track event to the native observability SDK so it emits
    * the native `track` span (gated by `analytics.trackEvents`) and the Session
    * Replay `Track` timeline event (always). `data` carries the optional event
-   * payload as a JSON object.
+   * payload as a JSON object. `contextKeys` carries the evaluation context's
+   * kind -> key pairs (from the LaunchDarkly client's `afterTrack` hook) so the
+   * native `track` span is attributed to the same context the web SDK records;
+   * only the span is annotated, not the Session Replay `Track` payload.
    */
-  fun track(key: String, data: Map<String, Any?>?, metricValue: Double?)
+  fun track(key: String, data: Map<String, Any?>?, metricValue: Double?, contextKeys: Map<String, String>?)
 
   companion object {
     /** The codec used by LDNativeApi. */
@@ -699,8 +702,9 @@ interface LDNativeApi {
             val keyArg = args[0] as String
             val dataArg = args[1] as Map<String, Any?>?
             val metricValueArg = args[2] as Double?
+            val contextKeysArg = args[3] as Map<String, String>?
             val wrapped: List<Any?> = try {
-              api.track(keyArg, dataArg, metricValueArg)
+              api.track(keyArg, dataArg, metricValueArg, contextKeysArg)
               listOf(null)
             } catch (exception: Throwable) {
               MessagesPigeonUtils.wrapError(exception)

--- a/sdk/@launchdarkly/flutter/packages/observability/ios/launchdarkly_flutter_observability.podspec
+++ b/sdk/@launchdarkly/flutter/packages/observability/ios/launchdarkly_flutter_observability.podspec
@@ -15,8 +15,8 @@ The LaunchDarkly Observability and Session Replay plugin for Flutter.
   # Native dependencies mirrored from the LaunchDarkly mobile SDKs (the same
   # stack used by sdk/@launchdarkly/react-native-ld-session-replay and the
   # .NET MAUI bridge in sdk/@launchdarkly/mobile-dotnet).
-  s.dependency 'LaunchDarklyObservability', '~> 0.40.0'
-  s.dependency 'LaunchDarklySessionReplay', '~> 0.40.0'
+  s.dependency 'LaunchDarklyObservability', '~> 0.41.0'
+  s.dependency 'LaunchDarklySessionReplay', '~> 0.41.0'
 
   s.platform         = :ios, '14.0'
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }

--- a/sdk/@launchdarkly/flutter/packages/observability/ios/launchdarkly_flutter_observability/Package.swift
+++ b/sdk/@launchdarkly/flutter/packages/observability/ios/launchdarkly_flutter_observability/Package.swift
@@ -20,7 +20,7 @@ let swiftObservabilityDependency: Package.Dependency = if useLocalNativeSdk {
 } else {
     .package(
         url: "https://github.com/launchdarkly/swift-launchdarkly-observability.git",
-        .upToNextMinor(from: "0.40.0")
+        .upToNextMinor(from: "0.41.0")
     )
 }
 

--- a/sdk/@launchdarkly/flutter/packages/observability/ios/launchdarkly_flutter_observability/Sources/launchdarkly_flutter_observability/LDNativeApiImpl.swift
+++ b/sdk/@launchdarkly/flutter/packages/observability/ios/launchdarkly_flutter_observability/Sources/launchdarkly_flutter_observability/LDNativeApiImpl.swift
@@ -106,13 +106,15 @@ final class LDNativeApiImpl: NSObject, LDNativeApi {
     // `track` always broadcasts a Session Replay `Track` timeline event and, when
     // `analytics.trackEvents` is enabled, emits the `track` span. This is why the
     // Dart side routes mobile track here instead of through `exportSpans`: only
-    // the native track path reaches Session Replay. The bridge owns the
-    // `Map` -> `LDValue` conversion so this plugin stays free of `LDValue`.
-    func track(key: String, data: [String: Any?]?, metricValue: Double?) throws {
+    // the native track path reaches Session Replay. `contextKeys` (the LD
+    // evaluation context's kind -> key pairs) is applied to the span so it is
+    // attributed to the same context the web SDK records.
+    func track(key: String, data: [String: Any?]?, metricValue: Double?, contextKeys: [String: String]?) throws {
         ObjcLDObserveBridge.track(
             key: key,
             data: data.map { cleanAttributes($0) },
-            metricValue: metricValue.map { NSNumber(value: $0) }
+            metricValue: metricValue.map { NSNumber(value: $0) },
+            contextKeys: contextKeys
         )
     }
 

--- a/sdk/@launchdarkly/flutter/packages/observability/ios/launchdarkly_flutter_observability/Sources/launchdarkly_flutter_observability/LDNativeApiImpl.swift
+++ b/sdk/@launchdarkly/flutter/packages/observability/ios/launchdarkly_flutter_observability/Sources/launchdarkly_flutter_observability/LDNativeApiImpl.swift
@@ -102,6 +102,20 @@ final class LDNativeApiImpl: NSObject, LDNativeApi {
         )
     }
 
+    // Forwards a custom track event to the native observability SDK. Native
+    // `track` always broadcasts a Session Replay `Track` timeline event and, when
+    // `analytics.trackEvents` is enabled, emits the `track` span. This is why the
+    // Dart side routes mobile track here instead of through `exportSpans`: only
+    // the native track path reaches Session Replay. The bridge owns the
+    // `Map` -> `LDValue` conversion so this plugin stays free of `LDValue`.
+    func track(key: String, data: [String: Any?]?, metricValue: Double?) throws {
+        ObjcLDObserveBridge.track(
+            key: key,
+            data: data.map { cleanAttributes($0) },
+            metricValue: metricValue.map { NSNumber(value: $0) }
+        )
+    }
+
     /// Drops `nil` values so the native bridge receives a `[String: Any]`.
     private func cleanAttributes(_ attributes: [String: Any?]?) -> [String: Any] {
         guard let attributes = attributes else { return [:] }
@@ -131,8 +145,9 @@ final class LDNativeApiImpl: NSObject, LDNativeApi {
         // switches: `instrumentation.userTaps` runs the tap-detection machinery, and
         // `analytics.taps` publishes each detected tap as a `click` span. We drive both from the
         // one Flutter flag so taps are detected (not just published) regardless of the native
-        // `Instrumentation` defaults. pageViews and trackEvents are Android-only and ignored here.
+        // `Instrumentation` defaults. pageViews is Android-only and ignored here.
         let tapsEnabled: Bool = observability.analytics?.taps ?? true
+        let trackEventsEnabled: Bool = observability.analytics?.trackEvents ?? true
         let launchTimesEnabled: Bool = observability.instrumentation?.launchTimes ?? true
         let metricsEnabled: Bool = observability.metricsEnabled ?? true
 
@@ -163,10 +178,12 @@ final class LDNativeApiImpl: NSObject, LDNativeApi {
             cpu: .disabled,
             launchTimes: launchTimesEnabled ? .enabled : .disabled
         )
-        // iOS exposes taps via Analytics; track events are Android-only.
+        // Taps and track events are both published as spans via Analytics. Track
+        // events additionally drive the Session Replay `Track` timeline event,
+        // which the Dart side reaches by calling `track` on this bridge.
         let analytics = ObservabilityOptions.Analytics(
             taps: tapsEnabled ? .enabled : .disabled,
-            trackEvents: .disabled
+            trackEvents: trackEventsEnabled ? .enabled : .disabled
         )
 
         let observabilityOptions = ObservabilityOptions(

--- a/sdk/@launchdarkly/flutter/packages/observability/ios/launchdarkly_flutter_observability/Sources/launchdarkly_flutter_observability/Messages.g.swift
+++ b/sdk/@launchdarkly/flutter/packages/observability/ios/launchdarkly_flutter_observability/Sources/launchdarkly_flutter_observability/Messages.g.swift
@@ -645,8 +645,11 @@ protocol LDNativeApi {
   /// Forwards a custom track event to the native observability SDK so it emits
   /// the native `track` span (gated by `analytics.trackEvents`) and the Session
   /// Replay `Track` timeline event (always). `data` carries the optional event
-  /// payload as a JSON object.
-  func track(key: String, data: [String: Any?]?, metricValue: Double?) throws
+  /// payload as a JSON object. `contextKeys` carries the evaluation context's
+  /// kind -> key pairs (from the LaunchDarkly client's `afterTrack` hook) so the
+  /// native `track` span is attributed to the same context the web SDK records;
+  /// only the span is annotated, not the Session Replay `Track` payload.
+  func track(key: String, data: [String: Any?]?, metricValue: Double?, contextKeys: [String: String]?) throws
 }
 
 /// Generated setup class from Pigeon to handle messages through the `binaryMessenger`.
@@ -712,7 +715,10 @@ class LDNativeApiSetup {
     /// Forwards a custom track event to the native observability SDK so it emits
     /// the native `track` span (gated by `analytics.trackEvents`) and the Session
     /// Replay `Track` timeline event (always). `data` carries the optional event
-    /// payload as a JSON object.
+    /// payload as a JSON object. `contextKeys` carries the evaluation context's
+    /// kind -> key pairs (from the LaunchDarkly client's `afterTrack` hook) so the
+    /// native `track` span is attributed to the same context the web SDK records;
+    /// only the span is annotated, not the Session Replay `Track` payload.
     let trackChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.launchdarkly_flutter_observability.LDNativeApi.track\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
       trackChannel.setMessageHandler { message, reply in
@@ -720,8 +726,9 @@ class LDNativeApiSetup {
         let keyArg = args[0] as! String
         let dataArg: [String: Any?]? = nilOrValue(args[1])
         let metricValueArg: Double? = nilOrValue(args[2])
+        let contextKeysArg: [String: String]? = nilOrValue(args[3])
         do {
-          try api.track(key: keyArg, data: dataArg, metricValue: metricValueArg)
+          try api.track(key: keyArg, data: dataArg, metricValue: metricValueArg, contextKeys: contextKeysArg)
           reply(wrapResult(nil))
         } catch {
           reply(wrapError(error))

--- a/sdk/@launchdarkly/flutter/packages/observability/ios/launchdarkly_flutter_observability/Sources/launchdarkly_flutter_observability/Messages.g.swift
+++ b/sdk/@launchdarkly/flutter/packages/observability/ios/launchdarkly_flutter_observability/Sources/launchdarkly_flutter_observability/Messages.g.swift
@@ -642,6 +642,11 @@ protocol LDNativeApi {
   /// Forwards a Dart log to the native logger so it is emitted as a native
   /// `LogRecord` with `session.id` and trace/span correlation.
   func recordLog(log: LDLogRecord) throws
+  /// Forwards a custom track event to the native observability SDK so it emits
+  /// the native `track` span (gated by `analytics.trackEvents`) and the Session
+  /// Replay `Track` timeline event (always). `data` carries the optional event
+  /// payload as a JSON object.
+  func track(key: String, data: [String: Any?]?, metricValue: Double?) throws
 }
 
 /// Generated setup class from Pigeon to handle messages through the `binaryMessenger`.
@@ -703,6 +708,27 @@ class LDNativeApiSetup {
       }
     } else {
       recordLogChannel.setMessageHandler(nil)
+    }
+    /// Forwards a custom track event to the native observability SDK so it emits
+    /// the native `track` span (gated by `analytics.trackEvents`) and the Session
+    /// Replay `Track` timeline event (always). `data` carries the optional event
+    /// payload as a JSON object.
+    let trackChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.launchdarkly_flutter_observability.LDNativeApi.track\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+    if let api = api {
+      trackChannel.setMessageHandler { message, reply in
+        let args = message as! [Any?]
+        let keyArg = args[0] as! String
+        let dataArg: [String: Any?]? = nilOrValue(args[1])
+        let metricValueArg: Double? = nilOrValue(args[2])
+        do {
+          try api.track(key: keyArg, data: dataArg, metricValue: metricValueArg)
+          reply(wrapResult(nil))
+        } catch {
+          reply(wrapError(error))
+        }
+      }
+    } else {
+      trackChannel.setMessageHandler(nil)
     }
   }
 }

--- a/sdk/@launchdarkly/flutter/packages/observability/lib/src/ld_observe.dart
+++ b/sdk/@launchdarkly/flutter/packages/observability/lib/src/ld_observe.dart
@@ -61,6 +61,16 @@ final class LDObserve {
     Map<String, Attribute>? attributes,
   }) => ObserveOtel.startSpan(name, kind: kind, attributes: attributes);
 
+  /// Record a custom `track` event as a `track` span.
+  ///
+  /// Mirrors `LDClient.track(eventName, {data, metricValue})` so the same call
+  /// shape works whether the event is recorded through the LaunchDarkly client
+  /// (via the `afterTrack` hook) or directly through this API. Use this for
+  /// standalone observability (no LaunchDarkly client) or to record custom
+  /// events that should not also be sent to LaunchDarkly.
+  static void track(String eventName, {LDValue? data, num? metricValue}) =>
+      ObserveOtel.track(eventName, data: data, metricValue: metricValue);
+
   /// Record an exception with an optional stack trace and attributes.
   static void recordException(
     dynamic exception, {

--- a/sdk/@launchdarkly/flutter/packages/observability/lib/src/ld_observe.dart
+++ b/sdk/@launchdarkly/flutter/packages/observability/lib/src/ld_observe.dart
@@ -67,9 +67,18 @@ final class LDObserve {
   /// shape works whether the event is recorded through the LaunchDarkly client
   /// (via the `afterTrack` hook) or directly through this API. Use this for
   /// standalone observability (no LaunchDarkly client) or to record custom
-  /// events that should not also be sent to LaunchDarkly.
-  static void track(String eventName, {LDValue? data, num? metricValue}) =>
-      ObserveOtel.track(eventName, data: data, metricValue: metricValue);
+  /// events that should not also be sent to LaunchDarkly. `data` is a plain JSON
+  /// map so callers need not depend on `LDValue`; object members are attached as
+  /// span attributes.
+  static void track(
+    String eventName, {
+    Map<String, dynamic>? data,
+    num? metricValue,
+  }) => ObserveOtel.track(
+    eventName,
+    data: data == null ? null : LDValue.ofDynamic(data),
+    metricValue: metricValue,
+  );
 
   /// Record an exception with an optional stack trace and attributes.
   static void recordException(

--- a/sdk/@launchdarkly/flutter/packages/observability/lib/src/observe_otel.dart
+++ b/sdk/@launchdarkly/flutter/packages/observability/lib/src/observe_otel.dart
@@ -1,12 +1,15 @@
 import 'dart:async';
 
+import 'package:launchdarkly_flutter_client_sdk/launchdarkly_flutter_client_sdk.dart';
 import 'package:opentelemetry/api.dart' as otel;
 
 import 'api/attribute.dart';
 import 'api/span.dart';
 import 'api/span_kind.dart';
+import 'api/span_status_code.dart';
 import 'otel/conversions.dart';
 import 'otel/setup.dart';
+import 'otel/track_convention.dart';
 import 'plugin/ld_observe_plugin.dart';
 import 'plugin/observability_config.dart';
 
@@ -22,6 +25,11 @@ const _defaultLogLevel = 'info';
 final class ObserveOtel {
   static bool _shutdown = false;
   static final List<LDObservePlugin> _pluginInstances = [];
+
+  /// Whether `track` spans are emitted. Mirrors `analytics.trackEvents`; set
+  /// during plugin registration. Defaults to `true` so manual track calls made
+  /// before registration completes are not dropped.
+  static bool _trackEventsEnabled = true;
 
   /// Start a span with the given name and optional attributes.
   static Span startSpan(
@@ -40,6 +48,34 @@ final class ObserveOtel {
     );
 
     return wrapSpan(span, token);
+  }
+
+  /// Emit a `track` span for a custom event.
+  ///
+  /// The single emitter for both track paths: the LaunchDarkly client's
+  /// `afterTrack` hook (which supplies the evaluation [context]) and the manual
+  /// [LDObserve.track] API (which has no context). Gated by
+  /// `analytics.trackEvents`; mirrors the native iOS/Android track span.
+  static void track(
+    String eventName, {
+    LDValue? data,
+    num? metricValue,
+    LDContext? context,
+  }) {
+    if (!_trackEventsEnabled) {
+      return;
+    }
+    final span = startSpan(
+      TrackConvention.spanName,
+      attributes: TrackConvention.getSpanAttributes(
+        eventName: eventName,
+        data: data,
+        metricValue: metricValue,
+        context: context,
+      ),
+    );
+    span.setStatus(SpanStatusCode.ok);
+    span.end();
   }
 
   /// Record an exception with an optional stack trace and attributes.
@@ -129,5 +165,6 @@ void registerPlugin(
   ObservabilityConfig config,
 ) {
   Otel.setup(credential, config);
+  ObserveOtel._trackEventsEnabled = config.trackEventsEnabled;
   ObserveOtel._pluginInstances.add(plugin);
 }

--- a/sdk/@launchdarkly/flutter/packages/observability/lib/src/observe_otel.dart
+++ b/sdk/@launchdarkly/flutter/packages/observability/lib/src/observe_otel.dart
@@ -6,10 +6,8 @@ import 'package:opentelemetry/api.dart' as otel;
 import 'api/attribute.dart';
 import 'api/span.dart';
 import 'api/span_kind.dart';
-import 'api/span_status_code.dart';
 import 'otel/conversions.dart';
 import 'otel/setup.dart';
-import 'otel/track_convention.dart';
 import 'plugin/ld_observe_plugin.dart';
 import 'plugin/observability_config.dart';
 
@@ -25,11 +23,6 @@ const _defaultLogLevel = 'info';
 final class ObserveOtel {
   static bool _shutdown = false;
   static final List<LDObservePlugin> _pluginInstances = [];
-
-  /// Whether `track` spans are emitted. Mirrors `analytics.trackEvents`; set
-  /// during plugin registration. Defaults to `true` so manual track calls made
-  /// before registration completes are not dropped.
-  static bool _trackEventsEnabled = true;
 
   /// Start a span with the given name and optional attributes.
   static Span startSpan(
@@ -50,32 +43,28 @@ final class ObserveOtel {
     return wrapSpan(span, token);
   }
 
-  /// Emit a `track` span for a custom event.
+  /// Record a `track` event for a custom event.
   ///
-  /// The single emitter for both track paths: the LaunchDarkly client's
+  /// The single entry point for both track paths: the LaunchDarkly client's
   /// `afterTrack` hook (which supplies the evaluation [context]) and the manual
-  /// [LDObserve.track] API (which has no context). Gated by
-  /// `analytics.trackEvents`; mirrors the native iOS/Android track span.
+  /// [LDObserve.track] API (which has no context). Delegates to the
+  /// platform-appropriate recorder: on web a Dart `track` span is emitted; on
+  /// mobile the native observability SDK is invoked so it emits the native
+  /// `track` span (gated by `analytics.trackEvents`) and the Session Replay
+  /// `Track` timeline event. `null` before the pipeline is initialized, in which
+  /// case the event is dropped.
   static void track(
     String eventName, {
     LDValue? data,
     num? metricValue,
     LDContext? context,
   }) {
-    if (!_trackEventsEnabled) {
-      return;
-    }
-    final span = startSpan(
-      TrackConvention.spanName,
-      attributes: TrackConvention.getSpanAttributes(
-        eventName: eventName,
-        data: data,
-        metricValue: metricValue,
-        context: context,
-      ),
+    Otel.trackRecorder?.track(
+      eventName,
+      data: data,
+      metricValue: metricValue,
+      context: context,
     );
-    span.setStatus(SpanStatusCode.ok);
-    span.end();
   }
 
   /// Record an exception with an optional stack trace and attributes.
@@ -165,6 +154,5 @@ void registerPlugin(
   ObservabilityConfig config,
 ) {
   Otel.setup(credential, config);
-  ObserveOtel._trackEventsEnabled = config.trackEventsEnabled;
   ObserveOtel._pluginInstances.add(plugin);
 }

--- a/sdk/@launchdarkly/flutter/packages/observability/lib/src/options/observability_options.dart
+++ b/sdk/@launchdarkly/flutter/packages/observability/lib/src/options/observability_options.dart
@@ -88,9 +88,10 @@ class InstrumentationOptions {
 /// Analytics telemetry emitted as OpenTelemetry spans. Mirrors Android
 /// `ObservabilityOptions.Analytics`.
 ///
-/// Native-only. [taps] maps to the native `analytics.taps` publish gate on both
-/// iOS and Android; [pageViews] and [trackEvents] are Android-only and are
-/// no-ops elsewhere.
+/// [taps] maps to the native `analytics.taps` publish gate on both iOS and
+/// Android; [pageViews] is Android-only and a no-op elsewhere. [trackEvents]
+/// gates the `track` span emitted by the cross-platform Dart pipeline (web and
+/// mobile) as well as the native Android span.
 class AnalyticsOptions {
   /// Whether to publish a `click` span for each detected tap. Tap detection is
   /// always enabled on the native side (`instrumentation.userTaps`); this flag
@@ -101,8 +102,9 @@ class AnalyticsOptions {
   /// Defaults to `true`.
   final bool pageViews;
 
-  /// Whether to emit a `launchdarkly.track` span when a custom event is tracked.
-  /// Android-only. Defaults to `true`.
+  /// Whether to emit a `track` span when a custom event is tracked, either
+  /// through the LaunchDarkly client's `afterTrack` hook or the manual
+  /// `LDObserve.track` API. Defaults to `true`.
   final bool trackEvents;
 
   const AnalyticsOptions({

--- a/sdk/@launchdarkly/flutter/packages/observability/lib/src/otel/exporters/exporter_factory.dart
+++ b/sdk/@launchdarkly/flutter/packages/observability/lib/src/otel/exporters/exporter_factory.dart
@@ -8,6 +8,7 @@
 // standalone Android/iOS SDKs. On web, the Dart OpenTelemetry pipeline is used
 // directly.
 
+import 'package:launchdarkly_flutter_client_sdk/launchdarkly_flutter_client_sdk.dart';
 import 'package:opentelemetry/sdk.dart' show SpanProcessor;
 
 import '../../api/attribute.dart';
@@ -37,6 +38,23 @@ abstract interface class LogRecorder {
   });
 }
 
+/// Records a custom `track` event through the platform-appropriate pipeline.
+///
+/// - Web: emitted as a Dart `track` span via `TrackConvention`, gated by
+///   `analytics.trackEvents`.
+/// - Native (io): forwarded to the native observability SDK so it emits the
+///   native `track` span (gated natively) and the Session Replay `Track`
+///   timeline event (always). The Dart span is intentionally not emitted on
+///   mobile, so `track` is not double-counted.
+abstract interface class TrackRecorder {
+  void track(
+    String eventName, {
+    LDValue? data,
+    num? metricValue,
+    LDContext? context,
+  });
+}
+
 /// Factory for the span and log exporters used by the observability pipeline.
 ///
 /// The concrete implementation is selected per build target via conditional
@@ -50,4 +68,7 @@ abstract interface class ObservabilityExporters {
 
   /// Builds the log recorder used by `recordLog`.
   LogRecorder createLogRecorder(ObservabilityConfig config);
+
+  /// Builds the track recorder used by `track`.
+  TrackRecorder createTrackRecorder(ObservabilityConfig config);
 }

--- a/sdk/@launchdarkly/flutter/packages/observability/lib/src/otel/exporters/exporter_factory_io.dart
+++ b/sdk/@launchdarkly/flutter/packages/observability/lib/src/otel/exporters/exporter_factory_io.dart
@@ -54,15 +54,21 @@ class _NativeTrackRecorder implements TrackRecorder {
   }) {
     // Reuse the SDK's canonical `LDValue` -> JSON transformation. Only object
     // payloads carry `track` attributes natively, so non-object payloads map to
-    // `null`. `context` is omitted: the native `LDObserve.track` API takes no
-    // context; native track events are correlated with the native session
-    // pipeline.
+    // `null`.
     final dynamic json = data?.toDynamic();
+    // Forward the evaluation context's kind -> key pairs so the native `track`
+    // span is attributed to the same context the web SDK records (the native
+    // LaunchDarkly client only holds an anonymous bootstrap context). `null` for
+    // the manual `LDObserve.track` path, which has no context.
+    final Map<String, String>? contextKeys = (context != null && context.valid)
+        ? context.keys
+        : null;
     unawaited(
       _api.track(
         eventName,
         json is Map ? Map<String, Object?>.from(json) : null,
         metricValue?.toDouble(),
+        contextKeys,
       ),
     );
   }

--- a/sdk/@launchdarkly/flutter/packages/observability/lib/src/otel/exporters/exporter_factory_io.dart
+++ b/sdk/@launchdarkly/flutter/packages/observability/lib/src/otel/exporters/exporter_factory_io.dart
@@ -6,6 +6,7 @@
 
 import 'dart:async';
 
+import 'package:launchdarkly_flutter_client_sdk/launchdarkly_flutter_client_sdk.dart';
 import 'package:opentelemetry/api.dart' as otel;
 import 'package:opentelemetry/sdk.dart'
     show BatchSpanProcessor, ReadOnlySpan, SpanExporter, SpanProcessor;
@@ -29,6 +30,42 @@ class _IoExporters implements ObservabilityExporters {
   @override
   LogRecorder createLogRecorder(ObservabilityConfig config) =>
       _NativeLogRecorder(_api);
+
+  @override
+  TrackRecorder createTrackRecorder(ObservabilityConfig config) =>
+      _NativeTrackRecorder(_api);
+}
+
+/// Forwards each `track` call to the native observability SDK so it emits the
+/// native `track` span (gated natively by `analytics.trackEvents`) and the
+/// Session Replay `Track` timeline event (always). The Dart span pipeline is
+/// intentionally bypassed for track on mobile so the event is not emitted twice.
+class _NativeTrackRecorder implements TrackRecorder {
+  _NativeTrackRecorder(this._api);
+
+  final wire.LDNativeApi _api;
+
+  @override
+  void track(
+    String eventName, {
+    LDValue? data,
+    num? metricValue,
+    LDContext? context,
+  }) {
+    // Reuse the SDK's canonical `LDValue` -> JSON transformation. Only object
+    // payloads carry `track` attributes natively, so non-object payloads map to
+    // `null`. `context` is omitted: the native `LDObserve.track` API takes no
+    // context; native track events are correlated with the native session
+    // pipeline.
+    final dynamic json = data?.toDynamic();
+    unawaited(
+      _api.track(
+        eventName,
+        json is Map ? Map<String, Object?>.from(json) : null,
+        metricValue?.toDouble(),
+      ),
+    );
+  }
 }
 
 /// Converts each completed Dart span into the pigeon wire type and forwards it

--- a/sdk/@launchdarkly/flutter/packages/observability/lib/src/otel/exporters/exporter_factory_stub.dart
+++ b/sdk/@launchdarkly/flutter/packages/observability/lib/src/otel/exporters/exporter_factory_stub.dart
@@ -2,6 +2,7 @@
 // There is no native bridge on such targets, so the cross-platform Dart
 // OpenTelemetry pipeline is used: spans over OTLP/HTTP and logs as span events.
 
+import 'package:launchdarkly_flutter_client_sdk/launchdarkly_flutter_client_sdk.dart';
 import 'package:opentelemetry/api.dart' as otel;
 import 'package:opentelemetry/sdk.dart'
     show BatchSpanProcessor, CollectorExporter, SpanProcessor;
@@ -10,6 +11,7 @@ import '../../api/attribute.dart';
 import '../../plugin/observability_config.dart';
 import '../conversions.dart';
 import '../log_convention.dart';
+import '../track_convention.dart';
 import 'exporter_factory.dart';
 
 const _tracesSuffix = '/v1/traces';
@@ -28,6 +30,44 @@ class _StubExporters implements ObservabilityExporters {
   @override
   LogRecorder createLogRecorder(ObservabilityConfig config) =>
       _SpanEventLogRecorder();
+
+  @override
+  TrackRecorder createTrackRecorder(ObservabilityConfig config) =>
+      _SpanTrackRecorder(config.trackEventsEnabled);
+}
+
+/// Emits each `track` event as a Dart `track` span via the OpenTelemetry
+/// pipeline. Gated by `analytics.trackEvents`.
+class _SpanTrackRecorder implements TrackRecorder {
+  _SpanTrackRecorder(this._trackEventsEnabled);
+
+  final bool _trackEventsEnabled;
+
+  @override
+  void track(
+    String eventName, {
+    LDValue? data,
+    num? metricValue,
+    LDContext? context,
+  }) {
+    if (!_trackEventsEnabled) {
+      return;
+    }
+    final tracer = otel.globalTracerProvider.getTracer(_tracerName);
+    final span = tracer.startSpan(
+      TrackConvention.spanName,
+      attributes: convertAttributes(
+        TrackConvention.getSpanAttributes(
+          eventName: eventName,
+          data: data,
+          metricValue: metricValue,
+          context: context,
+        ),
+      ),
+    );
+    span.setStatus(otel.StatusCode.ok);
+    span.end();
+  }
 }
 
 class _SpanEventLogRecorder implements LogRecorder {

--- a/sdk/@launchdarkly/flutter/packages/observability/lib/src/otel/exporters/exporter_factory_web.dart
+++ b/sdk/@launchdarkly/flutter/packages/observability/lib/src/otel/exporters/exporter_factory_web.dart
@@ -3,6 +3,7 @@
 // [CollectorExporter], and logs are emitted as span events (the Dart pipeline
 // has no standalone logs exporter). This preserves the pre-existing behaviour.
 
+import 'package:launchdarkly_flutter_client_sdk/launchdarkly_flutter_client_sdk.dart';
 import 'package:opentelemetry/api.dart' as otel;
 import 'package:opentelemetry/sdk.dart'
     show BatchSpanProcessor, CollectorExporter, SpanProcessor;
@@ -11,6 +12,7 @@ import '../../api/attribute.dart';
 import '../../plugin/observability_config.dart';
 import '../conversions.dart';
 import '../log_convention.dart';
+import '../track_convention.dart';
 import 'exporter_factory.dart';
 
 const _tracesSuffix = '/v1/traces';
@@ -29,6 +31,44 @@ class _WebExporters implements ObservabilityExporters {
   @override
   LogRecorder createLogRecorder(ObservabilityConfig config) =>
       _SpanEventLogRecorder();
+
+  @override
+  TrackRecorder createTrackRecorder(ObservabilityConfig config) =>
+      _SpanTrackRecorder(config.trackEventsEnabled);
+}
+
+/// Emits each `track` event as a Dart `track` span via the OpenTelemetry
+/// pipeline. Gated by `analytics.trackEvents`.
+class _SpanTrackRecorder implements TrackRecorder {
+  _SpanTrackRecorder(this._trackEventsEnabled);
+
+  final bool _trackEventsEnabled;
+
+  @override
+  void track(
+    String eventName, {
+    LDValue? data,
+    num? metricValue,
+    LDContext? context,
+  }) {
+    if (!_trackEventsEnabled) {
+      return;
+    }
+    final tracer = otel.globalTracerProvider.getTracer(_tracerName);
+    final span = tracer.startSpan(
+      TrackConvention.spanName,
+      attributes: convertAttributes(
+        TrackConvention.getSpanAttributes(
+          eventName: eventName,
+          data: data,
+          metricValue: metricValue,
+          context: context,
+        ),
+      ),
+    );
+    span.setStatus(otel.StatusCode.ok);
+    span.end();
+  }
 }
 
 /// Emits each log as an event on a short-lived span, parented to the active

--- a/sdk/@launchdarkly/flutter/packages/observability/lib/src/otel/setup.dart
+++ b/sdk/@launchdarkly/flutter/packages/observability/lib/src/otel/setup.dart
@@ -16,6 +16,11 @@ class Otel {
   static LogRecorder? _logRecorder;
   static LogRecorder? get logRecorder => _logRecorder;
 
+  /// The platform-appropriate track recorder, set during [setup]. `null` before
+  /// the pipeline is initialized.
+  static TrackRecorder? _trackRecorder;
+  static TrackRecorder? get trackRecorder => _trackRecorder;
+
   static void setup(String sdkKey, ObservabilityConfig config) {
     // TODO: Log when otel is setup multiple times. It will work, but the
     // behavior may be confusing.
@@ -43,6 +48,7 @@ class Otel {
     registerGlobalTracerProvider(tracerProvider);
 
     _logRecorder = exporters.createLogRecorder(config);
+    _trackRecorder = exporters.createTrackRecorder(config);
   }
 
   static void shutdown() {
@@ -51,5 +57,6 @@ class Otel {
     }
     _tracerProviders.clear();
     _logRecorder = null;
+    _trackRecorder = null;
   }
 }

--- a/sdk/@launchdarkly/flutter/packages/observability/lib/src/otel/track_convention.dart
+++ b/sdk/@launchdarkly/flutter/packages/observability/lib/src/otel/track_convention.dart
@@ -1,0 +1,118 @@
+import 'package:launchdarkly_flutter_client_sdk/launchdarkly_flutter_client_sdk.dart';
+
+import '../api/attribute.dart';
+
+/// Semantic convention for custom `track` events.
+///
+/// Mirrors the native iOS/Android observability SDKs, which emit a span named
+/// `track` carrying the event key under the reserved `key` attribute and the
+/// optional numeric metric value under `value`. User-supplied `data` members
+/// and the context kind/key pairs are attached as additional attributes.
+class TrackConvention {
+  /// The name used for the track span. Matches the native iOS/Android exporters
+  /// (`SemanticConvention.trackSpanName = "track"`).
+  static const spanName = 'track';
+
+  /// Reserved attribute carrying the track event key.
+  static const keyAttr = 'key';
+
+  /// Reserved attribute carrying the numeric metric value, when present.
+  static const valueAttr = 'value';
+
+  /// Builds the span attributes for a track event.
+  ///
+  /// Applied in increasing precedence so the reserved keys can never be
+  /// clobbered by user-supplied [data]: user data first, then the context
+  /// kind/key pairs, then the reserved `key`/`value` last (matching the native
+  /// track path).
+  static Map<String, Attribute> getSpanAttributes({
+    required String eventName,
+    LDValue? data,
+    num? metricValue,
+    LDContext? context,
+  }) {
+    final attributes = <String, Attribute>{};
+
+    if (data != null) {
+      attributes.addAll(_attributesFromData(data));
+    }
+
+    if (context != null && context.valid) {
+      context.keys.forEach((kind, key) {
+        attributes[kind] = StringAttribute(key);
+      });
+    }
+
+    attributes[keyAttr] = StringAttribute(eventName);
+    if (metricValue != null) {
+      attributes[valueAttr] = DoubleAttribute(metricValue.toDouble());
+    }
+
+    return attributes;
+  }
+
+  /// Flattens an object [data] payload into a flat attribute map.
+  ///
+  /// Mirrors the native `LDValue.toAttributes()`: only object payloads
+  /// contribute members; scalar and array payloads contribute nothing. Members
+  /// that cannot be represented as an OpenTelemetry attribute (nested objects,
+  /// heterogeneous arrays) are skipped.
+  static Map<String, Attribute> _attributesFromData(LDValue data) {
+    if (data.type != LDValueType.object) {
+      return const {};
+    }
+    final attributes = <String, Attribute>{};
+    for (final key in data.keys) {
+      final attribute = _attributeFromValue(data.getFor(key));
+      if (attribute != null) {
+        attributes[key] = attribute;
+      }
+    }
+    return attributes;
+  }
+
+  static Attribute? _attributeFromValue(LDValue value) {
+    switch (value.type) {
+      case LDValueType.boolean:
+        return BooleanAttribute(value.booleanValue());
+      case LDValueType.number:
+        return DoubleAttribute(value.doubleValue());
+      case LDValueType.string:
+        return StringAttribute(value.stringValue());
+      case LDValueType.array:
+        return _attributeFromArray(value);
+      case LDValueType.object:
+      case LDValueType.nullType:
+        return null;
+    }
+  }
+
+  static Attribute? _attributeFromArray(LDValue value) {
+    final values = value.values.toList(growable: false);
+    if (values.isEmpty) {
+      return null;
+    }
+    final elementType = values.first.type;
+    if (!values.every((v) => v.type == elementType)) {
+      return null;
+    }
+    switch (elementType) {
+      case LDValueType.boolean:
+        return BooleanListAttribute(
+          values.map((v) => v.booleanValue()).toList(growable: false),
+        );
+      case LDValueType.number:
+        return DoubleListAttribute(
+          values.map((v) => v.doubleValue()).toList(growable: false),
+        );
+      case LDValueType.string:
+        return StringListAttribute(
+          values.map((v) => v.stringValue()).toList(growable: false),
+        );
+      case LDValueType.array:
+      case LDValueType.object:
+      case LDValueType.nullType:
+        return null;
+    }
+  }
+}

--- a/sdk/@launchdarkly/flutter/packages/observability/lib/src/platform/io/messages.g.dart
+++ b/sdk/@launchdarkly/flutter/packages/observability/lib/src/platform/io/messages.g.dart
@@ -798,4 +798,39 @@ class LDNativeApi {
       return;
     }
   }
+
+  /// Forwards a custom track event to the native observability SDK so it emits
+  /// the native `track` span (gated by `analytics.trackEvents`) and the Session
+  /// Replay `Track` timeline event (always). `data` carries the optional event
+  /// payload as a JSON object.
+  Future<void> track(
+    String key,
+    Map<String, Object?>? data,
+    double? metricValue,
+  ) async {
+    final String pigeonVar_channelName =
+        'dev.flutter.pigeon.launchdarkly_flutter_observability.LDNativeApi.track$pigeonVar_messageChannelSuffix';
+    final BasicMessageChannel<Object?> pigeonVar_channel =
+        BasicMessageChannel<Object?>(
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
+      <Object?>[key, data, metricValue],
+    );
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_sendFuture as List<Object?>?;
+    if (pigeonVar_replyList == null) {
+      throw _createConnectionError(pigeonVar_channelName);
+    } else if (pigeonVar_replyList.length > 1) {
+      throw PlatformException(
+        code: pigeonVar_replyList[0]! as String,
+        message: pigeonVar_replyList[1] as String?,
+        details: pigeonVar_replyList[2],
+      );
+    } else {
+      return;
+    }
+  }
 }

--- a/sdk/@launchdarkly/flutter/packages/observability/lib/src/platform/io/messages.g.dart
+++ b/sdk/@launchdarkly/flutter/packages/observability/lib/src/platform/io/messages.g.dart
@@ -802,11 +802,15 @@ class LDNativeApi {
   /// Forwards a custom track event to the native observability SDK so it emits
   /// the native `track` span (gated by `analytics.trackEvents`) and the Session
   /// Replay `Track` timeline event (always). `data` carries the optional event
-  /// payload as a JSON object.
+  /// payload as a JSON object. `contextKeys` carries the evaluation context's
+  /// kind -> key pairs (from the LaunchDarkly client's `afterTrack` hook) so the
+  /// native `track` span is attributed to the same context the web SDK records;
+  /// only the span is annotated, not the Session Replay `Track` payload.
   Future<void> track(
     String key,
     Map<String, Object?>? data,
     double? metricValue,
+    Map<String, String>? contextKeys,
   ) async {
     final String pigeonVar_channelName =
         'dev.flutter.pigeon.launchdarkly_flutter_observability.LDNativeApi.track$pigeonVar_messageChannelSuffix';
@@ -817,7 +821,7 @@ class LDNativeApi {
           binaryMessenger: pigeonVar_binaryMessenger,
         );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[key, data, metricValue],
+      <Object?>[key, data, metricValue, contextKeys],
     );
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_sendFuture as List<Object?>?;

--- a/sdk/@launchdarkly/flutter/packages/observability/lib/src/plugin/ld_observe_plugin.dart
+++ b/sdk/@launchdarkly/flutter/packages/observability/lib/src/plugin/ld_observe_plugin.dart
@@ -76,6 +76,18 @@ final class _ObservabilityHook extends Hook {
     }
     return data;
   }
+
+  @override
+  void afterTrack(TrackSeriesContext hookContext) {
+    // Funnel through the single track emitter so the LaunchDarkly client's
+    // track path and the manual LDObserve.track API stay consistent.
+    ObserveOtel.track(
+      hookContext.key,
+      data: hookContext.data,
+      metricValue: hookContext.numericValue,
+      context: hookContext.context,
+    );
+  }
 }
 
 /// Internal LaunchDarkly plugin that wires up the cross-platform Dart

--- a/sdk/@launchdarkly/flutter/packages/observability/lib/src/plugin/observability_config.dart
+++ b/sdk/@launchdarkly/flutter/packages/observability/lib/src/plugin/observability_config.dart
@@ -109,6 +109,12 @@ final class ObservabilityConfig {
   /// Configuration of instrumentations.
   final InstrumentationConfig instrumentationConfig;
 
+  /// Whether a `track` span is emitted when a custom event is tracked (either
+  /// through the LaunchDarkly client's `afterTrack` hook or the manual
+  /// [LDObserve.track] API). Mirrors `analytics.trackEvents`. Defaults to
+  /// `true`.
+  final bool trackEventsEnabled;
+
   ObservabilityConfig({
     this.applicationName,
     this.applicationVersion,
@@ -116,6 +122,7 @@ final class ObservabilityConfig {
     required this.backendUrl,
     required this.instrumentationConfig,
     this.contextFriendlyName,
+    this.trackEventsEnabled = true,
   });
 }
 
@@ -150,5 +157,6 @@ ObservabilityConfig configFromOptions(ObservabilityOptions options) {
     instrumentationConfig: InstrumentationConfig(
       debugPrint: options.instrumentation.debugPrint,
     ),
+    trackEventsEnabled: options.analytics.trackEvents,
   );
 }

--- a/sdk/@launchdarkly/flutter/packages/observability/pigeons/messages.dart
+++ b/sdk/@launchdarkly/flutter/packages/observability/pigeons/messages.dart
@@ -145,4 +145,10 @@ abstract class LDNativeApi {
   /// Forwards a Dart log to the native logger so it is emitted as a native
   /// `LogRecord` with `session.id` and trace/span correlation.
   void recordLog(LDLogRecord log);
+
+  /// Forwards a custom track event to the native observability SDK so it emits
+  /// the native `track` span (gated by `analytics.trackEvents`) and the Session
+  /// Replay `Track` timeline event (always). `data` carries the optional event
+  /// payload as a JSON object.
+  void track(String key, Map<String, Object?>? data, double? metricValue);
 }

--- a/sdk/@launchdarkly/flutter/packages/observability/pigeons/messages.dart
+++ b/sdk/@launchdarkly/flutter/packages/observability/pigeons/messages.dart
@@ -149,6 +149,14 @@ abstract class LDNativeApi {
   /// Forwards a custom track event to the native observability SDK so it emits
   /// the native `track` span (gated by `analytics.trackEvents`) and the Session
   /// Replay `Track` timeline event (always). `data` carries the optional event
-  /// payload as a JSON object.
-  void track(String key, Map<String, Object?>? data, double? metricValue);
+  /// payload as a JSON object. `contextKeys` carries the evaluation context's
+  /// kind -> key pairs (from the LaunchDarkly client's `afterTrack` hook) so the
+  /// native `track` span is attributed to the same context the web SDK records;
+  /// only the span is annotated, not the Session Replay `Track` payload.
+  void track(
+    String key,
+    Map<String, Object?>? data,
+    double? metricValue,
+    Map<String, String>? contextKeys,
+  );
 }

--- a/sdk/@launchdarkly/flutter/packages/observability/test/track_convention_test.dart
+++ b/sdk/@launchdarkly/flutter/packages/observability/test/track_convention_test.dart
@@ -1,0 +1,181 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:launchdarkly_flutter_client_sdk/launchdarkly_flutter_client_sdk.dart';
+
+import 'package:launchdarkly_flutter_observability/src/api/attribute.dart';
+import 'package:launchdarkly_flutter_observability/src/otel/track_convention.dart';
+
+Matcher matchesAttribute(String key, dynamic value) {
+  return predicate<MapEntry<String, Attribute>>((entry) {
+    if (entry.key != key) return false;
+    final attr = entry.value;
+    return switch (attr) {
+      StringAttribute() => attr.value == value,
+      IntAttribute() => attr.value == value,
+      BooleanAttribute() => attr.value == value,
+      DoubleAttribute() => attr.value == value,
+      _ => false,
+    };
+  }, 'has key "$key" and value "$value"');
+}
+
+void main() {
+  test('uses the native "track" span name', () {
+    expect(TrackConvention.spanName, equals('track'));
+  });
+
+  test('includes the event key with no data or metric value', () {
+    final attributes = TrackConvention.getSpanAttributes(eventName: 'checkout');
+
+    expect(attributes.length, equals(1));
+    expect(attributes.entries, contains(matchesAttribute('key', 'checkout')));
+  });
+
+  test('includes the numeric metric value as a double', () {
+    final attributes = TrackConvention.getSpanAttributes(
+      eventName: 'purchase',
+      metricValue: 42,
+    );
+
+    expect(
+      attributes.entries,
+      containsAll([
+        matchesAttribute('key', 'purchase'),
+        matchesAttribute('value', 42.0),
+      ]),
+    );
+  });
+
+  test('omits the metric value when null', () {
+    final attributes = TrackConvention.getSpanAttributes(eventName: 'purchase');
+
+    expect(attributes['value'], isNull);
+  });
+
+  test('flattens scalar members of object data', () {
+    final data = LDValue.buildObject()
+        .addValue('plan', LDValue.ofString('pro'))
+        .addValue('count', LDValue.ofNum(3))
+        .addValue('trial', LDValue.ofBool(true))
+        .build();
+
+    final attributes = TrackConvention.getSpanAttributes(
+      eventName: 'subscribe',
+      data: data,
+    );
+
+    expect(
+      attributes.entries,
+      containsAll([
+        matchesAttribute('plan', 'pro'),
+        matchesAttribute('count', 3.0),
+        matchesAttribute('trial', true),
+        matchesAttribute('key', 'subscribe'),
+      ]),
+    );
+  });
+
+  test('flattens homogeneous array members of object data', () {
+    final data = LDValue.buildObject()
+        .addValue(
+          'tags',
+          LDValue.buildArray()
+              .addValue(LDValue.ofString('a'))
+              .addValue(LDValue.ofString('b'))
+              .build(),
+        )
+        .build();
+
+    final attributes = TrackConvention.getSpanAttributes(
+      eventName: 'tagged',
+      data: data,
+    );
+
+    final tags = attributes['tags'];
+    expect(tags, isA<StringListAttribute>());
+    expect((tags as StringListAttribute).value, equals(['a', 'b']));
+  });
+
+  test('skips members that cannot be represented as attributes', () {
+    final data = LDValue.buildObject()
+        .addValue(
+          'nested',
+          LDValue.buildObject()
+              .addValue('inner', LDValue.ofString('x'))
+              .build(),
+        )
+        .addValue(
+          'mixed',
+          LDValue.buildArray()
+              .addValue(LDValue.ofString('a'))
+              .addValue(LDValue.ofNum(1))
+              .build(),
+        )
+        .build();
+
+    final attributes = TrackConvention.getSpanAttributes(
+      eventName: 'edge',
+      data: data,
+    );
+
+    expect(attributes['nested'], isNull);
+    expect(attributes['mixed'], isNull);
+    expect(attributes.entries, contains(matchesAttribute('key', 'edge')));
+  });
+
+  test('ignores non-object data payloads', () {
+    final attributes = TrackConvention.getSpanAttributes(
+      eventName: 'scalar',
+      data: LDValue.ofString('not-an-object'),
+    );
+
+    expect(attributes.length, equals(1));
+    expect(attributes.entries, contains(matchesAttribute('key', 'scalar')));
+  });
+
+  test('includes context kind/key pairs for a valid context', () {
+    final context = LDContextBuilder()
+        .kind('user', 'user-key')
+        .kind('org', 'org-key')
+        .build();
+
+    final attributes = TrackConvention.getSpanAttributes(
+      eventName: 'evt',
+      context: context,
+    );
+
+    expect(
+      attributes.entries,
+      containsAll([
+        matchesAttribute('user', 'user-key'),
+        matchesAttribute('org', 'org-key'),
+      ]),
+    );
+  });
+
+  test('excludes context keys when the context is invalid', () {
+    final invalidContext = LDContextBuilder().kind('user', '').build();
+
+    final attributes = TrackConvention.getSpanAttributes(
+      eventName: 'evt',
+      context: invalidContext,
+    );
+
+    expect(attributes['user'], isNull);
+  });
+
+  test('reserved key/value take precedence over user data', () {
+    final data = LDValue.buildObject()
+        .addValue('key', LDValue.ofString('should-not-win'))
+        .addValue('value', LDValue.ofString('should-not-win'))
+        .build();
+
+    final attributes = TrackConvention.getSpanAttributes(
+      eventName: 'evt',
+      data: data,
+      metricValue: 5,
+    );
+
+    expect(attributes.entries, contains(matchesAttribute('key', 'evt')));
+    expect(attributes.entries, contains(matchesAttribute('value', 5.0)));
+  });
+}

--- a/sdk/@launchdarkly/observability-android/README.md
+++ b/sdk/@launchdarkly/observability-android/README.md
@@ -342,13 +342,13 @@ LDObserve.recordIncr(Metric("page_views", 1.0))
 LDObserve.recordHistogram(Metric("response_time", 150.0))
 LDObserve.recordUpDownCounter(Metric("active_connections", 1.0))
 
-// Record logs
+// Record logs — pass attributes as a plain map via `properties`.
 LDObserve.recordLog(
     "User performed action",
     Severity.INFO,
-    Attributes.of(
-        AttributeKey.stringKey("user_id"), "12345",
-        AttributeKey.stringKey("action"), "button_click"
+    properties = mapOf(
+        "user_id" to "12345",
+        "action" to "button_click"
     )
 )
 
@@ -364,9 +364,9 @@ LDObserve.recordError(
 // Create spans for tracing
 val span = LDObserve.startSpan(
     "api_request",
-    Attributes.of(
-        AttributeKey.stringKey("endpoint"), "/api/users",
-        AttributeKey.stringKey("method"), "GET"
+    properties = mapOf(
+        "endpoint" to "/api/users",
+        "method" to "GET"
     )
 )
 span.makeCurrent().use {
@@ -378,7 +378,7 @@ span.end()
 // (Calling LDClient.track(...) records the same span automatically via the afterTrack hook.)
 LDObserve.track(
     "checkout_completed",
-    data = mapOf("currency" to "USD"),
+    properties = mapOf("currency" to "USD"),
     metricValue = 42.0
 )
 
@@ -387,9 +387,18 @@ LDObserve.track(
 LDObserve.trackScreenView(
     name = "Profile",
     screenClass = "ProfileFragment",
-    category = "Account"
+    category = "Account",
+    properties = mapOf("tab" to "overview")
 )
 ```
+
+`recordLog`, `startSpan`, `track`, and `trackScreenView` accept attributes/data as a
+plain Kotlin map via the `properties` parameter — pass `String`, `Boolean`, `Int`,
+`Long`, `Double`, lists, and nested maps directly, with no need to build OpenTelemetry
+`Attributes`. The `Attributes` overloads remain available when you need precise
+OpenTelemetry typing (as shown for `recordError` above). For `trackScreenView`, custom
+properties are applied at lower precedence than the reserved `event.*` taxonomy fields,
+so they can never clobber them.
 
 ### Session Replay
 

--- a/sdk/@launchdarkly/observability-android/README.md
+++ b/sdk/@launchdarkly/observability-android/README.md
@@ -378,10 +378,8 @@ span.end()
 // (Calling LDClient.track(...) records the same span automatically via the afterTrack hook.)
 LDObserve.track(
     "checkout_completed",
-    value = 42.0,
-    attributes = Attributes.of(
-        AttributeKey.stringKey("currency"), "USD"
-    )
+    data = mapOf("currency" to "USD"),
+    metricValue = 42.0
 )
 
 // Record a `screen_view` span for screens not backed by a distinct Activity

--- a/sdk/@launchdarkly/observability-android/lib/build.gradle.kts
+++ b/sdk/@launchdarkly/observability-android/lib/build.gradle.kts
@@ -56,10 +56,10 @@ configurations.all {
 
 dependencies {
     if (isClientSdkProvidedByHost) {
-        compileOnly("com.launchdarkly:launchdarkly-android-client-sdk:5.12.2")
-        testImplementation("com.launchdarkly:launchdarkly-android-client-sdk:5.12.2")
+        compileOnly("com.launchdarkly:launchdarkly-android-client-sdk:5.13.1")
+        testImplementation("com.launchdarkly:launchdarkly-android-client-sdk:5.13.1")
     } else {
-        implementation("com.launchdarkly:launchdarkly-android-client-sdk:5.12.2")
+        implementation("com.launchdarkly:launchdarkly-android-client-sdk:5.13.1")
     }
 
     // AndroidX

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/bridge/LDObserveBridge.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/bridge/LDObserveBridge.kt
@@ -50,7 +50,7 @@ object LDObserveBridge {
         service.track(
             key,
             metricValue,
-            data?.toAttributes() ?: Attributes.empty(),
+            data?.toOtelAttributes() ?: Attributes.empty(),
             contextKeyBuilder.build(),
         )
     }

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/bridge/LDObserveBridge.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/bridge/LDObserveBridge.kt
@@ -16,4 +16,15 @@ object LDObserveBridge {
             KotlinLogger(internalLogger = it.getLogger(), customerLogger = it)
         }
     }
+
+    /**
+     * Records a custom `track` event. Always broadcasts a Session Replay `Track`
+     * timeline event and, when `analytics.trackEvents` is enabled, emits the
+     * `track` span. [data] carries the optional event payload as a plain map
+     * (e.g. across the Flutter pigeon bridge), so callers need not depend on the
+     * LaunchDarkly model types.
+     */
+    fun track(key: String, data: Map<String, Any?>?, metricValue: Double?) {
+        LDObserve.track(key, data, metricValue)
+    }
 }

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/bridge/LDObserveBridge.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/bridge/LDObserveBridge.kt
@@ -50,7 +50,7 @@ object LDObserveBridge {
         service.track(
             key,
             metricValue,
-            data?.toLDValue()?.toAttributes() ?: Attributes.empty(),
+            data?.toAttributes() ?: Attributes.empty(),
             contextKeyBuilder.build(),
         )
     }

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/bridge/LDObserveBridge.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/bridge/LDObserveBridge.kt
@@ -1,6 +1,8 @@
 package com.launchdarkly.observability.bridge
 
 import com.launchdarkly.observability.sdk.LDObserve
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.api.common.Attributes
 
 object LDObserveBridge {
     fun getObservabilityHookProxy(): ObservabilityHookProxy? {
@@ -22,9 +24,34 @@ object LDObserveBridge {
      * timeline event and, when `analytics.trackEvents` is enabled, emits the
      * `track` span. [data] carries the optional event payload as a plain map
      * (e.g. across the Flutter pigeon bridge), so callers need not depend on the
-     * LaunchDarkly model types.
+     * LaunchDarkly model types. [contextKeys] carries the evaluation context's
+     * kind -> key pairs; when supplied they annotate the `track` span (not the
+     * Session Replay `Track` payload), so hosts whose LaunchDarkly client lives
+     * outside this SDK (e.g. Flutter) can attribute the span to the same context
+     * the web SDK records.
      */
-    fun track(key: String, data: Map<String, Any?>?, metricValue: Double?) {
-        LDObserve.track(key, data, metricValue)
+    fun track(
+        key: String,
+        data: Map<String, Any?>?,
+        metricValue: Double?,
+        contextKeys: Map<String, String>?,
+    ) {
+        val service = LDObserve.observabilityClient
+        if (contextKeys.isNullOrEmpty() || service == null) {
+            // No explicit context (or no live service): the public path uses the
+            // cached identify keys for the span.
+            LDObserve.track(key, data, metricValue)
+            return
+        }
+        val contextKeyBuilder = Attributes.builder()
+        for ((kind, value) in contextKeys) {
+            contextKeyBuilder.put(AttributeKey.stringKey(kind), value)
+        }
+        service.track(
+            key,
+            metricValue,
+            data?.toLDValue()?.toAttributes() ?: Attributes.empty(),
+            contextKeyBuilder.build(),
+        )
     }
 }

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/bridge/LDValueAttributes.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/bridge/LDValueAttributes.kt
@@ -3,7 +3,9 @@ package com.launchdarkly.observability.bridge
 import com.launchdarkly.sdk.LDValue
 import com.launchdarkly.sdk.LDValueType
 import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.api.common.AttributeType
 import io.opentelemetry.api.common.Attributes
+import io.opentelemetry.api.common.AttributesBuilder
 
 /**
  * Converts an object payload (e.g. a `track` event's `data`) into OTel [Attributes].
@@ -28,27 +30,78 @@ internal fun LDValue.toAttributes(): Attributes {
 }
 
 /**
- * Converts a plain object payload (e.g. a `track` event's `data` carried across
- * a bridge as a `Map`) directly into OTel [Attributes].
+ * Converts a plain object payload (e.g. a `track` event's `data` carried across a
+ * bridge as a `Map`) into OTel [Attributes].
  *
- * Mirrors [toAttributes] for [LDValue]: only scalar members contribute (boolean,
- * number -> double, string); null/array/object members are skipped because OTel
- * [Attributes] is a flat scalar map. Kept here so callers that cannot depend on
- * the LaunchDarkly model types (such as the Flutter plugin) can forward a `Map`
- * without first building an [LDValue].
+ * OTel [Attributes] is a flat map, so structure is preserved where it can be:
+ *  - scalars (boolean, number -> double, string) become scalar attributes;
+ *  - homogeneous scalar lists become array attributes (string / boolean / double arrays);
+ *  - nested maps are flattened using dotted keys (e.g. `user.id`);
+ *  - lists of objects (or mixed types) are flattened with indexed dotted keys
+ *    (e.g. `products.0.product_id`, `products.1.price`);
+ *  - an already-built [Attributes] value is merged in, its keys prefixed with the
+ *    enclosing key (e.g. `payload.<inner-key>`), preserving the original value types;
+ *  - any other value (null, heterogeneous/nested list, arbitrary object) is
+ *    skipped — never stringified.
+ *
+ * Kept here so callers that cannot depend on the LaunchDarkly model types (such as
+ * the Flutter plugin) can forward a `Map` without first building an [LDValue].
  */
-internal fun Map<String, Any?>.toAttributes(): Attributes {
+internal fun Map<String, Any?>.toOtelAttributes(): Attributes {
     val builder = Attributes.builder()
-    for ((key, value) in this) {
-        when (value) {
-            is Boolean -> builder.put(AttributeKey.booleanKey(key), value)
-            is Int -> builder.put(AttributeKey.doubleKey(key), value.toDouble())
-            is Long -> builder.put(AttributeKey.doubleKey(key), value.toDouble())
-            is Float -> builder.put(AttributeKey.doubleKey(key), value.toDouble())
-            is Double -> builder.put(AttributeKey.doubleKey(key), value)
-            is String -> builder.put(AttributeKey.stringKey(key), value)
-            else -> {} // skip null/array/object
-        }
-    }
+    builder.putMap(prefix = null, source = this)
     return builder.build()
+}
+
+private fun AttributesBuilder.putMap(prefix: String?, source: Map<*, *>) {
+    for ((rawKey, value) in source) {
+        val name = rawKey?.toString() ?: continue
+        putValue(if (prefix == null) name else "$prefix.$name", value)
+    }
+}
+
+private fun AttributesBuilder.putValue(key: String, value: Any?) {
+    when (value) {
+        is Boolean -> put(AttributeKey.booleanKey(key), value)
+        is Int -> put(AttributeKey.doubleKey(key), value.toDouble())
+        is Long -> put(AttributeKey.doubleKey(key), value.toDouble())
+        is Float -> put(AttributeKey.doubleKey(key), value.toDouble())
+        is Double -> put(AttributeKey.doubleKey(key), value)
+        is String -> put(AttributeKey.stringKey(key), value)
+        is Attributes -> putAttributes(key, value)
+        is Map<*, *> -> putMap(key, value)
+        is List<*> -> putList(key, value)
+        else -> {} // skip null / unknown; never stringify
+    }
+}
+
+private fun AttributesBuilder.putAttributes(prefix: String, attributes: Attributes) {
+    attributes.forEach { attrKey, value ->
+        @Suppress("UNCHECKED_CAST")
+        put(reKey(attrKey, "$prefix.${attrKey.key}") as AttributeKey<Any>, value)
+    }
+}
+
+private fun AttributesBuilder.putList(key: String, list: List<*>) {
+    if (list.isEmpty()) return
+    when {
+        list.all { it is String } ->
+            put(AttributeKey.stringArrayKey(key), list.map { it as String })
+        list.all { it is Boolean } ->
+            put(AttributeKey.booleanArrayKey(key), list.map { it as Boolean })
+        list.all { it is Number } ->
+            put(AttributeKey.doubleArrayKey(key), list.map { (it as Number).toDouble() })
+        else -> list.forEachIndexed { index, element -> putValue("$key.$index", element) }
+    }
+}
+
+private fun reKey(original: AttributeKey<*>, newName: String): AttributeKey<*> = when (original.type) {
+    AttributeType.STRING -> AttributeKey.stringKey(newName)
+    AttributeType.BOOLEAN -> AttributeKey.booleanKey(newName)
+    AttributeType.LONG -> AttributeKey.longKey(newName)
+    AttributeType.DOUBLE -> AttributeKey.doubleKey(newName)
+    AttributeType.STRING_ARRAY -> AttributeKey.stringArrayKey(newName)
+    AttributeType.BOOLEAN_ARRAY -> AttributeKey.booleanArrayKey(newName)
+    AttributeType.LONG_ARRAY -> AttributeKey.longArrayKey(newName)
+    AttributeType.DOUBLE_ARRAY -> AttributeKey.doubleArrayKey(newName)
 }

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/bridge/LDValueAttributes.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/bridge/LDValueAttributes.kt
@@ -34,8 +34,12 @@ internal fun LDValue.toAttributes(): Attributes {
  * bridge as a `Map`) into OTel [Attributes].
  *
  * OTel [Attributes] is a flat map, so structure is preserved where it can be:
- *  - scalars (boolean, number -> double, string) become scalar attributes;
- *  - homogeneous scalar lists become array attributes (string / boolean / double arrays);
+ *  - scalars become scalar attributes: integers (`Int`/`Long`) stay 64-bit longs,
+ *    `Float`/`Double` become doubles, plus boolean and string. (Unlike the
+ *    `LDClient.track` hook, which receives an `LDValue` whose only number type is
+ *    `double`, these direct `LDObserve` APIs keep the caller's integer type.)
+ *  - homogeneous scalar lists become array attributes (string / boolean / long /
+ *    double arrays);
  *  - nested maps are flattened using dotted keys (e.g. `user.id`);
  *  - lists of objects (or mixed types) are flattened with indexed dotted keys
  *    (e.g. `products.0.product_id`, `products.1.price`);
@@ -63,8 +67,8 @@ private fun AttributesBuilder.putMap(prefix: String?, source: Map<*, *>) {
 private fun AttributesBuilder.putValue(key: String, value: Any?) {
     when (value) {
         is Boolean -> put(AttributeKey.booleanKey(key), value)
-        is Int -> put(AttributeKey.doubleKey(key), value.toDouble())
-        is Long -> put(AttributeKey.doubleKey(key), value.toDouble())
+        is Int -> put(AttributeKey.longKey(key), value.toLong())
+        is Long -> put(AttributeKey.longKey(key), value)
         is Float -> put(AttributeKey.doubleKey(key), value.toDouble())
         is Double -> put(AttributeKey.doubleKey(key), value)
         is String -> put(AttributeKey.stringKey(key), value)
@@ -89,6 +93,10 @@ private fun AttributesBuilder.putList(key: String, list: List<*>) {
             put(AttributeKey.stringArrayKey(key), list.map { it as String })
         list.all { it is Boolean } ->
             put(AttributeKey.booleanArrayKey(key), list.map { it as Boolean })
+        // All-integer lists keep 64-bit long precision; any Float/Double present
+        // falls through to a double array.
+        list.all { it is Int || it is Long } ->
+            put(AttributeKey.longArrayKey(key), list.map { (it as Number).toLong() })
         list.all { it is Number } ->
             put(AttributeKey.doubleArrayKey(key), list.map { (it as Number).toDouble() })
         else -> list.forEachIndexed { index, element -> putValue("$key.$index", element) }

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/bridge/LDValueAttributes.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/bridge/LDValueAttributes.kt
@@ -26,3 +26,34 @@ internal fun LDValue.toAttributes(): Attributes {
     }
     return builder.build()
 }
+
+/**
+ * Converts a plain JSON value (e.g. a `track` event's `data` carried across a
+ * bridge as Java collections/primitives) into an [LDValue].
+ *
+ * The inverse of the value mapping used by [toAttributes], kept here so callers
+ * that cannot depend on the LaunchDarkly model types (such as the Flutter
+ * plugin) can forward a `Map` and let the bridge build the [LDValue].
+ */
+internal fun Any?.toLDValue(): LDValue = when (this) {
+    null -> LDValue.ofNull()
+    is Boolean -> LDValue.of(this)
+    is Int -> LDValue.of(this)
+    is Long -> LDValue.of(this)
+    is Float -> LDValue.of(this)
+    is Double -> LDValue.of(this)
+    is String -> LDValue.of(this)
+    is Map<*, *> -> {
+        val builder = LDValue.buildObject()
+        for ((key, value) in this) {
+            if (key is String) builder.put(key, value.toLDValue())
+        }
+        builder.build()
+    }
+    is List<*> -> {
+        val builder = LDValue.buildArray()
+        for (element in this) builder.add(element.toLDValue())
+        builder.build()
+    }
+    else -> LDValue.of(this.toString())
+}

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/bridge/LDValueAttributes.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/bridge/LDValueAttributes.kt
@@ -28,32 +28,27 @@ internal fun LDValue.toAttributes(): Attributes {
 }
 
 /**
- * Converts a plain JSON value (e.g. a `track` event's `data` carried across a
- * bridge as Java collections/primitives) into an [LDValue].
+ * Converts a plain object payload (e.g. a `track` event's `data` carried across
+ * a bridge as a `Map`) directly into OTel [Attributes].
  *
- * The inverse of the value mapping used by [toAttributes], kept here so callers
- * that cannot depend on the LaunchDarkly model types (such as the Flutter
- * plugin) can forward a `Map` and let the bridge build the [LDValue].
+ * Mirrors [toAttributes] for [LDValue]: only scalar members contribute (boolean,
+ * number -> double, string); null/array/object members are skipped because OTel
+ * [Attributes] is a flat scalar map. Kept here so callers that cannot depend on
+ * the LaunchDarkly model types (such as the Flutter plugin) can forward a `Map`
+ * without first building an [LDValue].
  */
-internal fun Any?.toLDValue(): LDValue = when (this) {
-    null -> LDValue.ofNull()
-    is Boolean -> LDValue.of(this)
-    is Int -> LDValue.of(this)
-    is Long -> LDValue.of(this)
-    is Float -> LDValue.of(this)
-    is Double -> LDValue.of(this)
-    is String -> LDValue.of(this)
-    is Map<*, *> -> {
-        val builder = LDValue.buildObject()
-        for ((key, value) in this) {
-            if (key is String) builder.put(key, value.toLDValue())
+internal fun Map<String, Any?>.toAttributes(): Attributes {
+    val builder = Attributes.builder()
+    for ((key, value) in this) {
+        when (value) {
+            is Boolean -> builder.put(AttributeKey.booleanKey(key), value)
+            is Int -> builder.put(AttributeKey.doubleKey(key), value.toDouble())
+            is Long -> builder.put(AttributeKey.doubleKey(key), value.toDouble())
+            is Float -> builder.put(AttributeKey.doubleKey(key), value.toDouble())
+            is Double -> builder.put(AttributeKey.doubleKey(key), value)
+            is String -> builder.put(AttributeKey.stringKey(key), value)
+            else -> {} // skip null/array/object
         }
-        builder.build()
     }
-    is List<*> -> {
-        val builder = LDValue.buildArray()
-        for (element in this) builder.add(element.toLDValue())
-        builder.build()
-    }
-    else -> LDValue.of(this.toString())
+    return builder.build()
 }

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/client/ObservabilityService.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/client/ObservabilityService.kt
@@ -7,6 +7,7 @@ import com.launchdarkly.observability.context.ObserveLogger
 import com.launchdarkly.observability.api.ObservabilityOptions
 import com.launchdarkly.observability.bridge.emitLog
 import com.launchdarkly.observability.bridge.toAttributes
+import com.launchdarkly.observability.bridge.toLDValue
 import com.launchdarkly.observability.client.screen.ScreenChange
 import com.launchdarkly.observability.client.screen.ScreenStack
 import com.launchdarkly.observability.client.screen.ScreenView
@@ -33,7 +34,6 @@ import com.launchdarkly.observability.sampling.SamplingLogProcessor
 import com.launchdarkly.observability.traces.EventSpanProcessor
 import com.launchdarkly.observability.traces.OtlpTraceExporter
 import com.launchdarkly.observability.util.requireMainThread
-import com.launchdarkly.sdk.LDValue
 import io.opentelemetry.android.OpenTelemetryRum
 import io.opentelemetry.android.OpenTelemetryRumBuilder
 import io.opentelemetry.android.config.OtelRumConfig
@@ -552,8 +552,8 @@ class ObservabilityService(
             .startSpan()
     }
 
-    override fun track(key: String, data: LDValue?, metricValue: Double?) {
-        track(key, metricValue, data?.toAttributes() ?: Attributes.empty(), contextKeyAttributes = null)
+    override fun track(key: String, data: Map<String, Any?>?, metricValue: Double?) {
+        track(key, metricValue, data?.toLDValue()?.toAttributes() ?: Attributes.empty(), contextKeyAttributes = null)
     }
 
     /**

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/client/ObservabilityService.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/client/ObservabilityService.kt
@@ -6,7 +6,7 @@ import android.view.ViewConfiguration
 import com.launchdarkly.observability.context.ObserveLogger
 import com.launchdarkly.observability.api.ObservabilityOptions
 import com.launchdarkly.observability.bridge.emitLog
-import com.launchdarkly.observability.bridge.toAttributes
+import com.launchdarkly.observability.bridge.toOtelAttributes
 import com.launchdarkly.observability.client.screen.ScreenChange
 import com.launchdarkly.observability.client.screen.ScreenStack
 import com.launchdarkly.observability.client.screen.ScreenView
@@ -52,6 +52,7 @@ import io.opentelemetry.api.metrics.LongCounter
 import io.opentelemetry.api.metrics.LongUpDownCounter
 import io.opentelemetry.api.metrics.Meter
 import io.opentelemetry.api.trace.Span
+import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.api.trace.Tracer
 import io.opentelemetry.context.Context
 import io.opentelemetry.sdk.logs.LogRecordProcessor
@@ -552,7 +553,7 @@ class ObservabilityService(
     }
 
     override fun track(key: String, data: Map<String, Any?>?, metricValue: Double?) {
-        track(key, metricValue, data?.toAttributes() ?: Attributes.empty(), contextKeyAttributes = null)
+        track(key, metricValue, data?.toOtelAttributes() ?: Attributes.empty(), contextKeyAttributes = null)
     }
 
     /**
@@ -583,6 +584,7 @@ class ObservabilityService(
         metricValue?.let { attrBuilder.put(AttributeKey.doubleKey("value"), it) }
 
         otelTracer.spanBuilder(TRACK_SPAN_NAME)
+            .setSpanKind(SpanKind.CONSUMER)
             .setAllAttributes(attrBuilder.build())
             .startSpan()
             .end()

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/client/ObservabilityService.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/client/ObservabilityService.kt
@@ -7,7 +7,6 @@ import com.launchdarkly.observability.context.ObserveLogger
 import com.launchdarkly.observability.api.ObservabilityOptions
 import com.launchdarkly.observability.bridge.emitLog
 import com.launchdarkly.observability.bridge.toAttributes
-import com.launchdarkly.observability.bridge.toLDValue
 import com.launchdarkly.observability.client.screen.ScreenChange
 import com.launchdarkly.observability.client.screen.ScreenStack
 import com.launchdarkly.observability.client.screen.ScreenView
@@ -553,7 +552,7 @@ class ObservabilityService(
     }
 
     override fun track(key: String, data: Map<String, Any?>?, metricValue: Double?) {
-        track(key, metricValue, data?.toLDValue()?.toAttributes() ?: Attributes.empty(), contextKeyAttributes = null)
+        track(key, metricValue, data?.toAttributes() ?: Attributes.empty(), contextKeyAttributes = null)
     }
 
     /**

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/client/ObservabilityService.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/client/ObservabilityService.kt
@@ -573,8 +573,8 @@ class ObservabilityService(
             .startSpan()
     }
 
-    override fun track(key: String, data: Map<String, Any?>?, metricValue: Double?) {
-        track(key, metricValue, data?.toOtelAttributes() ?: Attributes.empty(), contextKeyAttributes = null)
+    override fun track(key: String, properties: Map<String, Any?>?, metricValue: Double?) {
+        track(key, metricValue, properties?.toOtelAttributes() ?: Attributes.empty(), contextKeyAttributes = null)
     }
 
     /**
@@ -611,8 +611,16 @@ class ObservabilityService(
             .end()
     }
 
-    override fun trackScreenView(name: String, screenClass: String?, screenId: String?, category: String?) {
-        emitScreenView(ScreenView(name = name, screenClass = screenClass, screenId = screenId, category = category))
+    override fun trackScreenView(name: String, screenClass: String?, screenId: String?, category: String?, properties: Map<String, Any?>?) {
+        emitScreenView(
+            ScreenView(
+                name = name,
+                screenClass = screenClass,
+                screenId = screenId,
+                category = category,
+                attributes = properties?.toOtelAttributes() ?: Attributes.empty()
+            )
+        )
     }
 
     /**
@@ -644,7 +652,10 @@ class ObservabilityService(
         if (!observabilityOptions.tracesApi.includeSpans) return
 
         val attrBuilder = Attributes.builder()
-        // Context keys first so the reserved `event.*` taxonomy fields always win.
+        // Apply in increasing precedence so the screen-view taxonomy can never be clobbered: caller
+        // properties first, then identify context keys, then the reserved `event.*` fields last
+        // (matching the track path).
+        attrBuilder.putAll(screen.attributes)
         attrBuilder.putAll(cachedContextKeyAttributes)
         attrBuilder.put(EVENT_NAME, screen.name)
         screen.screenClass?.let { attrBuilder.put(EVENT_SCREEN_CLASS, it) }

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/client/screen/ScreenView.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/client/screen/ScreenView.kt
@@ -1,5 +1,7 @@
 package com.launchdarkly.observability.client.screen
 
+import io.opentelemetry.api.common.Attributes
+
 /**
  * A single screen appearance, mapped to the taxonomy `screen_view` event.
  *
@@ -10,6 +12,9 @@ package com.launchdarkly.observability.client.screen
  * @property screenClass Activity/Fragment class, e.g. `ProfileActivity`. Maps to `event.screen_class`.
  * @property screenId Stable, fully-qualified identifier, e.g. `com.example.app.ProfileActivity`. Maps to `event.screen_id`.
  * @property category Screen group, e.g. `Onboarding`. Maps to `event.category`.
+ * @property attributes Optional caller-supplied attributes attached to the `screen_view` span,
+ *   applied at lower precedence than the reserved `event.*` fields so they can never clobber the
+ *   taxonomy. Empty for automatically captured screens.
  * @property timestamp Capture time, in milliseconds since epoch.
  */
 data class ScreenView(
@@ -17,5 +22,6 @@ data class ScreenView(
     val screenClass: String? = null,
     val screenId: String? = null,
     val category: String? = null,
+    val attributes: Attributes = Attributes.empty(),
     val timestamp: Long = System.currentTimeMillis(),
 )

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/interfaces/Observe.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/interfaces/Observe.kt
@@ -1,5 +1,6 @@
 package com.launchdarkly.observability.interfaces
 
+import com.launchdarkly.observability.bridge.toOtelAttributes
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.logs.Severity
 import io.opentelemetry.api.trace.Span
@@ -46,6 +47,20 @@ interface LogsApi {
      * @param spanContext Optional span context for trace-log correlation
      */
     fun recordLog(message: String, severity: Severity, attributes: Attributes = Attributes.empty(), spanContext: SpanContext? = null)
+
+    /**
+     * Record a log whose attributes are supplied as a plain map.
+     *
+     * Prefer this over the [Attributes] overload for everyday use: pass native
+     * values (String, Boolean, Int, Long, Double, lists, nested maps) and they are
+     * converted to OTel attributes with the same rules as a `track` event's
+     * `properties`. The [Attributes] overload remains available when you need
+     * precise OpenTelemetry typing. A distinct parameter name keeps the two
+     * overloads unambiguous.
+     */
+    fun recordLog(message: String, severity: Severity, properties: Map<String, Any?>, spanContext: SpanContext? = null) {
+        recordLog(message, severity, properties.toOtelAttributes(), spanContext)
+    }
 }
 
 interface TracesApi {
@@ -62,6 +77,18 @@ interface TracesApi {
      * @param attributes The attributes to record with the span
      */
     fun startSpan(name: String, attributes: Attributes = Attributes.empty()): Span
+
+    /**
+     * Start a span whose attributes are supplied as a plain map.
+     *
+     * Prefer this over the [Attributes] overload for everyday use: pass native
+     * values and they are converted to OTel attributes with the same rules as a
+     * `track` event's `properties`. The [Attributes] overload remains available
+     * when you need precise OpenTelemetry typing.
+     */
+    fun startSpan(name: String, properties: Map<String, Any?>): Span {
+        return startSpan(name, properties.toOtelAttributes())
+    }
 }
 
 /**
@@ -80,17 +107,18 @@ interface Observe : MetricsApi, LogsApi, TracesApi {
     /**
      * Record a custom track event as a `track` span.
      *
-     * Mirrors `LDClient.track(key, data, metricValue)` so the same call shape works
-     * whether the event is recorded through the LaunchDarkly client (via the
-     * `afterTrack` hook) or directly through this API. `data` is a plain map so
-     * callers need not depend on `LDValue`.
+     * Mirrors `LDClient.track(...)` so the same call shape works whether the event
+     * is recorded through the LaunchDarkly client (via the `afterTrack` hook) or
+     * directly through this API. The payload is passed as `properties`, a plain
+     * map, so callers need not depend on `LDValue` — matching the `properties`
+     * overloads of `recordLog`/`startSpan`.
      * @param key The key for the event.
-     * @param data The data associated with the event, if any. Object members are
-     *   attached as span attributes.
+     * @param properties The data associated with the event, if any. Object members
+     *   are attached as span attributes.
      * @param metricValue A numeric value used by LaunchDarkly experimentation for
      *   numeric custom metrics, if any.
      */
-    fun track(key: String, data: Map<String, Any?>? = null, metricValue: Double? = null)
+    fun track(key: String, properties: Map<String, Any?>? = null, metricValue: Double? = null)
 
     /**
      * Record a screen view as a `screen_view` span, following the analytics taxonomy `event.*`
@@ -102,11 +130,16 @@ interface Observe : MetricsApi, LogsApi, TracesApi {
      * @param screenClass Optional class backing the screen (maps to `event.screen_class`).
      * @param screenId Optional stable identifier (maps to `event.screen_id`).
      * @param category Optional screen group (maps to `event.category`).
+     * @param properties Optional custom attributes, supplied as a plain map (same
+     *   conversion rules as a `track` event's `properties`). They are attached at
+     *   lower precedence than the reserved `event.*` fields, so they can never
+     *   clobber the taxonomy.
      */
     fun trackScreenView(
         name: String,
         screenClass: String? = null,
         screenId: String? = null,
-        category: String? = null
+        category: String? = null,
+        properties: Map<String, Any?>? = null
     )
 }

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/interfaces/Observe.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/interfaces/Observe.kt
@@ -1,6 +1,5 @@
 package com.launchdarkly.observability.interfaces
 
-import com.launchdarkly.sdk.LDValue
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.logs.Severity
 import io.opentelemetry.api.trace.Span
@@ -83,13 +82,15 @@ interface Observe : MetricsApi, LogsApi, TracesApi {
      *
      * Mirrors `LDClient.track(key, data, metricValue)` so the same call shape works
      * whether the event is recorded through the LaunchDarkly client (via the
-     * `afterTrack` hook) or directly through this API.
+     * `afterTrack` hook) or directly through this API. `data` is a plain map so
+     * callers need not depend on `LDValue`.
      * @param key The key for the event.
-     * @param data The data associated with the event, if any.
+     * @param data The data associated with the event, if any. Object members are
+     *   attached as span attributes.
      * @param metricValue A numeric value used by LaunchDarkly experimentation for
      *   numeric custom metrics, if any.
      */
-    fun track(key: String, data: LDValue? = null, metricValue: Double? = null)
+    fun track(key: String, data: Map<String, Any?>? = null, metricValue: Double? = null)
 
     /**
      * Record a screen view as a `screen_view` span, following the analytics taxonomy `event.*`

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/sdk/LDObserve.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/sdk/LDObserve.kt
@@ -14,7 +14,6 @@ import com.launchdarkly.observability.replay.ReplayOptions
 import com.launchdarkly.observability.replay.capture.ImageCaptureServicing
 import com.launchdarkly.observability.replay.plugin.SessionReplayPluginImpl
 import com.launchdarkly.observability.util.runOnMainThread
-import com.launchdarkly.sdk.LDValue
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.logs.Severity
 import io.opentelemetry.api.trace.Span
@@ -71,7 +70,7 @@ class LDObserve(private val client: Observe) : Observe {
         client.flush()
     }
 
-    override fun track(key: String, data: LDValue?, metricValue: Double?) {
+    override fun track(key: String, data: Map<String, Any?>?, metricValue: Double?) {
         client.track(key, data, metricValue)
     }
 
@@ -95,7 +94,7 @@ class LDObserve(private val client: Observe) : Observe {
                 return Span.getInvalid()
             }
             override fun flush() {}
-            override fun track(key: String, data: LDValue?, metricValue: Double?) {}
+            override fun track(key: String, data: Map<String, Any?>?, metricValue: Double?) {}
             override fun trackScreenView(name: String, screenClass: String?, screenId: String?, category: String?) {}
         }
 
@@ -231,7 +230,7 @@ class LDObserve(private val client: Observe) : Observe {
         override fun recordLog(message: String, severity: Severity, attributes: Attributes, spanContext: SpanContext?) = delegate.recordLog(message, severity, attributes, spanContext)
         override fun startSpan(name: String, attributes: Attributes): Span = delegate.startSpan(name, attributes)
         override fun flush() = delegate.flush()
-        override fun track(key: String, data: LDValue?, metricValue: Double?) = delegate.track(key, data, metricValue)
+        override fun track(key: String, data: Map<String, Any?>?, metricValue: Double?) = delegate.track(key, data, metricValue)
         override fun trackScreenView(name: String, screenClass: String?, screenId: String?, category: String?) = delegate.trackScreenView(name, screenClass, screenId, category)
 
         /**

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/sdk/LDObserve.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/sdk/LDObserve.kt
@@ -70,12 +70,12 @@ class LDObserve(private val client: Observe) : Observe {
         client.flush()
     }
 
-    override fun track(key: String, data: Map<String, Any?>?, metricValue: Double?) {
-        client.track(key, data, metricValue)
+    override fun track(key: String, properties: Map<String, Any?>?, metricValue: Double?) {
+        client.track(key, properties, metricValue)
     }
 
-    override fun trackScreenView(name: String, screenClass: String?, screenId: String?, category: String?) {
-        client.trackScreenView(name, screenClass, screenId, category)
+    override fun trackScreenView(name: String, screenClass: String?, screenId: String?, category: String?, properties: Map<String, Any?>?) {
+        client.trackScreenView(name, screenClass, screenId, category, properties)
     }
 
     companion object : Observe {
@@ -94,8 +94,8 @@ class LDObserve(private val client: Observe) : Observe {
                 return Span.getInvalid()
             }
             override fun flush() {}
-            override fun track(key: String, data: Map<String, Any?>?, metricValue: Double?) {}
-            override fun trackScreenView(name: String, screenClass: String?, screenId: String?, category: String?) {}
+            override fun track(key: String, properties: Map<String, Any?>?, metricValue: Double?) {}
+            override fun trackScreenView(name: String, screenClass: String?, screenId: String?, category: String?, properties: Map<String, Any?>?) {}
         }
 
         /**
@@ -230,8 +230,8 @@ class LDObserve(private val client: Observe) : Observe {
         override fun recordLog(message: String, severity: Severity, attributes: Attributes, spanContext: SpanContext?) = delegate.recordLog(message, severity, attributes, spanContext)
         override fun startSpan(name: String, attributes: Attributes): Span = delegate.startSpan(name, attributes)
         override fun flush() = delegate.flush()
-        override fun track(key: String, data: Map<String, Any?>?, metricValue: Double?) = delegate.track(key, data, metricValue)
-        override fun trackScreenView(name: String, screenClass: String?, screenId: String?, category: String?) = delegate.trackScreenView(name, screenClass, screenId, category)
+        override fun track(key: String, properties: Map<String, Any?>?, metricValue: Double?) = delegate.track(key, properties, metricValue)
+        override fun trackScreenView(name: String, screenClass: String?, screenId: String?, category: String?, properties: Map<String, Any?>?) = delegate.trackScreenView(name, screenClass, screenId, category, properties)
 
         /**
          * Bridge-friendly overloads that avoid exposing OpenTelemetry types

--- a/sdk/@launchdarkly/observability-android/lib/src/test/kotlin/com/launchdarkly/observability/bridge/LDValueAttributesTest.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/test/kotlin/com/launchdarkly/observability/bridge/LDValueAttributesTest.kt
@@ -1,0 +1,214 @@
+package com.launchdarkly.observability.bridge
+
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.api.common.Attributes
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+/**
+ * Exercises the `Map<String, Any?>.toOtelAttributes()` mapping used by the `track`
+ * paths (`ObservabilityService.track` / `LDObserveBridge.track`).
+ *
+ * Scalars convert to scalar attributes, homogeneous lists to array attributes,
+ * nested maps are flattened with dotted keys, and a whole [Attributes] value is
+ * merged in (keys prefixed, value types preserved). Values with no attribute form
+ * are dropped rather than stringified.
+ */
+class LDValueAttributesTest {
+
+    private data class Arbitrary(val name: String)
+
+    @Test
+    fun `converts boolean, number and string members`() {
+        val data: Map<String, Any?> = mapOf(
+            "flag" to true,
+            "off" to false,
+            "int" to 42,
+            "long" to 7L,
+            "float" to 1.5f,
+            "double" to 3.14,
+            "name" to "checkout"
+        )
+
+        val attrs = data.toOtelAttributes()
+
+        assertEquals(true, attrs.get(AttributeKey.booleanKey("flag")))
+        assertEquals(false, attrs.get(AttributeKey.booleanKey("off")))
+        assertEquals(42.0, attrs.get(AttributeKey.doubleKey("int")))
+        assertEquals(7.0, attrs.get(AttributeKey.doubleKey("long")))
+        assertEquals(1.5, attrs.get(AttributeKey.doubleKey("float")))
+        assertEquals(3.14, attrs.get(AttributeKey.doubleKey("double")))
+        assertEquals("checkout", attrs.get(AttributeKey.stringKey("name")))
+        assertEquals(7, attrs.size())
+    }
+
+    @Test
+    fun `numbers are normalized to double attributes`() {
+        val data: Map<String, Any?> = mapOf("int" to 42)
+
+        val attrs = data.toOtelAttributes()
+
+        assertEquals(42.0, attrs.get(AttributeKey.doubleKey("int")))
+        assertNull(attrs.get(AttributeKey.longKey("int")))
+        assertNull(attrs.get(AttributeKey.stringKey("int")))
+    }
+
+    @Test
+    fun `converts homogeneous lists into array attributes`() {
+        val data: Map<String, Any?> = mapOf(
+            "tags" to listOf("a", "b"),
+            "flags" to listOf(true, false),
+            "scores" to listOf(1, 2, 3)
+        )
+
+        val attrs = data.toOtelAttributes()
+
+        assertEquals(listOf("a", "b"), attrs.get(AttributeKey.stringArrayKey("tags")))
+        assertEquals(listOf(true, false), attrs.get(AttributeKey.booleanArrayKey("flags")))
+        assertEquals(listOf(1.0, 2.0, 3.0), attrs.get(AttributeKey.doubleArrayKey("scores")))
+    }
+
+    @Test
+    fun `flattens lists of objects with indexed dotted keys`() {
+        val data: Map<String, Any?> = mapOf(
+            "products" to listOf(
+                mapOf("product_id" to "SKU-1234", "quantity" to 2),
+                mapOf("product_id" to "SKU-9876", "quantity" to 1)
+            )
+        )
+
+        val attrs = data.toOtelAttributes()
+
+        assertEquals("SKU-1234", attrs.get(AttributeKey.stringKey("products.0.product_id")))
+        assertEquals(2.0, attrs.get(AttributeKey.doubleKey("products.0.quantity")))
+        assertEquals("SKU-9876", attrs.get(AttributeKey.stringKey("products.1.product_id")))
+        assertEquals(1.0, attrs.get(AttributeKey.doubleKey("products.1.quantity")))
+        assertEquals(4, attrs.size())
+    }
+
+    // MARK: - Segment e-commerce examples from analytics-taxonomy.md (§4.2)
+
+    @Test
+    fun `Product Added flat payload`() {
+        val data: Map<String, Any?> = mapOf(
+            "name" to "Product Added",
+            "product_id" to "SKU-1234",
+            "quantity" to 2,
+            "price" to 24.0,
+            "currency" to "USD",
+            "cart_id" to "cart_98f1"
+        )
+
+        val attrs = data.toOtelAttributes()
+
+        assertEquals("Product Added", attrs.get(AttributeKey.stringKey("name")))
+        assertEquals("SKU-1234", attrs.get(AttributeKey.stringKey("product_id")))
+        assertEquals(2.0, attrs.get(AttributeKey.doubleKey("quantity")))
+        assertEquals(24.0, attrs.get(AttributeKey.doubleKey("price")))
+        assertEquals("USD", attrs.get(AttributeKey.stringKey("currency")))
+        assertEquals("cart_98f1", attrs.get(AttributeKey.stringKey("cart_id")))
+        assertEquals(6, attrs.size())
+    }
+
+    @Test
+    fun `Checkout Started nested products payload`() {
+        val data: Map<String, Any?> = mapOf(
+            "name" to "Checkout Started",
+            "order_id" to "ord_5521",
+            "value" to 72.0,
+            "currency" to "USD",
+            "products" to listOf(
+                mapOf("product_id" to "SKU-1234", "quantity" to 2, "price" to 24.0),
+                mapOf("product_id" to "SKU-9876", "quantity" to 1, "price" to 24.0)
+            )
+        )
+
+        val attrs = data.toOtelAttributes()
+
+        assertEquals("Checkout Started", attrs.get(AttributeKey.stringKey("name")))
+        assertEquals("ord_5521", attrs.get(AttributeKey.stringKey("order_id")))
+        assertEquals(72.0, attrs.get(AttributeKey.doubleKey("value")))
+        assertEquals("USD", attrs.get(AttributeKey.stringKey("currency")))
+        // The products array of objects is flattened with indexed dotted keys.
+        assertEquals("SKU-1234", attrs.get(AttributeKey.stringKey("products.0.product_id")))
+        assertEquals(2.0, attrs.get(AttributeKey.doubleKey("products.0.quantity")))
+        assertEquals(24.0, attrs.get(AttributeKey.doubleKey("products.0.price")))
+        assertEquals("SKU-9876", attrs.get(AttributeKey.stringKey("products.1.product_id")))
+        assertEquals(1.0, attrs.get(AttributeKey.doubleKey("products.1.quantity")))
+        assertEquals(24.0, attrs.get(AttributeKey.doubleKey("products.1.price")))
+    }
+
+    @Test
+    fun `flattens nested maps with dotted keys`() {
+        val data: Map<String, Any?> = mapOf(
+            "user" to mapOf(
+                "id" to "u-1",
+                "premium" to true,
+                "address" to mapOf("city" to "SF")
+            )
+        )
+
+        val attrs = data.toOtelAttributes()
+
+        assertEquals("u-1", attrs.get(AttributeKey.stringKey("user.id")))
+        assertEquals(true, attrs.get(AttributeKey.booleanKey("user.premium")))
+        assertEquals("SF", attrs.get(AttributeKey.stringKey("user.address.city")))
+        assertEquals(3, attrs.size())
+    }
+
+    @Test
+    fun `merges a whole Attributes value preserving key types`() {
+        val inner = Attributes.builder()
+            .put(AttributeKey.stringKey("name"), "y")
+            .put(AttributeKey.longKey("n"), 5L)
+            .put(AttributeKey.stringArrayKey("tags"), listOf("a", "b"))
+            .build()
+        val data: Map<String, Any?> = mapOf(
+            "event" to "signup",
+            "payload" to inner
+        )
+
+        val attrs = data.toOtelAttributes()
+
+        assertEquals("signup", attrs.get(AttributeKey.stringKey("event")))
+        assertEquals("y", attrs.get(AttributeKey.stringKey("payload.name")))
+        // The long stays a long (not coerced to double or stringified).
+        assertEquals(5L, attrs.get(AttributeKey.longKey("payload.n")))
+        assertEquals(listOf("a", "b"), attrs.get(AttributeKey.stringArrayKey("payload.tags")))
+        assertEquals(4, attrs.size())
+    }
+
+    @Test
+    fun `skips null values`() {
+        val data: Map<String, Any?> = mapOf(
+            "keep" to "yes",
+            "missing" to null
+        )
+
+        val attrs = data.toOtelAttributes()
+
+        assertEquals("yes", attrs.get(AttributeKey.stringKey("keep")))
+        assertNull(attrs.get(AttributeKey.stringKey("missing")))
+        assertEquals(1, attrs.size())
+    }
+
+    @Test
+    fun `skips arbitrary objects without stringifying`() {
+        val data: Map<String, Any?> = mapOf(
+            "keep" to 1,
+            "object" to Arbitrary("payload")
+        )
+
+        val attrs = data.toOtelAttributes()
+
+        assertEquals(1.0, attrs.get(AttributeKey.doubleKey("keep")))
+        assertNull(attrs.get(AttributeKey.stringKey("object")))
+        assertEquals(1, attrs.size())
+    }
+
+    @Test
+    fun `empty map yields empty attributes`() {
+        assertEquals(0, emptyMap<String, Any?>().toOtelAttributes().size())
+    }
+}

--- a/sdk/@launchdarkly/observability-android/lib/src/test/kotlin/com/launchdarkly/observability/bridge/LDValueAttributesTest.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/test/kotlin/com/launchdarkly/observability/bridge/LDValueAttributesTest.kt
@@ -158,6 +158,38 @@ class LDValueAttributesTest {
     }
 
     @Test
+    fun `mixes native values with a whole Attributes value in one payload`() {
+        // Mirrors a real track/recordLog payload: callers favor native values (the
+        // `properties` API) but can still embed a pre-built OTel Attributes value
+        // (the `attributes` API) in the same map. Both must survive conversion. The
+        // example apps now use only native values, so this is the unit-test home for
+        // the OTel-attribute path.
+        val otel = Attributes.builder()
+            .put(AttributeKey.stringKey("string"), "android")
+            .build()
+        val data: Map<String, Any?> = mapOf(
+            "test-string" to "android",
+            "test-true" to true,
+            "test-integer" to 42,
+            "test-double" to 3.14,
+            "test-map" to mapOf("test-string" to "val"),
+            "test-attributes" to otel
+        )
+
+        val attrs = data.toOtelAttributes()
+
+        assertEquals("android", attrs.get(AttributeKey.stringKey("test-string")))
+        assertEquals(true, attrs.get(AttributeKey.booleanKey("test-true")))
+        assertEquals(42.0, attrs.get(AttributeKey.doubleKey("test-integer")))
+        assertEquals(3.14, attrs.get(AttributeKey.doubleKey("test-double")))
+        // Native nested map flattens with dotted keys.
+        assertEquals("val", attrs.get(AttributeKey.stringKey("test-map.test-string")))
+        // Pre-built OTel attributes merge in with the enclosing key as prefix.
+        assertEquals("android", attrs.get(AttributeKey.stringKey("test-attributes.string")))
+        assertEquals(6, attrs.size())
+    }
+
+    @Test
     fun `merges a whole Attributes value preserving key types`() {
         val inner = Attributes.builder()
             .put(AttributeKey.stringKey("name"), "y")

--- a/sdk/@launchdarkly/observability-android/lib/src/test/kotlin/com/launchdarkly/observability/bridge/LDValueAttributesTest.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/test/kotlin/com/launchdarkly/observability/bridge/LDValueAttributesTest.kt
@@ -35,8 +35,9 @@ class LDValueAttributesTest {
 
         assertEquals(true, attrs.get(AttributeKey.booleanKey("flag")))
         assertEquals(false, attrs.get(AttributeKey.booleanKey("off")))
-        assertEquals(42.0, attrs.get(AttributeKey.doubleKey("int")))
-        assertEquals(7.0, attrs.get(AttributeKey.doubleKey("long")))
+        // Integers keep their type (64-bit long); only Float/Double become doubles.
+        assertEquals(42L, attrs.get(AttributeKey.longKey("int")))
+        assertEquals(7L, attrs.get(AttributeKey.longKey("long")))
         assertEquals(1.5, attrs.get(AttributeKey.doubleKey("float")))
         assertEquals(3.14, attrs.get(AttributeKey.doubleKey("double")))
         assertEquals("checkout", attrs.get(AttributeKey.stringKey("name")))
@@ -44,13 +45,17 @@ class LDValueAttributesTest {
     }
 
     @Test
-    fun `numbers are normalized to double attributes`() {
-        val data: Map<String, Any?> = mapOf("int" to 42)
+    fun `integers are preserved as 64-bit longs without precision loss`() {
+        // Beyond Int32 range (e.g. epoch nanos / large IDs): must not be coerced
+        // to double, which would lose precision above 2^53.
+        val big = 9_000_000_000L
+        val data: Map<String, Any?> = mapOf("int" to 42, "long" to big)
 
         val attrs = data.toOtelAttributes()
 
-        assertEquals(42.0, attrs.get(AttributeKey.doubleKey("int")))
-        assertNull(attrs.get(AttributeKey.longKey("int")))
+        assertEquals(42L, attrs.get(AttributeKey.longKey("int")))
+        assertEquals(big, attrs.get(AttributeKey.longKey("long")))
+        assertNull(attrs.get(AttributeKey.doubleKey("int")))
         assertNull(attrs.get(AttributeKey.stringKey("int")))
     }
 
@@ -66,7 +71,8 @@ class LDValueAttributesTest {
 
         assertEquals(listOf("a", "b"), attrs.get(AttributeKey.stringArrayKey("tags")))
         assertEquals(listOf(true, false), attrs.get(AttributeKey.booleanArrayKey("flags")))
-        assertEquals(listOf(1.0, 2.0, 3.0), attrs.get(AttributeKey.doubleArrayKey("scores")))
+        // All-integer lists keep 64-bit long precision.
+        assertEquals(listOf(1L, 2L, 3L), attrs.get(AttributeKey.longArrayKey("scores")))
     }
 
     @Test
@@ -81,9 +87,9 @@ class LDValueAttributesTest {
         val attrs = data.toOtelAttributes()
 
         assertEquals("SKU-1234", attrs.get(AttributeKey.stringKey("products.0.product_id")))
-        assertEquals(2.0, attrs.get(AttributeKey.doubleKey("products.0.quantity")))
+        assertEquals(2L, attrs.get(AttributeKey.longKey("products.0.quantity")))
         assertEquals("SKU-9876", attrs.get(AttributeKey.stringKey("products.1.product_id")))
-        assertEquals(1.0, attrs.get(AttributeKey.doubleKey("products.1.quantity")))
+        assertEquals(1L, attrs.get(AttributeKey.longKey("products.1.quantity")))
         assertEquals(4, attrs.size())
     }
 
@@ -104,7 +110,7 @@ class LDValueAttributesTest {
 
         assertEquals("Product Added", attrs.get(AttributeKey.stringKey("name")))
         assertEquals("SKU-1234", attrs.get(AttributeKey.stringKey("product_id")))
-        assertEquals(2.0, attrs.get(AttributeKey.doubleKey("quantity")))
+        assertEquals(2L, attrs.get(AttributeKey.longKey("quantity")))
         assertEquals(24.0, attrs.get(AttributeKey.doubleKey("price")))
         assertEquals("USD", attrs.get(AttributeKey.stringKey("currency")))
         assertEquals("cart_98f1", attrs.get(AttributeKey.stringKey("cart_id")))
@@ -132,10 +138,10 @@ class LDValueAttributesTest {
         assertEquals("USD", attrs.get(AttributeKey.stringKey("currency")))
         // The products array of objects is flattened with indexed dotted keys.
         assertEquals("SKU-1234", attrs.get(AttributeKey.stringKey("products.0.product_id")))
-        assertEquals(2.0, attrs.get(AttributeKey.doubleKey("products.0.quantity")))
+        assertEquals(2L, attrs.get(AttributeKey.longKey("products.0.quantity")))
         assertEquals(24.0, attrs.get(AttributeKey.doubleKey("products.0.price")))
         assertEquals("SKU-9876", attrs.get(AttributeKey.stringKey("products.1.product_id")))
-        assertEquals(1.0, attrs.get(AttributeKey.doubleKey("products.1.quantity")))
+        assertEquals(1L, attrs.get(AttributeKey.longKey("products.1.quantity")))
         assertEquals(24.0, attrs.get(AttributeKey.doubleKey("products.1.price")))
     }
 
@@ -180,7 +186,7 @@ class LDValueAttributesTest {
 
         assertEquals("android", attrs.get(AttributeKey.stringKey("test-string")))
         assertEquals(true, attrs.get(AttributeKey.booleanKey("test-true")))
-        assertEquals(42.0, attrs.get(AttributeKey.doubleKey("test-integer")))
+        assertEquals(42L, attrs.get(AttributeKey.longKey("test-integer")))
         assertEquals(3.14, attrs.get(AttributeKey.doubleKey("test-double")))
         // Native nested map flattens with dotted keys.
         assertEquals("val", attrs.get(AttributeKey.stringKey("test-map.test-string")))
@@ -234,7 +240,7 @@ class LDValueAttributesTest {
 
         val attrs = data.toOtelAttributes()
 
-        assertEquals(1.0, attrs.get(AttributeKey.doubleKey("keep")))
+        assertEquals(1L, attrs.get(AttributeKey.longKey("keep")))
         assertNull(attrs.get(AttributeKey.stringKey("object")))
         assertEquals(1, attrs.size())
     }


### PR DESCRIPTION
## Summary

Adds a custom-event **track API** to the Flutter observability SDK (`sdk/@launchdarkly/flutter`), mirroring the native iOS/Android SDKs and the Swift TestApp.

- **`LDObserve.track(eventName, {data, metricValue})`** facade — matches `LDClient.track` from the flutter-client-sdk.
- **`afterTrack` hook** wired into the observability `_ObservabilityHook`, so `LDClient.track` is captured automatically. Both paths funnel through a single emitter that produces a `track` span, gated by `analytics.trackEvents`.
- **`TrackConvention`** builds span attributes (user `data`, context kind/key pairs, reserved `key`/`value`) with the same precedence as the native track path (reserved keys can't be clobbered).
- **Example app**: `Track (LDClient)` / `Track (LDObserve)` buttons under Observability, mirroring the Swift `MainMenuView`.
- **Native iOS dependency bumped to `~> 0.41.0`** (podspec + `Package.swift`).

## Notes / caveats

- The native iOS bump assumes `LaunchDarklyObservability` / `LaunchDarklySessionReplay` **0.41.0 are published to CocoaPods trunk**; published (non-`LD_USE_LOCAL_NATIVE`) builds will otherwise fail dependency resolution.
- The track span is emitted by the cross-platform Dart OpenTelemetry pipeline (web + mobile via the native bridge), so no native track hook is needed.
- The manual `LDObserve.track` facade has no `LDContext` (client-less entry point), so context kind/key attributes are only attached on the `afterTrack` hook path.

## Test plan

- [x] `flutter analyze` clean
- [x] `dart format --set-exit-if-changed .` passes
- [x] `flutter test test/track_convention_test.dart` (11 tests pass)
- [ ] Manually exercise both Track buttons in the example app and confirm a `track` span is exported

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Telemetry and public Android `track` signatures change across Flutter bridges and observability-android; mobile vs web routing and CocoaPods 0.41.0 dependency need careful validation so events are not dropped or duplicated.
> 
> **Overview**
> Adds end-to-end **custom `track` events** across Flutter observability and aligned native mobile SDKs: **`LDObserve.track`** and an **`afterTrack`** hook share one emitter, **`TrackConvention`** builds `track` span attributes on web, and **iOS/Android forward track over Pigeon** so mobile gets native `track` spans (gated by **`analytics.trackEvents`**) and always-on Session Replay **`Track`** breadcrumbs—without double-emitting Dart spans on mobile. **`contextKeys`** from the LD client hook annotate native spans; manual `LDObserve.track` has no context.
> 
> **Android observability** changes the public **`track` `data` type from `LDValue` to `Map`**, with **`Map`→OTel attribute** flattening (nested maps, product arrays). The Flutter Android plugin adds a **`track` bridge** and **`runtimeOnly` java-sdk-common** for conversions.
> 
> **`analytics-taxonomy.md`** replaces **`app_open` / `app_install` / `app_update`** with **`app_launch`** (`launch_type` + cold/warm via **`app.start` span events**) and clarifies **`app_foreground`** for resume.
> 
> Example apps gain **Track (LDClient / LDObserve / Nested)**; iOS pods bump to **LaunchDarklyObservability ~> 0.41.0**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c0a7905df1d0a998c268e54b156a37e510a1701. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->