### PR TITLE
feat: richer Session Replay click descriptions (target text/selector)

### DIFF
--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/client/ObservabilityService.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/client/ObservabilityService.kt
@@ -53,6 +53,7 @@ import io.opentelemetry.api.metrics.LongCounter
 import io.opentelemetry.api.metrics.LongUpDownCounter
 import io.opentelemetry.api.metrics.Meter
 import io.opentelemetry.api.trace.Span
+import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.api.trace.Tracer
 import io.opentelemetry.context.Context
 import io.opentelemetry.sdk.logs.LogRecordProcessor
@@ -328,6 +329,7 @@ class ObservabilityService(
                             }
                             .build()
                         otelTracer.spanBuilder(UserInteractionManager.CLICK_SPAN_NAME)
+                            .setSpanKind(SpanKind.CLIENT)
                             .setAllAttributes(attrs)
                             .setStartTimestamp(downTimeMs, TimeUnit.MILLISECONDS)
                             .startSpan()
@@ -546,6 +548,7 @@ class ObservabilityService(
 
         val span = otelTracer
             .spanBuilder(ERROR_SPAN_NAME)
+            .setSpanKind(SpanKind.CLIENT)
             .setParent(Context.current().with(Span.current()))
             .startSpan()
 
@@ -560,6 +563,7 @@ class ObservabilityService(
         if (!observabilityOptions.tracesApi.includeSpans) return Span.getInvalid()
 
         return otelTracer.spanBuilder(name)
+            .setSpanKind(SpanKind.CLIENT)
             .setAllAttributes(attributes)
             .startSpan()
     }
@@ -596,6 +600,7 @@ class ObservabilityService(
         metricValue?.let { attrBuilder.put(AttributeKey.doubleKey("value"), it) }
 
         otelTracer.spanBuilder(TRACK_SPAN_NAME)
+            .setSpanKind(SpanKind.CLIENT)
             .setAllAttributes(attrBuilder.build())
             .startSpan()
             .end()
@@ -643,6 +648,7 @@ class ObservabilityService(
         screen.category?.let { attrBuilder.put(EVENT_CATEGORY, it) }
 
         otelTracer.spanBuilder(SCREEN_VIEW_SPAN_NAME)
+            .setSpanKind(SpanKind.CLIENT)
             .setAllAttributes(attrBuilder.build())
             .startSpan()
             .end()
@@ -674,6 +680,7 @@ class ObservabilityService(
         signal.lifecycleState?.let { attrBuilder.put(EVENT_LIFECYCLE_STATE, it) }
 
         otelTracer.spanBuilder(spanName)
+            .setSpanKind(SpanKind.CLIENT)
             .setAllAttributes(attrBuilder.build())
             .startSpan()
             .end()

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/client/ObservabilityService.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/client/ObservabilityService.kt
@@ -323,7 +323,13 @@ class ObservabilityService(
                             .put(EVENT_X, sample.x.toLong())
                             .put(EVENT_Y, sample.y.toLong())
                             .apply {
-                                downTargetClassName?.let { put(EVENT_TAG, it) }
+                                downTargetClassName?.let {
+                                    // `event.tag` is the short element tag (e.g. `Button`), per
+                                    // analytics-taxonomy; the fully-qualified class name is kept in
+                                    // `event.classname`.
+                                    put(EVENT_TAG, shortElementTag(it))
+                                    put(EVENT_CLASSNAME, it)
+                                }
                                 downTargetText?.let { put(EVENT_TEXT, it) }
                                 downTargetResourceId?.let { put(EVENT_ID, it) }
                             }
@@ -762,6 +768,7 @@ class ObservabilityService(
         private val EVENT_X = AttributeKey.longKey("event.x")
         private val EVENT_Y = AttributeKey.longKey("event.y")
         private val EVENT_TAG = AttributeKey.stringKey("event.tag")
+        private val EVENT_CLASSNAME = AttributeKey.stringKey("event.classname")
         private val EVENT_TEXT = AttributeKey.stringKey("event.text")
         private val EVENT_ID = AttributeKey.stringKey("event.id")
         private val EVENT_NAME = AttributeKey.stringKey("event.name")
@@ -781,5 +788,14 @@ class ObservabilityService(
         // pending instrument values and hand them to the exporter. Kept short so flush stays
         // responsive even if the reader's executor is backed up.
         private const val FLUSH_TIMEOUT_SECONDS = 5L
+
+        /**
+         * Derives the short element tag (`event.tag`) from a fully-qualified view class name,
+         * keeping click analytics aligned with the cross-platform taxonomy (e.g.
+         * `android.widget.Button` -> `Button`). Trailing package and nested-class prefixes are
+         * dropped; the original string is returned if no short form can be derived.
+         */
+        internal fun shortElementTag(className: String): String =
+            className.substringAfterLast('.').substringAfterLast('$').ifEmpty { className }
     }
 }

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/client/ObservabilityService.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/client/ObservabilityService.kt
@@ -71,9 +71,6 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.launch
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.put
-import kotlinx.serialization.json.putJsonObject
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeUnit
 
@@ -335,21 +332,6 @@ class ObservabilityService(
                             .setStartTimestamp(downTimeMs, TimeUnit.MILLISECONDS)
                             .startSpan()
                             .end(sample.timestamp, TimeUnit.MILLISECONDS)
-
-                        // Debug: log the JSON shape of the OTel `click` span (name + `event.*`).
-                        logger.debug(
-                            "[Otel Click] " + buildJsonObject {
-                                put("span", UserInteractionManager.CLICK_SPAN_NAME)
-                                putJsonObject("attributes") {
-                                    put(EVENT_TYPE.key, UserInteractionManager.CLICK_SPAN_NAME)
-                                    put(EVENT_X.key, sample.x.toLong())
-                                    put(EVENT_Y.key, sample.y.toLong())
-                                    downTargetClassName?.let { put(EVENT_TAG.key, it) }
-                                    downTargetText?.let { put(EVENT_TEXT.key, it) }
-                                    downTargetResourceId?.let { put(EVENT_ID.key, it) }
-                                }
-                            }.toString()
-                        )
                     }
                 }
             }

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/client/ObservabilityService.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/client/ObservabilityService.kt
@@ -71,6 +71,9 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.launch
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonObject
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeUnit
 
@@ -292,12 +295,19 @@ class ObservabilityService(
             var downX = 0f
             var downY = 0f
             var downTimeMs = 0L
+            // Target description is captured at ACTION_DOWN and described on the span at ACTION_UP.
+            var downTargetClassName: String? = null
+            var downTargetText: String? = null
+            var downTargetResourceId: String? = null
             userInteractionManager.touchFlow.collect { sample ->
                 when (sample.action) {
                     MotionEvent.ACTION_DOWN -> {
                         downX = sample.x
                         downY = sample.y
                         downTimeMs = sample.timestamp
+                        downTargetClassName = sample.targetClassName
+                        downTargetText = sample.targetText
+                        downTargetResourceId = sample.targetResourceId
                     }
                     MotionEvent.ACTION_UP -> {
                         if (!observabilityOptions.analytics.taps) return@collect
@@ -314,12 +324,32 @@ class ObservabilityService(
                             .put(EVENT_TYPE, UserInteractionManager.CLICK_SPAN_NAME)
                             .put(EVENT_X, sample.x.toLong())
                             .put(EVENT_Y, sample.y.toLong())
+                            .apply {
+                                downTargetClassName?.let { put(EVENT_TAG, it) }
+                                downTargetText?.let { put(EVENT_TEXT, it) }
+                                downTargetResourceId?.let { put(EVENT_ID, it) }
+                            }
                             .build()
                         otelTracer.spanBuilder(UserInteractionManager.CLICK_SPAN_NAME)
                             .setAllAttributes(attrs)
                             .setStartTimestamp(downTimeMs, TimeUnit.MILLISECONDS)
                             .startSpan()
                             .end(sample.timestamp, TimeUnit.MILLISECONDS)
+
+                        // Debug: log the JSON shape of the OTel `click` span (name + `event.*`).
+                        logger.debug(
+                            "[Otel Click] " + buildJsonObject {
+                                put("span", UserInteractionManager.CLICK_SPAN_NAME)
+                                putJsonObject("attributes") {
+                                    put(EVENT_TYPE.key, UserInteractionManager.CLICK_SPAN_NAME)
+                                    put(EVENT_X.key, sample.x.toLong())
+                                    put(EVENT_Y.key, sample.y.toLong())
+                                    downTargetClassName?.let { put(EVENT_TAG.key, it) }
+                                    downTargetText?.let { put(EVENT_TEXT.key, it) }
+                                    downTargetResourceId?.let { put(EVENT_ID.key, it) }
+                                }
+                            }.toString()
+                        )
                     }
                 }
             }
@@ -742,6 +772,9 @@ class ObservabilityService(
         private val EVENT_TYPE = AttributeKey.stringKey("event.type")
         private val EVENT_X = AttributeKey.longKey("event.x")
         private val EVENT_Y = AttributeKey.longKey("event.y")
+        private val EVENT_TAG = AttributeKey.stringKey("event.tag")
+        private val EVENT_TEXT = AttributeKey.stringKey("event.text")
+        private val EVENT_ID = AttributeKey.stringKey("event.id")
         private val EVENT_NAME = AttributeKey.stringKey("event.name")
         private val EVENT_SCREEN_CLASS = AttributeKey.stringKey("event.screen_class")
         private val EVENT_SCREEN_ID = AttributeKey.stringKey("event.screen_id")

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/client/TouchSample.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/client/TouchSample.kt
@@ -11,10 +11,18 @@ import android.view.MotionEvent
  * @property x raw x coordinate in pixels.
  * @property y raw y coordinate in pixels.
  * @property timestamp epoch milliseconds for the sample.
+ * @property targetClassName fully-qualified class name of the view under the touch (ACTION_DOWN
+ *   only), or null when no target could be resolved.
+ * @property targetText visible text / content description of the target view (truncated), if any.
+ * @property targetResourceId the target view's resource entry name (the `accessibilityIdentifier`
+ *   analog), if any.
  */
 data class TouchSample(
     val action: Int,
     val x: Float,
     val y: Float,
     val timestamp: Long,
+    val targetClassName: String? = null,
+    val targetText: String? = null,
+    val targetResourceId: String? = null,
 )

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/client/UserInteractionManager.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/client/UserInteractionManager.kt
@@ -245,12 +245,22 @@ class UserInteractionManager : Application.ActivityLifecycleCallbacks {
         view.transformationMethod is PasswordTransformationMethod
 
     private fun resolveResourceId(view: View): String? {
-        if (view.id == View.NO_ID) return null
-        return try {
-            view.resources.getResourceEntryName(view.id)
-        } catch (_: Resources.NotFoundException) {
-            null
+        if (view.id != View.NO_ID) {
+            try {
+                return view.resources.getResourceEntryName(view.id)
+            } catch (_: Resources.NotFoundException) {
+                // Fall through to the React Native testID lookup below.
+            }
         }
+        // React Native views typically have no native id; RN stores the JS `testID` prop on the
+        // `react_test_id` tag (the same identifier the privacy matchers use), so fall back to it.
+        return resolveReactTestId(view)
+    }
+
+    /** Reads React Native's JS `testID` prop from the `react_test_id` tag, when present. */
+    private fun resolveReactTestId(view: View): String? {
+        val resId = reactTestIdResId ?: return null
+        return (view.getTag(resId) as? String)?.takeIf { it.isNotEmpty() }
     }
 
     companion object {
@@ -258,5 +268,19 @@ class UserInteractionManager : Application.ActivityLifecycleCallbacks {
 
         // Cap captured text to match the web SDK's `Click` payload truncation.
         private const val MAX_TEXT_LENGTH = 2000
+
+        /**
+         * Resource id of React Native's `react_test_id` tag, where RN stores the JS `testID` prop
+         * on each view. Resolved reflectively to avoid a compile-time dependency on React Native;
+         * `null` when the RN library isn't on the runtime classpath. Mirrors the lookup used by the
+         * Session Replay privacy matchers.
+         */
+        private val reactTestIdResId: Int? by lazy {
+            runCatching {
+                Class.forName("com.facebook.react.R\$id")
+                    .getField("react_test_id")
+                    .getInt(null)
+            }.getOrNull()
+        }
     }
 }

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/client/UserInteractionManager.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/client/UserInteractionManager.kt
@@ -2,13 +2,17 @@ package com.launchdarkly.observability.client
 
 import android.app.Activity
 import android.app.Application
+import android.content.res.Resources
 import android.os.Build
 import android.os.Bundle
 import android.os.SystemClock
 import android.view.KeyboardShortcutGroup
 import android.view.Menu
 import android.view.MotionEvent
+import android.view.View
+import android.view.ViewGroup
 import android.view.Window
+import android.widget.TextView
 import androidx.annotation.RequiresApi
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -81,12 +85,19 @@ class UserInteractionManager : Application.ActivityLifecycleCallbacks {
 
         when (motionEvent.actionMasked) {
             MotionEvent.ACTION_DOWN -> {
+                val downX = motionEvent.getX(pointerIndex)
+                val downY = motionEvent.getY(pointerIndex)
+                // Resolve the tapped view so consumers can describe the click target (web/iOS parity).
+                val target = resolveTargetInfo(window, downX, downY)
                 _touchFlow.tryEmit(
                     TouchSample(
                         action = MotionEvent.ACTION_DOWN,
-                        x = motionEvent.getX(pointerIndex),
-                        y = motionEvent.getY(pointerIndex),
+                        x = downX,
+                        y = downY,
                         timestamp = eventTimeReference + motionEvent.eventTime,
+                        targetClassName = target?.className,
+                        targetText = target?.text,
+                        targetResourceId = target?.resourceId,
                     )
                 )
             }
@@ -167,7 +178,72 @@ class UserInteractionManager : Application.ActivityLifecycleCallbacks {
     override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) {}
     override fun onActivityDestroyed(activity: Activity) {}
 
+    /** Resolved description of the view under a touch point. */
+    private data class TargetInfo(
+        val className: String?,
+        val text: String?,
+        val resourceId: String?,
+    )
+
+    /**
+     * Hit-tests the window's view hierarchy to describe the view under ([x], [y]). Coordinates are
+     * relative to the window's decor view (as delivered to the [Window.Callback]). Best-effort: any
+     * failure resolves to null so touch dispatch is never affected.
+     */
+    private fun resolveTargetInfo(window: Window, x: Float, y: Float): TargetInfo? {
+        return try {
+            val target = findDeepestViewAt(window.decorView, x, y) ?: return null
+            TargetInfo(
+                className = target.javaClass.name,
+                text = extractText(target),
+                resourceId = resolveResourceId(target),
+            )
+        } catch (_: Throwable) {
+            null
+        }
+    }
+
+    /**
+     * Returns the deepest visible view containing the point, translating coordinates into each
+     * child's coordinate space (accounting for child offset and parent scroll). Children are walked
+     * in reverse draw order so the topmost view wins.
+     */
+    private fun findDeepestViewAt(root: View, x: Float, y: Float): View? {
+        if (root.visibility != View.VISIBLE) return null
+        if (root is ViewGroup) {
+            for (i in root.childCount - 1 downTo 0) {
+                val child = root.getChildAt(i)
+                val childX = x - child.left + root.scrollX
+                val childY = y - child.top + root.scrollY
+                if (childX >= 0 && childX < child.width && childY >= 0 && childY < child.height) {
+                    findDeepestViewAt(child, childX, childY)?.let { return it }
+                }
+            }
+        }
+        return root
+    }
+
+    private fun extractText(view: View): String? {
+        val raw = when (view) {
+            is TextView -> view.text?.toString()
+            else -> view.contentDescription?.toString()
+        }
+        return raw?.takeIf { it.isNotEmpty() }?.take(MAX_TEXT_LENGTH)
+    }
+
+    private fun resolveResourceId(view: View): String? {
+        if (view.id == View.NO_ID) return null
+        return try {
+            view.resources.getResourceEntryName(view.id)
+        } catch (_: Resources.NotFoundException) {
+            null
+        }
+    }
+
     companion object {
         const val CLICK_SPAN_NAME = "click"
+
+        // Cap captured text to match the web SDK's `Click` payload truncation.
+        private const val MAX_TEXT_LENGTH = 2000
     }
 }

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/client/UserInteractionManager.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/client/UserInteractionManager.kt
@@ -6,12 +6,14 @@ import android.content.res.Resources
 import android.os.Build
 import android.os.Bundle
 import android.os.SystemClock
+import android.text.method.PasswordTransformationMethod
 import android.view.KeyboardShortcutGroup
 import android.view.Menu
 import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
 import android.view.Window
+import android.widget.EditText
 import android.widget.TextView
 import androidx.annotation.RequiresApi
 import kotlinx.coroutines.channels.BufferOverflow
@@ -223,13 +225,24 @@ class UserInteractionManager : Application.ActivityLifecycleCallbacks {
         return root
     }
 
+    /**
+     * Best-effort, privacy-safe label for the target view. User-entered values are never captured:
+     * editable fields contribute only their hint (placeholder), and any password-masked view is
+     * skipped entirely. This mirrors the web SDK, which records an element's textContent (labels),
+     * never an input's typed value. Non-input [TextView]s (labels, buttons) contribute their text.
+     */
     private fun extractText(view: View): String? {
-        val raw = when (view) {
-            is TextView -> view.text?.toString()
+        val raw = when {
+            view is EditText -> if (isSensitive(view)) null else view.hint?.toString()
+            view is TextView -> if (isSensitive(view)) null else view.text?.toString()
             else -> view.contentDescription?.toString()
         }
         return raw?.takeIf { it.isNotEmpty() }?.take(MAX_TEXT_LENGTH)
     }
+
+    /** True when the field masks its content (password input), so its text must not be captured. */
+    private fun isSensitive(view: TextView): Boolean =
+        view.transformationMethod is PasswordTransformationMethod
 
     private fun resolveResourceId(view: View): String? {
         if (view.id == View.NO_ID) return null

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/plugin/ObservabilityHookExporter.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/plugin/ObservabilityHookExporter.kt
@@ -7,6 +7,7 @@ import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.logs.Severity
 import io.opentelemetry.api.trace.Span
+import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.api.trace.Tracer
 import org.json.JSONObject
 
@@ -42,6 +43,7 @@ internal class ObservabilityHookExporter(
 
         val tracer = getTracer()
         val span = tracer.spanBuilder(FEATURE_FLAG_SPAN_NAME)
+            .setSpanKind(SpanKind.INTERNAL)
             .setAllAttributes(
                 Attributes.builder()
                     .put(SEMCONV_FEATURE_FLAG_KEY, flagKey)

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/InteractionEvent.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/InteractionEvent.kt
@@ -10,4 +10,7 @@ data class InteractionEvent(
     val action: Int,
     val positions: List<Position>,
     val session: String,
+    val targetClassName: String? = null,
+    val targetText: String? = null,
+    val targetResourceId: String? = null,
 )

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/InteractionSource.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/InteractionSource.kt
@@ -57,6 +57,9 @@ class InteractionSource(
                         action = MotionEvent.ACTION_DOWN,
                         positions = listOf(Position(x, y, sample.timestamp)),
                         session = sessionManager.getSessionId(),
+                        targetClassName = sample.targetClassName,
+                        targetText = sample.targetText,
+                        targetResourceId = sample.targetResourceId,
                     )
                 )
             }

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/exporter/RRWebEventGenerator.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/exporter/RRWebEventGenerator.kt
@@ -1,6 +1,7 @@
 package com.launchdarkly.observability.replay.exporter
 
 import android.view.MotionEvent
+import com.launchdarkly.observability.context.ObserveLogger
 import com.launchdarkly.observability.replay.Event
 import com.launchdarkly.observability.replay.Addition
 import com.launchdarkly.observability.replay.EventData
@@ -31,7 +32,8 @@ import kotlinx.serialization.json.putJsonObject
  */
 class RRWebEventGenerator(
     private val canvasDrawEntourage: Int,
-    private val title: String
+    private val title: String,
+    private val logger: ObserveLogger? = null
 ) {
     companion object {
         private const val RRWEB_DOCUMENT_PADDING = 11
@@ -43,9 +45,7 @@ class RRWebEventGenerator(
         private const val DOM_LANG_EN = "en"
         private const val DOM_STYLE = "style"
         private const val DOM_BODY_STYLE = "position:relative;"
-        private const val CLICK_TARGET_VALUE = ""
-        private const val CLICK_TEXT_CONTENT_VALUE = ""
-        private const val CLICK_SELECTOR_VALUE = "view"
+        private const val CLICK_SELECTOR_FALLBACK = "view"
     }
 
     /**
@@ -314,21 +314,31 @@ class RRWebEventGenerator(
                         )
                     )
                 )
+                // Mirror the web `Click` payload (`highlight-run` ClickListener):
+                // - clickTarget: target view class name (web: full CSS selector path)
+                // - clickTextContent: the target's visible text (web: `target.textContent`)
+                // - clickSelector: resource-id else class name (web: `#id` else tag)
+                val clickCustomData = buildJsonObject {
+                    put("tag", RRWebCustomDataTag.CLICK.wireValue)
+                    putJsonObject("payload") {
+                        put("clickTarget", interactionEvent.targetClassName ?: "")
+                        put("clickTextContent", interactionEvent.targetText ?: "")
+                        put(
+                            "clickSelector",
+                            interactionEvent.targetResourceId
+                                ?: interactionEvent.targetClassName
+                                ?: CLICK_SELECTOR_FALLBACK
+                        )
+                    }
+                }
+                // Debug: log the JSON shape of the Session Replay `Click` custom event.
+                logger?.debug("[SR Click] $clickCustomData")
                 events.add(
                     Event(
                         type = EventType.CUSTOM,
                         timestamp = firstPosition.timestamp,
                         sid = nextSid(),
-                        data = EventDataUnion.CustomEventDataWrapper(
-                            buildJsonObject {
-                                put("tag", RRWebCustomDataTag.CLICK.wireValue)
-                                putJsonObject("payload") {
-                                    put("clickTarget", CLICK_TARGET_VALUE)
-                                    put("clickTextContent", CLICK_TEXT_CONTENT_VALUE)
-                                    put("clickSelector", CLICK_SELECTOR_VALUE)
-                                }
-                            }
-                        )
+                        data = EventDataUnion.CustomEventDataWrapper(clickCustomData)
                     )
                 )
             }

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/exporter/RRWebEventGenerator.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/exporter/RRWebEventGenerator.kt
@@ -1,7 +1,6 @@
 package com.launchdarkly.observability.replay.exporter
 
 import android.view.MotionEvent
-import com.launchdarkly.observability.context.ObserveLogger
 import com.launchdarkly.observability.replay.Event
 import com.launchdarkly.observability.replay.Addition
 import com.launchdarkly.observability.replay.EventData
@@ -32,8 +31,7 @@ import kotlinx.serialization.json.putJsonObject
  */
 class RRWebEventGenerator(
     private val canvasDrawEntourage: Int,
-    private val title: String,
-    private val logger: ObserveLogger? = null
+    private val title: String
 ) {
     companion object {
         private const val RRWEB_DOCUMENT_PADDING = 11
@@ -331,8 +329,6 @@ class RRWebEventGenerator(
                         )
                     }
                 }
-                // Debug: log the JSON shape of the Session Replay `Click` custom event.
-                logger?.debug("[SR Click] $clickCustomData")
                 events.add(
                     Event(
                         type = EventType.CUSTOM,

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/exporter/SessionReplayExporter.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/exporter/SessionReplayExporter.kt
@@ -53,7 +53,7 @@ class SessionReplayExporter(
     // TODO: O11Y-624 - need to implement sid, payloadId reset when multiple sessions occur in one application process lifecycle.
     private var payloadIdCounter = 0
     private var shouldWakeUpSession = true
-    private val eventGenerator = RRWebEventGenerator(canvasDrawEntourage, title)
+    private val eventGenerator = RRWebEventGenerator(canvasDrawEntourage, title, logger)
 
     private data class LastCaptureState(
         val sessionId: String?,

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/exporter/SessionReplayExporter.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/exporter/SessionReplayExporter.kt
@@ -53,7 +53,7 @@ class SessionReplayExporter(
     // TODO: O11Y-624 - need to implement sid, payloadId reset when multiple sessions occur in one application process lifecycle.
     private var payloadIdCounter = 0
     private var shouldWakeUpSession = true
-    private val eventGenerator = RRWebEventGenerator(canvasDrawEntourage, title, logger)
+    private val eventGenerator = RRWebEventGenerator(canvasDrawEntourage, title)
 
     private data class LastCaptureState(
         val sessionId: String?,


### PR DESCRIPTION
## Summary
- Hit-test the view hierarchy on `ACTION_DOWN` to resolve the tapped view and capture its class name, visible text, and resource id (best-effort; never affects touch dispatch).
- Populate the SR `Click` payload (`clickTarget` / `clickTextContent` / `clickSelector`) and the OTel `click` span (`event.tag` / `event.text` / `event.id`), matching the web/iOS semantics so the session player shows a meaningful description.
- Add **temporary** debug logs of the JSON shapes for both the OTel `click` span and the SR `Click` custom event.

## Note
The debug log lines are intentional and will be removed before release.

## Test plan
- [ ] Tap text and non-text elements; confirm `[Otel Click]` and `[SR Click]` debug logs show populated target/text/selector.
- [ ] Verify the session player renders a non-empty click description.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touch handling adds UI-thread hit-testing and may capture labels/ids (with password and input-value exclusions); span kind changes affect trace semantics across analytics and hooks.
> 
> **Overview**
> **Android touch analytics now resolve the tapped view** on `ACTION_DOWN` via a best-effort hierarchy hit-test (topmost visible child, scroll-aware). `TouchSample` and Session Replay `InteractionEvent` carry **class name**, **privacy-safe label** (button/label text or EditText hint—not typed values or password fields), and **resource entry name** (with React Native `testID` fallback).
> 
> **OTel `click` spans** add taxonomy fields `event.tag` / `event.classname` / `event.text` / `event.id` (tag derived via `shortElementTag`). **Session Replay** `Click` custom events populate `clickTarget`, `clickTextContent`, and `clickSelector` instead of placeholders.
> 
> **Span kinds** are set explicitly: `SpanKind.CLIENT` on user-facing spans (`click`, errors, track, screen views, app lifecycle, generic `startSpan`) and `SpanKind.INTERNAL` on feature-flag evaluation spans in `ObservabilityHookExporter`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e20b414e47044db5072c84a6bb2bc39c812bcd0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->