### PR TITLE
feat: update rrweb submodule to upstream v2.0.1 refresh

### DIFF
--- a/sdk/highlight-run/README.md
+++ b/sdk/highlight-run/README.md
@@ -2,6 +2,8 @@
 
 The official Javascript SDK for [Highlight](https://highlight.run).
 
+Session replay recording is powered by the [launchdarkly/rrweb](https://github.com/launchdarkly/rrweb) fork, currently synced with upstream rrweb v2.0.1.
+
 ## Next Steps
 
 -   [Documentation](https://docs.highlight.run)

--- a/yarn.lock
+++ b/yarn.lock
@@ -7488,7 +7488,6 @@ __metadata:
   resolution: "@highlight-run/rrdom-nodejs@workspace:rrweb/packages/rrdom-nodejs"
   dependencies:
     "@highlight-run/rrdom": "workspace:*"
-    "@highlight-run/rrweb-snapshot": "workspace:*"
     "@highlight-run/rrweb-types": "workspace:*"
     "@types/cssom": "npm:^0.4.1"
     "@types/cssstyle": "npm:^2.2.1"
@@ -7500,13 +7499,12 @@ __metadata:
     cssom: "npm:^0.5.0"
     cssstyle: "npm:^2.3.0"
     eslint: "npm:^8.15.0"
-    nwsapi: "npm:^2.2.0"
+    nwsapi: "npm:2.2.0"
     puppeteer: "npm:^9.1.1"
-    turbo: "npm:^2.0.5"
     typescript: "npm:^5.4.5"
-    vite: "npm:^5.3.1"
+    vite: "npm:^6.4.2"
     vite-plugin-dts: "npm:^3.9.1"
-    vitest: "npm:^4.1.0"
+    vitest: "npm:^3.2.6"
   languageName: unknown
   linkType: soft
 
@@ -7520,11 +7518,12 @@ __metadata:
     "@typescript-eslint/eslint-plugin": "npm:^5.23.0"
     "@typescript-eslint/parser": "npm:^5.23.0"
     eslint: "npm:^8.15.0"
+    happy-dom: "npm:^20.8.9"
     puppeteer: "npm:^17.1.3"
-    turbo: "npm:^2.0.5"
     typescript: "npm:^5.4.5"
-    vite: "npm:^5.3.1"
+    vite: "npm:^6.4.2"
     vite-plugin-dts: "npm:^3.9.1"
+    vitest: "npm:^3.2.6"
   languageName: unknown
   linkType: soft
 
@@ -7542,7 +7541,7 @@ __metadata:
     fs-extra: "npm:^11.1.1"
     jest: "npm:^27.5.1"
     minimist: "npm:^1.2.5"
-    playwright: "npm:^1.32.1"
+    playwright: "npm:^1.60.0"
     ts-jest: "npm:^27.1.3"
   bin:
     rrvideo: build/cli.js
@@ -7567,12 +7566,11 @@ __metadata:
     eslint-plugin-compat: "npm:^5.0.0"
     eslint-plugin-jest: "npm:^27.6.0"
     eslint-plugin-tsdoc: "npm:^0.2.17"
-    happy-dom: "npm:^14.12.0"
     markdownlint: "npm:^0.25.1"
     markdownlint-cli: "npm:^0.31.1"
     prettier: "npm:2.8.4"
     rollup-plugin-visualizer: "npm:^5.12.0"
-    turbo: "npm:2.8.7"
+    turbo: "npm:^2.9.14"
     typescript: "npm:^5.4.5"
   languageName: unknown
   linkType: soft
@@ -7585,11 +7583,29 @@ __metadata:
     "@highlight-run/rrweb-packer": "workspace:*"
     "@highlight-run/rrweb-types": "workspace:*"
     puppeteer: "npm:^20.9.0"
-    turbo: "npm:^2.0.5"
     typescript: "npm:^5.4.5"
-    vite: "npm:^5.3.1"
+    vite: "npm:^6.4.2"
     vite-plugin-dts: "npm:^3.9.1"
-    vitest: "npm:^4.1.0"
+    vitest: "npm:^3.2.6"
+  languageName: unknown
+  linkType: soft
+
+"@highlight-run/rrweb-browser-client@workspace:rrweb/packages/browser-client":
+  version: 0.0.0-use.local
+  resolution: "@highlight-run/rrweb-browser-client@workspace:rrweb/packages/browser-client"
+  dependencies:
+    "@highlight-run/rrweb": "workspace:*"
+    "@highlight-run/rrweb-record": "workspace:*"
+    "@highlight-run/rrweb-types": "workspace:*"
+    "@highlight-run/rrweb-utils": "workspace:*"
+    cross-env: "npm:^7.0.3"
+    happy-dom: "npm:^20.8.9"
+    puppeteer: "npm:^20.9.0"
+    typescript: "npm:^5.4.5"
+    vite: "npm:^6.4.2"
+    vite-plugin-dts: "npm:^3.9.1"
+    vitest: "npm:^3.2.6"
+    websocket-ts: "npm:^2.2.1"
   languageName: unknown
   linkType: soft
 
@@ -7599,11 +7615,10 @@ __metadata:
   dependencies:
     "@highlight-run/rrweb-types": "workspace:*"
     fflate: "npm:^0.4.4"
-    turbo: "npm:^2.0.5"
     typescript: "npm:^5.4.5"
-    vite: "npm:^5.3.1"
+    vite: "npm:^6.4.2"
     vite-plugin-dts: "npm:^3.9.1"
-    vitest: "npm:^4.1.0"
+    vitest: "npm:^3.2.6"
   languageName: unknown
   linkType: soft
 
@@ -7622,17 +7637,17 @@ __metadata:
     "@typescript-eslint/eslint-plugin": "npm:^7.0.0"
     "@typescript-eslint/parser": "npm:^7.0.0"
     eslint-plugin-svelte: "npm:^2.37.0"
-    prettier-plugin-svelte: "npm:^3.1.2"
+    prettier-plugin-svelte: "npm:3.2.4"
     svelte: "npm:^4.2.14"
     svelte-check: "npm:^3.4.3"
     svelte-preprocess: "npm:^5.0.3"
     svelte2tsx: "npm:^0.7.30"
     tslib: "npm:^2.0.0"
-    vite: "npm:^5.3.1"
+    vite: "npm:^6.4.2"
   languageName: unknown
   linkType: soft
 
-"@highlight-run/rrweb-record@workspace:rrweb/packages/record":
+"@highlight-run/rrweb-record@workspace:*, @highlight-run/rrweb-record@workspace:rrweb/packages/record":
   version: 0.0.0-use.local
   resolution: "@highlight-run/rrweb-record@workspace:rrweb/packages/record"
   dependencies:
@@ -7640,11 +7655,10 @@ __metadata:
     "@highlight-run/rrweb-types": "workspace:*"
     "@highlight-run/rrweb-utils": "workspace:*"
     puppeteer: "npm:^20.9.0"
-    turbo: "npm:^2.0.5"
     typescript: "npm:^5.4.5"
-    vite: "npm:^5.3.1"
+    vite: "npm:^6.4.2"
     vite-plugin-dts: "npm:^3.9.1"
-    vitest: "npm:^4.1.0"
+    vitest: "npm:^3.2.6"
   languageName: unknown
   linkType: soft
 
@@ -7655,11 +7669,10 @@ __metadata:
     "@highlight-run/rrweb": "workspace:*"
     "@highlight-run/rrweb-types": "workspace:*"
     puppeteer: "npm:^20.9.0"
-    turbo: "npm:^2.0.5"
     typescript: "npm:^5.4.5"
-    vite: "npm:^5.3.1"
+    vite: "npm:^6.4.2"
     vite-plugin-dts: "npm:^3.9.1"
-    vitest: "npm:^4.1.0"
+    vitest: "npm:^3.2.6"
   languageName: unknown
   linkType: soft
 
@@ -7668,9 +7681,8 @@ __metadata:
   resolution: "@highlight-run/rrweb-rrweb-plugin-canvas-webrtc-record@workspace:rrweb/packages/plugins/rrweb-plugin-canvas-webrtc-record"
   dependencies:
     "@highlight-run/rrweb": "workspace:*"
-    turbo: "npm:^2.0.5"
     typescript: "npm:^5.4.5"
-    vite: "npm:^5.3.1"
+    vite: "npm:^6.4.2"
     vite-plugin-dts: "npm:^3.9.1"
   peerDependencies:
     "@highlight-run/rrweb": "workspace:*"
@@ -7682,9 +7694,8 @@ __metadata:
   resolution: "@highlight-run/rrweb-rrweb-plugin-canvas-webrtc-replay@workspace:rrweb/packages/plugins/rrweb-plugin-canvas-webrtc-replay"
   dependencies:
     "@highlight-run/rrweb": "workspace:*"
-    turbo: "npm:^2.0.5"
     typescript: "npm:^5.4.5"
-    vite: "npm:^5.3.1"
+    vite: "npm:^6.4.2"
     vite-plugin-dts: "npm:^3.9.1"
   peerDependencies:
     "@highlight-run/rrweb": "workspace:*"
@@ -7697,11 +7708,10 @@ __metadata:
   dependencies:
     "@highlight-run/rrweb": "workspace:*"
     puppeteer: "npm:^20.9.0"
-    turbo: "npm:^2.0.5"
     typescript: "npm:^5.4.5"
-    vite: "npm:^5.3.1"
+    vite: "npm:^6.4.2"
     vite-plugin-dts: "npm:^3.9.1"
-    vitest: "npm:^4.1.0"
+    vitest: "npm:^3.2.6"
   peerDependencies:
     "@highlight-run/rrweb": "workspace:*"
     "@highlight-run/rrweb-utils": "workspace:*"
@@ -7714,12 +7724,44 @@ __metadata:
   dependencies:
     "@highlight-run/rrweb": "workspace:*"
     "@highlight-run/rrweb-rrweb-plugin-console-record": "workspace:*"
-    turbo: "npm:^2.0.5"
     typescript: "npm:^5.4.5"
-    vite: "npm:^5.3.1"
+    vite: "npm:^6.4.2"
     vite-plugin-dts: "npm:^3.9.1"
   peerDependencies:
     "@highlight-run/rrweb": "workspace:*"
+  languageName: unknown
+  linkType: soft
+
+"@highlight-run/rrweb-rrweb-plugin-network-record@workspace:*, @highlight-run/rrweb-rrweb-plugin-network-record@workspace:rrweb/packages/plugins/rrweb-plugin-network-record":
+  version: 0.0.0-use.local
+  resolution: "@highlight-run/rrweb-rrweb-plugin-network-record@workspace:rrweb/packages/plugins/rrweb-plugin-network-record"
+  dependencies:
+    "@highlight-run/rrweb": "workspace:*"
+    "@highlight-run/rrweb-types": "workspace:*"
+    "@highlight-run/rrweb-utils": "workspace:*"
+    typescript: "npm:^5.4.5"
+    vite: "npm:^6.4.2"
+    vite-plugin-dts: "npm:^3.9.1"
+    vitest: "npm:^3.2.6"
+  peerDependencies:
+    "@highlight-run/rrweb": "workspace:*"
+    "@highlight-run/rrweb-utils": "workspace:*"
+  languageName: unknown
+  linkType: soft
+
+"@highlight-run/rrweb-rrweb-plugin-network-replay@workspace:rrweb/packages/plugins/rrweb-plugin-network-replay":
+  version: 0.0.0-use.local
+  resolution: "@highlight-run/rrweb-rrweb-plugin-network-replay@workspace:rrweb/packages/plugins/rrweb-plugin-network-replay"
+  dependencies:
+    "@highlight-run/rrweb": "workspace:*"
+    "@highlight-run/rrweb-rrweb-plugin-network-record": "workspace:*"
+    "@highlight-run/rrweb-types": "workspace:*"
+    typescript: "npm:^5.4.5"
+    vite: "npm:^6.4.2"
+    vite-plugin-dts: "npm:^3.9.1"
+  peerDependencies:
+    "@highlight-run/rrweb": "workspace:*"
+    "@highlight-run/rrweb-types": "workspace:*"
   languageName: unknown
   linkType: soft
 
@@ -7728,9 +7770,8 @@ __metadata:
   resolution: "@highlight-run/rrweb-rrweb-plugin-sequential-id-record@workspace:rrweb/packages/plugins/rrweb-plugin-sequential-id-record"
   dependencies:
     "@highlight-run/rrweb": "workspace:*"
-    turbo: "npm:^2.0.5"
     typescript: "npm:^5.4.5"
-    vite: "npm:^5.3.1"
+    vite: "npm:^6.4.2"
     vite-plugin-dts: "npm:^3.9.1"
   peerDependencies:
     "@highlight-run/rrweb": "workspace:*"
@@ -7743,9 +7784,8 @@ __metadata:
   dependencies:
     "@highlight-run/rrweb": "workspace:*"
     "@highlight-run/rrweb-rrweb-plugin-sequential-id-record": "workspace:*"
-    turbo: "npm:^2.0.5"
     typescript: "npm:^5.4.5"
-    vite: "npm:^5.3.1"
+    vite: "npm:^6.4.2"
     vite-plugin-dts: "npm:^3.9.1"
   peerDependencies:
     "@highlight-run/rrweb": "workspace:*"
@@ -7761,15 +7801,16 @@ __metadata:
     "@types/jsdom": "npm:^20.0.0"
     "@types/node": "npm:^18.15.11"
     "@types/puppeteer": "npm:^5.4.4"
+    happy-dom: "npm:^20.8.9"
+    playwright: "npm:^1.60.0"
     postcss: "npm:^8.4.38"
     puppeteer: "npm:^17.1.3"
     ts-node: "npm:^7.0.1"
     tslib: "npm:^1.9.3"
-    turbo: "npm:^2.0.5"
     typescript: "npm:^5.4.5"
-    vite: "npm:^5.3.1"
+    vite: "npm:^6.4.2"
     vite-plugin-dts: "npm:^3.9.1"
-    vitest: "npm:^4.1.0"
+    vitest: "npm:^3.2.6"
   languageName: unknown
   linkType: soft
 
@@ -7777,8 +7818,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@highlight-run/rrweb-types@workspace:rrweb/packages/types"
   dependencies:
-    turbo: "npm:^2.0.5"
-    vite: "npm:^5.3.1"
+    vite: "npm:^6.4.2"
     vite-plugin-dts: "npm:^3.9.1"
   languageName: unknown
   linkType: soft
@@ -7787,7 +7827,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@highlight-run/rrweb-utils@workspace:rrweb/packages/utils"
   dependencies:
-    vite: "npm:^5.2.8"
+    vite: "npm:^6.4.2"
     vite-plugin-dts: "npm:^3.8.1"
   languageName: unknown
   linkType: soft
@@ -7804,21 +7844,23 @@ __metadata:
     "@highlight-run/rrweb-types": "workspace:*"
     "@tanstack/react-table": "npm:^8.5.22"
     "@types/chrome": "npm:^0.0.287"
+    "@types/react": "npm:^18.0.21"
     "@types/react-dom": "npm:^18.0.6"
     "@types/semver": "npm:^7.5.8"
     "@types/webextension-polyfill": "npm:^0.9.1"
     "@vitejs/plugin-react": "npm:^4.2.1"
+    cross-env: "npm:^7.0.3"
     framer-motion: "npm:^7.3.6"
     idb: "npm:^7.1.1"
     mitt: "npm:^3.0.0"
-    nanoid: "npm:^5.0.9"
+    nanoid: "npm:^4.0.0"
     react: "npm:^18.2.0"
     react-dom: "npm:^18.2.0"
     react-icons: "npm:^4.4.0"
     react-router-dom: "npm:^6.4.1"
     semver: "npm:^7.6.3"
     type-fest: "npm:^2.19.0"
-    vite: "npm:^5.3.1"
+    vite: "npm:^6.4.2"
     vite-plugin-web-extension: "npm:^4.1.3"
     vite-plugin-zip-pack: "npm:^1.2.2"
     webextension-polyfill: "npm:^0.10.0"
@@ -7842,20 +7884,22 @@ __metadata:
     "@xstate/fsm": "npm:^1.4.0"
     base64-arraybuffer: "npm:^1.0.1"
     construct-style-sheets-polyfill: "npm:^3.1.0"
+    cross-env: "npm:^7.0.3"
     fast-mhtml: "npm:^1.1.9"
     identity-obj-proxy: "npm:^3.0.0"
     ignore-styles: "npm:^5.0.1"
     inquirer: "npm:^9.0.0"
     jest-image-snapshot: "npm:^6.2.0"
     mitt: "npm:^3.0.0"
+    playwright: "npm:^1.60.0"
     puppeteer: "npm:^20.9.0"
     simple-peer-light: "npm:^9.10.0"
     ts-node: "npm:^10.9.1"
     tslib: "npm:^2.3.1"
-    turbo: "npm:^2.0.5"
     typescript: "npm:^5.4.5"
-    vite: "npm:^5.3.1"
+    vite: "npm:^6.4.2"
     vite-plugin-dts: "npm:^3.9.1"
+    vitest: "npm:^3.2.6"
   languageName: unknown
   linkType: soft
 
@@ -16923,13 +16967,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react@npm:^18, @types/react@npm:~18.3.12":
-  version: 18.3.23
-  resolution: "@types/react@npm:18.3.23"
+"@types/react@npm:^18, @types/react@npm:^18.0.21, @types/react@npm:~18.3.12":
+  version: 18.3.31
+  resolution: "@types/react@npm:18.3.31"
   dependencies:
     "@types/prop-types": "npm:*"
-    csstype: "npm:^3.0.2"
-  checksum: 10/4b965dffe34a1f8aac8e2d7e976f113373f38134f9e37239f7e75d7ac6b3c2e1333a8df21febf1fe7749640f8de5708f7668cdfc70bffebda1cc4d3346724fd5
+    csstype: "npm:^3.2.2"
+  checksum: 10/0a5d73b1ba3ce73273b28cc50da78d520b1a8d4253075820dc5cf6c9e286ff6cb339b56bd613d05885fec214fbecd8137bddcbdb475612fdcc46e061d88f00fc
   languageName: node
   linkType: hard
 
@@ -36341,12 +36385,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^5.0.9":
-  version: 5.1.5
-  resolution: "nanoid@npm:5.1.5"
+"nanoid@npm:^4.0.0":
+  version: 4.0.2
+  resolution: "nanoid@npm:4.0.2"
   bin:
     nanoid: bin/nanoid.js
-  checksum: 10/6de2d006b51c983be385ef7ee285f7f2a57bd96f8c0ca881c4111461644bd81fafc2544f8e07cb834ca0f3e0f3f676c1fe78052183f008b0809efe6e273119f5
+  checksum: 10/8c0c267de44cddcad79c3361d2cbd281694c36bf7ab6a163f36dd8f6e6ee43e9783561302c55fab2986a2fa847e7a6b30fedabd1e117fdb8aecc5ab21555428d
   languageName: node
   linkType: hard
 
@@ -37294,6 +37338,13 @@ __metadata:
   version: 1.1.1
   resolution: "nullthrows@npm:1.1.1"
   checksum: 10/c7cf377a095535dc301d81cf7959d3784d090a609a2a4faa40b6121a0c1d7f70d3a3aa534a34ab852e8553b66848ec503c28f2c19efd617ed564dc07dfbb6d33
+  languageName: node
+  linkType: hard
+
+"nwsapi@npm:2.2.0":
+  version: 2.2.0
+  resolution: "nwsapi@npm:2.2.0"
+  checksum: 10/d27812654974786b5ddaf3d5834dbcd840d5705f3b594e9b11a6eb67f35349b847111e16c178ad98d327a4de3b98a5b765809d294066e13d9793486d68823a91
   languageName: node
   linkType: hard
 
@@ -38839,27 +38890,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"playwright-core@npm:1.58.2":
-  version: 1.58.2
-  resolution: "playwright-core@npm:1.58.2"
+"playwright-core@npm:1.60.0":
+  version: 1.60.0
+  resolution: "playwright-core@npm:1.60.0"
   bin:
     playwright-core: cli.js
-  checksum: 10/8a98fcf122167e8703d525db2252de0e3da4ab9110ab6ea9951247e52d846310eb25ea2c805e1b7ccb54b4010c44e5adc3a76aae6da02f34324ccc3e76683bb1
+  checksum: 10/66c0f83d627e673261c848dd6fe1f2856d5b5b6859268acb61a45c00f5bf926e596a351a9c481a3a4e82a45022c7c6b5d99ebc3906fc6876ac582ed6f7e16190
   languageName: node
   linkType: hard
 
-"playwright@npm:^1.32.1":
-  version: 1.58.2
-  resolution: "playwright@npm:1.58.2"
+"playwright@npm:^1.60.0":
+  version: 1.60.0
+  resolution: "playwright@npm:1.60.0"
   dependencies:
     fsevents: "npm:2.3.2"
-    playwright-core: "npm:1.58.2"
+    playwright-core: "npm:1.60.0"
   dependenciesMeta:
     fsevents:
       optional: true
   bin:
     playwright: cli.js
-  checksum: 10/d89d6c8a32388911b9aff9ee0f1a90076219f15c804f2b287db048b9e9cde182aea3131fac1959051d25189ed4218ec4272b137c83cd7f9cd24781cbc77edd86
+  checksum: 10/8569770637ee35d08cca3b53a5b56c21e9236bd1ac4718456d5988fb8acd51c5b3cc2cf90748363a36199529e870a9b6c68d6fc9e19571261cd867005d6331c1
   languageName: node
   linkType: hard
 
@@ -39224,13 +39275,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier-plugin-svelte@npm:^3.1.2":
-  version: 3.2.5
-  resolution: "prettier-plugin-svelte@npm:3.2.5"
+"prettier-plugin-svelte@npm:3.2.4":
+  version: 3.2.4
+  resolution: "prettier-plugin-svelte@npm:3.2.4"
   peerDependencies:
     prettier: ^3.0.0
     svelte: ^3.2.0 || ^4.0.0-next.0 || ^5.0.0-next.0
-  checksum: 10/5d2e506294800cded1f6b5af7941a7afbafd7caf68625b89863729746ab58746f5466368ebbfd104069fc722fedb98eb9a397d8fc2dbe9ba2c1de3909272f0c3
+  checksum: 10/3daebb256138aa0f6487cb8e80a38945ba484284a6d48c551de5f08a5e48c4f3a642432363ddee9f4d4c058c2da3f443728585257c99c4301dd6576b9e088aee
   languageName: node
   linkType: hard
 
@@ -47045,7 +47096,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite5@npm:vite@^5.4.21, vite@npm:^5.0.0 || ^4.1.4, vite@npm:^5.2.8, vite@npm:^5.3.1, vite@npm:^5.4.21":
+"vite5@npm:vite@^5.4.21, vite@npm:^5.0.0 || ^4.1.4, vite@npm:^5.4.21":
   version: 5.4.21
   resolution: "vite@npm:5.4.21"
   dependencies:
@@ -47870,6 +47921,13 @@ __metadata:
   version: 0.1.4
   resolution: "websocket-extensions@npm:0.1.4"
   checksum: 10/b5399b487d277c78cdd2aef63764b67764aa9899431e3a2fa272c6ad7236a0fb4549b411d89afa76d5afd664c39d62fc19118582dc937e5bb17deb694f42a0d1
+  languageName: node
+  linkType: hard
+
+"websocket-ts@npm:^2.2.1":
+  version: 2.3.0
+  resolution: "websocket-ts@npm:2.3.0"
+  checksum: 10/915bb47d46acf6ca619e579130e7a6a99aa8ec9f714943dad84b7a92fb7d61bbafaf7f5bfc4e415b741bb643b534ebd957f6b4ca2ecbee47482facbbdc05f1c7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Bumps the `rrweb` submodule to current fork main, which includes:

- **Upstream refresh to rrweb v2.0.1** (launchdarkly/rrweb#29) — first upstream sync in ~2 years, plus standalone CI (build/lint/tests) for the fork
- **Dependabot updates** (launchdarkly/rrweb#31) — vite 6, vitest 3, happy-dom 20, turbo 2.9
- **tsconfig lib fix** (launchdarkly/rrweb#34) — restores ES2017 lib so `@highlight-run/rrweb` type-checks inside this workspace

Only the submodule pin and the regenerated `yarn.lock` change — no SDK source changes needed (main already migrated to vite 6 / vitest 4, which covers the previously-required companion changes).

## Validation (local, against this exact pin)

- `yarn install` + `yarn dedupe --check` clean
- `yarn build:sdk` 18/18 tasks green
- `yarn enforce-size` 9/9 (highlight.run within the 256 kB brotli limit)
- `yarn turbo run test --filter=highlight.run` — 437/437 tests pass

## Release

`feat:` commit → release-please cuts a **minor** for `highlight.run`; the `node-workspace` plugin cascades linked bumps to `@launchdarkly/observability` and `@launchdarkly/session-replay`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large session-replay dependency refresh after a long upstream gap; replay fidelity and bundle behavior depend on rrweb even though SDK code is unchanged in this PR.
> 
> **Overview**
> Updates the vendored **launchdarkly/rrweb** workspace (submodule refresh to upstream **v2.0.1**) and regenerates **`yarn.lock`** so Highlight’s session-replay stack matches the fork’s current packages and tooling.
> 
> The lockfile shifts rrweb workspaces toward **Vite 6**, **Vitest 3**, **happy-dom 20**, **Playwright 1.60**, and **turbo 2.9**, and wires in new fork packages such as **`@highlight-run/rrweb-browser-client`** and the **network record/replay** plugins. **`sdk/highlight-run/README.md`** now states that recording uses the LaunchDarkly rrweb fork synced to v2.0.1.
> 
> No `highlight.run` SDK source changes in this diff—only dependency/workspace metadata and documentation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16df13f46784788b8f99b3bee73e9012808d8c66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->