### PR TITLE
feat(flutter): forward identify to native observability + Session Replay

### DIFF
--- a/sdk/@launchdarkly/flutter/example/lib/dialogs_page.dart
+++ b/sdk/@launchdarkly/flutter/example/lib/dialogs_page.dart
@@ -23,7 +23,9 @@ class DialogsPage extends StatefulWidget {
 
 class _DialogsPageState extends State<DialogsPage> {
   final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
-  final TextEditingController _delayController = TextEditingController(text: '0');
+  final TextEditingController _delayController = TextEditingController(
+    text: '0',
+  );
   final GlobalKey<TooltipState> _tooltipKey = GlobalKey<TooltipState>();
 
   @override
@@ -40,8 +42,9 @@ class _DialogsPageState extends State<DialogsPage> {
 
   /// Waits the configured "Show delay" before presenting, mirroring MAUI's
   /// `WaitForDelay`.
-  Future<void> _waitDelay() =>
-      _delay == Duration.zero ? Future<void>.value() : Future<void>.delayed(_delay);
+  Future<void> _waitDelay() => _delay == Duration.zero
+      ? Future<void>.value()
+      : Future<void>.delayed(_delay);
 
   /// Auto-dismiss interval for transient items (snackbar, banner, overlays).
   /// Falls back to [fallback] when no delay is configured.
@@ -278,7 +281,9 @@ class _DialogsPageState extends State<DialogsPage> {
   Future<void> _onCustomTransitionDialog() async {
     await _waitDelay();
     if (!mounted) return;
-    final seconds = _delay == Duration.zero ? 8 : (_delay.inSeconds).clamp(1, 999);
+    final seconds = _delay == Duration.zero
+        ? 8
+        : (_delay.inSeconds).clamp(1, 999);
     await showGeneralDialog<void>(
       context: context,
       barrierDismissible: true,
@@ -294,7 +299,10 @@ class _DialogsPageState extends State<DialogsPage> {
         ),
       ),
       transitionBuilder: (context, animation, secondaryAnimation, child) {
-        final curved = CurvedAnimation(parent: animation, curve: Curves.easeOutBack);
+        final curved = CurvedAnimation(
+          parent: animation,
+          curve: Curves.easeOutBack,
+        );
         return FadeTransition(
           opacity: animation,
           child: ScaleTransition(scale: curved, child: child),
@@ -333,7 +341,10 @@ class _DialogsPageState extends State<DialogsPage> {
       ),
     );
     overlay.insert(entry);
-    Future<void>.delayed(_autoDismiss(fallback: const Duration(seconds: 8)), remove);
+    Future<void>.delayed(
+      _autoDismiss(fallback: const Duration(seconds: 8)),
+      remove,
+    );
   }
 
   // --- Notifications ---
@@ -384,10 +395,7 @@ class _DialogsPageState extends State<DialogsPage> {
   Future<void> _onTimePicker() async {
     await _waitDelay();
     if (!mounted) return;
-    await showTimePicker(
-      context: context,
-      initialTime: TimeOfDay.now(),
-    );
+    await showTimePicker(context: context, initialTime: TimeOfDay.now());
   }
 
   // --- Shared helpers ---
@@ -471,7 +479,10 @@ class _DialogsPageState extends State<DialogsPage> {
                 _DialogButton('Modal Sheet', _onModalSheet),
                 _DialogButton('Expandable Sheet', _onExpandableSheet),
                 _DialogButton('Persistent Sheet', _onPersistentSheet),
-                _DialogButton('Cupertino Action Sheet', _onCupertinoActionSheet),
+                _DialogButton(
+                  'Cupertino Action Sheet',
+                  _onCupertinoActionSheet,
+                ),
               ],
             ),
 
@@ -621,10 +632,7 @@ class _CountdownCardState extends State<_CountdownCard> {
               ],
             ),
             const SizedBox(height: 16),
-            Text(
-              '$mm:$ss',
-              style: Theme.of(context).textTheme.displaySmall,
-            ),
+            Text('$mm:$ss', style: Theme.of(context).textTheme.displaySmall),
             Text(
               'Time Remaining',
               style: Theme.of(context).textTheme.bodySmall,
@@ -649,10 +657,7 @@ class _DialogButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ElevatedButton(
-      onPressed: () => onPressed(),
-      child: Text(label),
-    );
+    return ElevatedButton(onPressed: () => onPressed(), child: Text(label));
   }
 }
 

--- a/sdk/@launchdarkly/flutter/example/lib/smoothie_list_page.dart
+++ b/sdk/@launchdarkly/flutter/example/lib/smoothie_list_page.dart
@@ -78,10 +78,7 @@ class _SmoothieRow extends StatelessWidget {
       padding: const EdgeInsets.all(12),
       child: Row(
         children: [
-          ClipRRect(
-            borderRadius: BorderRadius.circular(4),
-            child: image,
-          ),
+          ClipRRect(borderRadius: BorderRadius.circular(4), child: image),
           const SizedBox(width: 12),
           Expanded(
             // Redact the smoothie title from session replay. `maskLabels` is

--- a/sdk/@launchdarkly/flutter/example/lib/web_view_page.dart
+++ b/sdk/@launchdarkly/flutter/example/lib/web_view_page.dart
@@ -67,9 +67,7 @@ class _WebViewDialogState extends State<WebViewDialog> {
             const Divider(height: 1),
             // The web view is a platform view; with `maskWebViews: true` its
             // region is redacted in Session Replay recordings.
-            Expanded(
-              child: WebViewWidget(controller: _controller),
-            ),
+            Expanded(child: WebViewWidget(controller: _controller)),
           ],
         ),
       ),

--- a/sdk/@launchdarkly/flutter/packages/observability/README.md
+++ b/sdk/@launchdarkly/flutter/packages/observability/README.md
@@ -403,6 +403,8 @@ final userContext = LDContextBuilder()
 await client.identify(userContext);
 ```
 
+You do not need to call anything on `LDObserve`: the observability plugin hooks into the LaunchDarkly client and, on mobile, forwards each completed identify to the native observability SDK and Session Replay. This attributes subsequent `LDObserve.track` events to the active context and records who the user is on the active Session Replay recording.
+
 ## Example
 
 A complete, runnable sample app lives in [`example/`](../../example). See its [README](../../example/README.md) for how to configure credentials and launch it on each platform.

--- a/sdk/@launchdarkly/flutter/packages/observability/android/build.gradle
+++ b/sdk/@launchdarkly/flutter/packages/observability/android/build.gradle
@@ -50,7 +50,7 @@ dependencies {
     // Native dependencies mirrored from the LaunchDarkly mobile SDKs (the same
     // stack used by sdk/@launchdarkly/react-native-ld-session-replay and the
     // .NET MAUI bridge in sdk/@launchdarkly/mobile-dotnet).
-    implementation "com.launchdarkly:launchdarkly-observability-android:0.54.0"
+    implementation "com.launchdarkly:launchdarkly-observability-android:0.56.0"
     // OTel Attributes appears in ObservabilityOptions parameter types; provided
     // at runtime transitively through launchdarkly-observability-android.
     implementation "io.opentelemetry:opentelemetry-api:1.62.0"

--- a/sdk/@launchdarkly/flutter/packages/observability/android/src/main/kotlin/com/launchdarkly/launchdarkly_flutter_observability/LDNativeApiImpl.kt
+++ b/sdk/@launchdarkly/flutter/packages/observability/android/src/main/kotlin/com/launchdarkly/launchdarkly_flutter_observability/LDNativeApiImpl.kt
@@ -215,13 +215,17 @@ internal class LDNativeApiImpl(
     // context keys so the manual track path is attributed to the active context)
     // and Session Replay (which records who the user is on the active recording).
     // The Dart side calls this from the LaunchDarkly client's `afterIdentify`
-    // hook. Mirrors MAUI's `ObservabilityHook.AfterIdentify`.
+    // hook. Reuses the same public cross-platform hook proxies that React Native
+    // (`LDReplay.hookProxy`) and MAUI drive, mirroring the iOS plugin — so no
+    // bespoke combined bridge entry point is needed.
     override fun identify(
         contextKeys: Map<String, String>,
         canonicalKey: String,
         completed: Boolean,
     ) {
-        LDObserveBridge.identify(contextKeys, canonicalKey, completed)
+        LDObserveBridge.getObservabilityHookProxy()
+            ?.afterIdentify(contextKeys, canonicalKey, completed)
+        LDReplay.hookProxy?.afterIdentify(contextKeys, canonicalKey, completed)
     }
 
     /**

--- a/sdk/@launchdarkly/flutter/packages/observability/android/src/main/kotlin/com/launchdarkly/launchdarkly_flutter_observability/LDNativeApiImpl.kt
+++ b/sdk/@launchdarkly/flutter/packages/observability/android/src/main/kotlin/com/launchdarkly/launchdarkly_flutter_observability/LDNativeApiImpl.kt
@@ -211,6 +211,19 @@ internal class LDNativeApiImpl(
         LDObserveBridge.track(key, data, metricValue, contextKeys)
     }
 
+    // Forwards an identify to the native observability SDK (which caches the
+    // context keys so the manual track path is attributed to the active context)
+    // and Session Replay (which records who the user is on the active recording).
+    // The Dart side calls this from the LaunchDarkly client's `afterIdentify`
+    // hook. Mirrors MAUI's `ObservabilityHook.AfterIdentify`.
+    override fun identify(
+        contextKeys: Map<String, String>,
+        canonicalKey: String,
+        completed: Boolean,
+    ) {
+        LDObserveBridge.identify(contextKeys, canonicalKey, completed)
+    }
+
     /**
      * Maps the OpenTelemetry log-severity number sent across the bridge onto the
      * native [ObservabilityOptions.LogLevel]. Defaults to [ObservabilityOptions.LogLevel.INFO]

--- a/sdk/@launchdarkly/flutter/packages/observability/android/src/main/kotlin/com/launchdarkly/launchdarkly_flutter_observability/Messages.g.kt
+++ b/sdk/@launchdarkly/flutter/packages/observability/android/src/main/kotlin/com/launchdarkly/launchdarkly_flutter_observability/Messages.g.kt
@@ -625,6 +625,17 @@ interface LDNativeApi {
    * only the span is annotated, not the Session Replay `Track` payload.
    */
   fun track(key: String, data: Map<String, Any?>?, metricValue: Double?, contextKeys: Map<String, String>?)
+  /**
+   * Forwards an `identify` to the native observability SDK and Session Replay.
+   * Native observability caches `contextKeys` so manual `LDObserve.track` calls
+   * (which carry no context) are attributed to the active context, and Session
+   * Replay records who the user is on the active recording. `contextKeys`
+   * carries the context's kind -> key pairs, `canonicalKey` the fully-qualified
+   * key, and `completed` whether the identify finished successfully (native
+   * ignores incomplete identifies). Mirrors MAUI's
+   * `ObservabilityHook.AfterIdentify` /  `SessionReplayHook.AfterIdentify`.
+   */
+  fun identify(contextKeys: Map<String, String>, canonicalKey: String, completed: Boolean)
 
   companion object {
     /** The codec used by LDNativeApi. */
@@ -705,6 +716,26 @@ interface LDNativeApi {
             val contextKeysArg = args[3] as Map<String, String>?
             val wrapped: List<Any?> = try {
               api.track(keyArg, dataArg, metricValueArg, contextKeysArg)
+              listOf(null)
+            } catch (exception: Throwable) {
+              MessagesPigeonUtils.wrapError(exception)
+            }
+            reply.reply(wrapped)
+          }
+        } else {
+          channel.setMessageHandler(null)
+        }
+      }
+      run {
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.launchdarkly_flutter_observability.LDNativeApi.identify$separatedMessageChannelSuffix", codec)
+        if (api != null) {
+          channel.setMessageHandler { message, reply ->
+            val args = message as List<Any?>
+            val contextKeysArg = args[0] as Map<String, String>
+            val canonicalKeyArg = args[1] as String
+            val completedArg = args[2] as Boolean
+            val wrapped: List<Any?> = try {
+              api.identify(contextKeysArg, canonicalKeyArg, completedArg)
               listOf(null)
             } catch (exception: Throwable) {
               MessagesPigeonUtils.wrapError(exception)

--- a/sdk/@launchdarkly/flutter/packages/observability/ios/launchdarkly_flutter_observability.podspec
+++ b/sdk/@launchdarkly/flutter/packages/observability/ios/launchdarkly_flutter_observability.podspec
@@ -15,8 +15,8 @@ The LaunchDarkly Observability and Session Replay plugin for Flutter.
   # Native dependencies mirrored from the LaunchDarkly mobile SDKs (the same
   # stack used by sdk/@launchdarkly/react-native-ld-session-replay and the
   # .NET MAUI bridge in sdk/@launchdarkly/mobile-dotnet).
-  s.dependency 'LaunchDarklyObservability', '~> 0.41.0'
-  s.dependency 'LaunchDarklySessionReplay', '~> 0.41.0'
+  s.dependency 'LaunchDarklyObservability', '~> 0.42.0'
+  s.dependency 'LaunchDarklySessionReplay', '~> 0.42.0'
 
   s.platform         = :ios, '14.0'
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }

--- a/sdk/@launchdarkly/flutter/packages/observability/ios/launchdarkly_flutter_observability/Package.swift
+++ b/sdk/@launchdarkly/flutter/packages/observability/ios/launchdarkly_flutter_observability/Package.swift
@@ -20,7 +20,7 @@ let swiftObservabilityDependency: Package.Dependency = if useLocalNativeSdk {
 } else {
     .package(
         url: "https://github.com/launchdarkly/swift-launchdarkly-observability.git",
-        .upToNextMinor(from: "0.41.0")
+        .upToNextMinor(from: "0.42.0")
     )
 }
 

--- a/sdk/@launchdarkly/flutter/packages/observability/ios/launchdarkly_flutter_observability/Sources/launchdarkly_flutter_observability/LDNativeApiImpl.swift
+++ b/sdk/@launchdarkly/flutter/packages/observability/ios/launchdarkly_flutter_observability/Sources/launchdarkly_flutter_observability/LDNativeApiImpl.swift
@@ -118,6 +118,26 @@ final class LDNativeApiImpl: NSObject, LDNativeApi {
         )
     }
 
+    // Forwards an identify to the native observability SDK (which caches the
+    // context keys so the manual track path is attributed to the active context)
+    // and Session Replay (which records who the user is on the active recording).
+    // The Dart side calls this from the LaunchDarkly client's `afterIdentify`
+    // hook. Mirrors MAUI's `ObservabilityHook.AfterIdentify` /
+    // `SessionReplayHook.AfterIdentify`.
+    func identify(contextKeys: [String: String], canonicalKey: String, completed: Bool) throws {
+        let keys = contextKeys as NSDictionary
+        ObjcLDObserveBridge.getObservabilityHookProxy()?.afterIdentify(
+            contextKeys: keys,
+            canonicalKey: canonicalKey,
+            completed: completed
+        )
+        LDReplay.shared.hookProxy?.afterIdentify(
+            contextKeys: keys,
+            canonicalKey: canonicalKey,
+            completed: completed
+        )
+    }
+
     /// Drops `nil` values so the native bridge receives a `[String: Any]`.
     private func cleanAttributes(_ attributes: [String: Any?]?) -> [String: Any] {
         guard let attributes = attributes else { return [:] }

--- a/sdk/@launchdarkly/flutter/packages/observability/ios/launchdarkly_flutter_observability/Sources/launchdarkly_flutter_observability/Messages.g.swift
+++ b/sdk/@launchdarkly/flutter/packages/observability/ios/launchdarkly_flutter_observability/Sources/launchdarkly_flutter_observability/Messages.g.swift
@@ -650,6 +650,15 @@ protocol LDNativeApi {
   /// native `track` span is attributed to the same context the web SDK records;
   /// only the span is annotated, not the Session Replay `Track` payload.
   func track(key: String, data: [String: Any?]?, metricValue: Double?, contextKeys: [String: String]?) throws
+  /// Forwards an `identify` to the native observability SDK and Session Replay.
+  /// Native observability caches `contextKeys` so manual `LDObserve.track` calls
+  /// (which carry no context) are attributed to the active context, and Session
+  /// Replay records who the user is on the active recording. `contextKeys`
+  /// carries the context's kind -> key pairs, `canonicalKey` the fully-qualified
+  /// key, and `completed` whether the identify finished successfully (native
+  /// ignores incomplete identifies). Mirrors MAUI's
+  /// `ObservabilityHook.AfterIdentify` /  `SessionReplayHook.AfterIdentify`.
+  func identify(contextKeys: [String: String], canonicalKey: String, completed: Bool) throws
 }
 
 /// Generated setup class from Pigeon to handle messages through the `binaryMessenger`.
@@ -736,6 +745,31 @@ class LDNativeApiSetup {
       }
     } else {
       trackChannel.setMessageHandler(nil)
+    }
+    /// Forwards an `identify` to the native observability SDK and Session Replay.
+    /// Native observability caches `contextKeys` so manual `LDObserve.track` calls
+    /// (which carry no context) are attributed to the active context, and Session
+    /// Replay records who the user is on the active recording. `contextKeys`
+    /// carries the context's kind -> key pairs, `canonicalKey` the fully-qualified
+    /// key, and `completed` whether the identify finished successfully (native
+    /// ignores incomplete identifies). Mirrors MAUI's
+    /// `ObservabilityHook.AfterIdentify` /  `SessionReplayHook.AfterIdentify`.
+    let identifyChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.launchdarkly_flutter_observability.LDNativeApi.identify\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+    if let api = api {
+      identifyChannel.setMessageHandler { message, reply in
+        let args = message as! [Any?]
+        let contextKeysArg = args[0] as! [String: String]
+        let canonicalKeyArg = args[1] as! String
+        let completedArg = args[2] as! Bool
+        do {
+          try api.identify(contextKeys: contextKeysArg, canonicalKey: canonicalKeyArg, completed: completedArg)
+          reply(wrapResult(nil))
+        } catch {
+          reply(wrapError(error))
+        }
+      }
+    } else {
+      identifyChannel.setMessageHandler(nil)
     }
   }
 }

--- a/sdk/@launchdarkly/flutter/packages/observability/lib/src/observe_otel.dart
+++ b/sdk/@launchdarkly/flutter/packages/observability/lib/src/observe_otel.dart
@@ -67,6 +67,28 @@ final class ObserveOtel {
     );
   }
 
+  /// Forward an `identify` to the platform-appropriate pipeline.
+  ///
+  /// Invoked from the LaunchDarkly client's `afterIdentify` hook. On mobile the
+  /// native observability SDK caches [contextKeys] so the manual
+  /// [LDObserve.track] path is attributed to the active context, and Session
+  /// Replay records who the user is on the active recording. On web this is a
+  /// no-op. [canonicalKey] is the context's fully-qualified key; [completed]
+  /// indicates whether the identify finished successfully (native ignores
+  /// incomplete identifies). `null` before the pipeline is initialized, in which
+  /// case the identify is dropped.
+  static void identify({
+    required Map<String, String> contextKeys,
+    required String canonicalKey,
+    required bool completed,
+  }) {
+    Otel.identifyRecorder?.identify(
+      contextKeys: contextKeys,
+      canonicalKey: canonicalKey,
+      completed: completed,
+    );
+  }
+
   /// Record an exception with an optional stack trace and attributes.
   ///
   /// In dart the stack trace is independent of the exception object and can

--- a/sdk/@launchdarkly/flutter/packages/observability/lib/src/otel/exporters/exporter_factory.dart
+++ b/sdk/@launchdarkly/flutter/packages/observability/lib/src/otel/exporters/exporter_factory.dart
@@ -55,6 +55,23 @@ abstract interface class TrackRecorder {
   });
 }
 
+/// Forwards an `identify` through the platform-appropriate pipeline.
+///
+/// - Web: no-op. The Dart pipeline has no Session Replay and the manual track
+///   path already attributes spans from the live context, so there is nothing
+///   to cache.
+/// - Native (io): forwarded to the native observability SDK (which caches the
+///   context keys so the manual `LDObserve.track` path is attributed to the
+///   active context) and Session Replay (which records who the user is on the
+///   active recording). Mirrors MAUI's `ObservabilityHook.AfterIdentify`.
+abstract interface class IdentifyRecorder {
+  void identify({
+    required Map<String, String> contextKeys,
+    required String canonicalKey,
+    required bool completed,
+  });
+}
+
 /// Factory for the span and log exporters used by the observability pipeline.
 ///
 /// The concrete implementation is selected per build target via conditional
@@ -71,4 +88,7 @@ abstract interface class ObservabilityExporters {
 
   /// Builds the track recorder used by `track`.
   TrackRecorder createTrackRecorder(ObservabilityConfig config);
+
+  /// Builds the identify recorder used by `identify`.
+  IdentifyRecorder createIdentifyRecorder(ObservabilityConfig config);
 }

--- a/sdk/@launchdarkly/flutter/packages/observability/lib/src/otel/exporters/exporter_factory_io.dart
+++ b/sdk/@launchdarkly/flutter/packages/observability/lib/src/otel/exporters/exporter_factory_io.dart
@@ -34,6 +34,29 @@ class _IoExporters implements ObservabilityExporters {
   @override
   TrackRecorder createTrackRecorder(ObservabilityConfig config) =>
       _NativeTrackRecorder(_api);
+
+  @override
+  IdentifyRecorder createIdentifyRecorder(ObservabilityConfig config) =>
+      _NativeIdentifyRecorder(_api);
+}
+
+/// Forwards each `identify` to the native observability SDK (which caches the
+/// context keys so the manual `LDObserve.track` path is attributed to the active
+/// context) and Session Replay (which records who the user is on the active
+/// recording). Mirrors MAUI's `ObservabilityHook.AfterIdentify`.
+class _NativeIdentifyRecorder implements IdentifyRecorder {
+  _NativeIdentifyRecorder(this._api);
+
+  final wire.LDNativeApi _api;
+
+  @override
+  void identify({
+    required Map<String, String> contextKeys,
+    required String canonicalKey,
+    required bool completed,
+  }) {
+    unawaited(_api.identify(contextKeys, canonicalKey, completed));
+  }
 }
 
 /// Forwards each `track` call to the native observability SDK so it emits the

--- a/sdk/@launchdarkly/flutter/packages/observability/lib/src/otel/exporters/exporter_factory_stub.dart
+++ b/sdk/@launchdarkly/flutter/packages/observability/lib/src/otel/exporters/exporter_factory_stub.dart
@@ -34,6 +34,21 @@ class _StubExporters implements ObservabilityExporters {
   @override
   TrackRecorder createTrackRecorder(ObservabilityConfig config) =>
       _SpanTrackRecorder(config.trackEventsEnabled);
+
+  @override
+  IdentifyRecorder createIdentifyRecorder(ObservabilityConfig config) =>
+      _NoopIdentifyRecorder();
+}
+
+/// No Session Replay or context-key caching exists on the Dart pipeline, so
+/// `identify` has nothing to forward.
+class _NoopIdentifyRecorder implements IdentifyRecorder {
+  @override
+  void identify({
+    required Map<String, String> contextKeys,
+    required String canonicalKey,
+    required bool completed,
+  }) {}
 }
 
 /// Emits each `track` event as a Dart `track` span via the OpenTelemetry

--- a/sdk/@launchdarkly/flutter/packages/observability/lib/src/otel/exporters/exporter_factory_web.dart
+++ b/sdk/@launchdarkly/flutter/packages/observability/lib/src/otel/exporters/exporter_factory_web.dart
@@ -35,6 +35,21 @@ class _WebExporters implements ObservabilityExporters {
   @override
   TrackRecorder createTrackRecorder(ObservabilityConfig config) =>
       _SpanTrackRecorder(config.trackEventsEnabled);
+
+  @override
+  IdentifyRecorder createIdentifyRecorder(ObservabilityConfig config) =>
+      _NoopIdentifyRecorder();
+}
+
+/// No Session Replay or context-key caching exists on the Dart web pipeline, so
+/// `identify` has nothing to forward.
+class _NoopIdentifyRecorder implements IdentifyRecorder {
+  @override
+  void identify({
+    required Map<String, String> contextKeys,
+    required String canonicalKey,
+    required bool completed,
+  }) {}
 }
 
 /// Emits each `track` event as a Dart `track` span via the OpenTelemetry

--- a/sdk/@launchdarkly/flutter/packages/observability/lib/src/otel/setup.dart
+++ b/sdk/@launchdarkly/flutter/packages/observability/lib/src/otel/setup.dart
@@ -21,6 +21,11 @@ class Otel {
   static TrackRecorder? _trackRecorder;
   static TrackRecorder? get trackRecorder => _trackRecorder;
 
+  /// The platform-appropriate identify recorder, set during [setup]. `null`
+  /// before the pipeline is initialized.
+  static IdentifyRecorder? _identifyRecorder;
+  static IdentifyRecorder? get identifyRecorder => _identifyRecorder;
+
   static void setup(String sdkKey, ObservabilityConfig config) {
     // TODO: Log when otel is setup multiple times. It will work, but the
     // behavior may be confusing.
@@ -49,6 +54,7 @@ class Otel {
 
     _logRecorder = exporters.createLogRecorder(config);
     _trackRecorder = exporters.createTrackRecorder(config);
+    _identifyRecorder = exporters.createIdentifyRecorder(config);
   }
 
   static void shutdown() {
@@ -58,5 +64,6 @@ class Otel {
     _tracerProviders.clear();
     _logRecorder = null;
     _trackRecorder = null;
+    _identifyRecorder = null;
   }
 }

--- a/sdk/@launchdarkly/flutter/packages/observability/lib/src/platform/io/messages.g.dart
+++ b/sdk/@launchdarkly/flutter/packages/observability/lib/src/platform/io/messages.g.dart
@@ -14,24 +14,20 @@ PlatformException _createConnectionError(String channelName) {
     message: 'Unable to establish connection on channel: "$channelName".',
   );
 }
-
 bool _deepEquals(Object? a, Object? b) {
   if (a is List && b is List) {
     return a.length == b.length &&
-        a.indexed.every(
-          ((int, dynamic) item) => _deepEquals(item.$2, b[item.$1]),
-        );
+        a.indexed
+        .every(((int, dynamic) item) => _deepEquals(item.$2, b[item.$1]));
   }
   if (a is Map && b is Map) {
-    return a.length == b.length &&
-        a.entries.every(
-          (MapEntry<Object?, Object?> entry) =>
-              (b as Map<Object?, Object?>).containsKey(entry.key) &&
-              _deepEquals(entry.value, b[entry.key]),
-        );
+    return a.length == b.length && a.entries.every((MapEntry<Object?, Object?> entry) =>
+        (b as Map<Object?, Object?>).containsKey(entry.key) &&
+        _deepEquals(entry.value, b[entry.key]));
   }
   return a == b;
 }
+
 
 class LDInstrumentationOptions {
   LDInstrumentationOptions({
@@ -47,12 +43,15 @@ class LDInstrumentationOptions {
   bool? crashReporting;
 
   List<Object?> _toList() {
-    return <Object?>[networkRequests, launchTimes, crashReporting];
+    return <Object?>[
+      networkRequests,
+      launchTimes,
+      crashReporting,
+    ];
   }
 
   Object encode() {
-    return _toList();
-  }
+    return _toList();  }
 
   static LDInstrumentationOptions decode(Object result) {
     result as List<Object?>;
@@ -66,8 +65,7 @@ class LDInstrumentationOptions {
   @override
   // ignore: avoid_equals_and_hash_code_on_mutable_classes
   bool operator ==(Object other) {
-    if (other is! LDInstrumentationOptions ||
-        other.runtimeType != runtimeType) {
+    if (other is! LDInstrumentationOptions || other.runtimeType != runtimeType) {
       return false;
     }
     if (identical(this, other)) {
@@ -78,23 +76,29 @@ class LDInstrumentationOptions {
 
   @override
   // ignore: avoid_equals_and_hash_code_on_mutable_classes
-  int get hashCode => Object.hashAll(_toList());
+  int get hashCode => Object.hashAll(_toList())
+;
 }
 
 class LDTracesOptions {
-  LDTracesOptions({this.includeErrors, this.includeSpans});
+  LDTracesOptions({
+    this.includeErrors,
+    this.includeSpans,
+  });
 
   bool? includeErrors;
 
   bool? includeSpans;
 
   List<Object?> _toList() {
-    return <Object?>[includeErrors, includeSpans];
+    return <Object?>[
+      includeErrors,
+      includeSpans,
+    ];
   }
 
   Object encode() {
-    return _toList();
-  }
+    return _toList();  }
 
   static LDTracesOptions decode(Object result) {
     result as List<Object?>;
@@ -118,11 +122,16 @@ class LDTracesOptions {
 
   @override
   // ignore: avoid_equals_and_hash_code_on_mutable_classes
-  int get hashCode => Object.hashAll(_toList());
+  int get hashCode => Object.hashAll(_toList())
+;
 }
 
 class LDAnalyticsOptions {
-  LDAnalyticsOptions({this.taps, this.pageViews, this.trackEvents});
+  LDAnalyticsOptions({
+    this.taps,
+    this.pageViews,
+    this.trackEvents,
+  });
 
   bool? taps;
 
@@ -131,12 +140,15 @@ class LDAnalyticsOptions {
   bool? trackEvents;
 
   List<Object?> _toList() {
-    return <Object?>[taps, pageViews, trackEvents];
+    return <Object?>[
+      taps,
+      pageViews,
+      trackEvents,
+    ];
   }
 
   Object encode() {
-    return _toList();
-  }
+    return _toList();  }
 
   static LDAnalyticsOptions decode(Object result) {
     result as List<Object?>;
@@ -161,7 +173,8 @@ class LDAnalyticsOptions {
 
   @override
   // ignore: avoid_equals_and_hash_code_on_mutable_classes
-  int get hashCode => Object.hashAll(_toList());
+  int get hashCode => Object.hashAll(_toList())
+;
 }
 
 class LDObservabilityOptions {
@@ -230,8 +243,7 @@ class LDObservabilityOptions {
   }
 
   Object encode() {
-    return _toList();
-  }
+    return _toList();  }
 
   static LDObservabilityOptions decode(Object result) {
     result as List<Object?>;
@@ -242,10 +254,8 @@ class LDObservabilityOptions {
       otlpEndpoint: result[3] as String?,
       backendUrl: result[4] as String?,
       contextFriendlyName: result[5] as String?,
-      attributes: (result[6] as Map<Object?, Object?>?)
-          ?.cast<String, Object?>(),
-      customHeaders: (result[7] as Map<Object?, Object?>?)
-          ?.cast<String, String>(),
+      attributes: (result[6] as Map<Object?, Object?>?)?.cast<String, Object?>(),
+      customHeaders: (result[7] as Map<Object?, Object?>?)?.cast<String, String>(),
       sessionBackgroundTimeoutMillis: result[8] as int?,
       logsApiLevel: result[9] as int?,
       traces: result[10] as LDTracesOptions?,
@@ -269,7 +279,8 @@ class LDObservabilityOptions {
 
   @override
   // ignore: avoid_equals_and_hash_code_on_mutable_classes
-  int get hashCode => Object.hashAll(_toList());
+  int get hashCode => Object.hashAll(_toList())
+;
 }
 
 class LDPrivacyOptions {
@@ -302,8 +313,7 @@ class LDPrivacyOptions {
   }
 
   Object encode() {
-    return _toList();
-  }
+    return _toList();  }
 
   static LDPrivacyOptions decode(Object result) {
     result as List<Object?>;
@@ -330,7 +340,8 @@ class LDPrivacyOptions {
 
   @override
   // ignore: avoid_equals_and_hash_code_on_mutable_classes
-  int get hashCode => Object.hashAll(_toList());
+  int get hashCode => Object.hashAll(_toList())
+;
 }
 
 class LDSessionReplayOptions {
@@ -350,12 +361,16 @@ class LDSessionReplayOptions {
   LDPrivacyOptions? privacy;
 
   List<Object?> _toList() {
-    return <Object?>[isEnabled, serviceName, frameRate, privacy];
+    return <Object?>[
+      isEnabled,
+      serviceName,
+      frameRate,
+      privacy,
+    ];
   }
 
   Object encode() {
-    return _toList();
-  }
+    return _toList();  }
 
   static LDSessionReplayOptions decode(Object result) {
     result as List<Object?>;
@@ -381,25 +396,31 @@ class LDSessionReplayOptions {
 
   @override
   // ignore: avoid_equals_and_hash_code_on_mutable_classes
-  int get hashCode => Object.hashAll(_toList());
+  int get hashCode => Object.hashAll(_toList())
+;
 }
 
 class LDStartResult {
-  LDStartResult({this.nativeVersion});
+  LDStartResult({
+    this.nativeVersion,
+  });
 
   String? nativeVersion;
 
   List<Object?> _toList() {
-    return <Object?>[nativeVersion];
+    return <Object?>[
+      nativeVersion,
+    ];
   }
 
   Object encode() {
-    return _toList();
-  }
+    return _toList();  }
 
   static LDStartResult decode(Object result) {
     result as List<Object?>;
-    return LDStartResult(nativeVersion: result[0] as String?);
+    return LDStartResult(
+      nativeVersion: result[0] as String?,
+    );
   }
 
   @override
@@ -416,31 +437,36 @@ class LDStartResult {
 
   @override
   // ignore: avoid_equals_and_hash_code_on_mutable_classes
-  int get hashCode => Object.hashAll(_toList());
+  int get hashCode => Object.hashAll(_toList())
+;
 }
 
 /// An event recorded on a span, forwarded to the native tracer.
 class LDSpanEvent {
-  LDSpanEvent({this.name, this.attributes});
+  LDSpanEvent({
+    this.name,
+    this.attributes,
+  });
 
   String? name;
 
   Map<String, Object?>? attributes;
 
   List<Object?> _toList() {
-    return <Object?>[name, attributes];
+    return <Object?>[
+      name,
+      attributes,
+    ];
   }
 
   Object encode() {
-    return _toList();
-  }
+    return _toList();  }
 
   static LDSpanEvent decode(Object result) {
     result as List<Object?>;
     return LDSpanEvent(
       name: result[0] as String?,
-      attributes: (result[1] as Map<Object?, Object?>?)
-          ?.cast<String, Object?>(),
+      attributes: (result[1] as Map<Object?, Object?>?)?.cast<String, Object?>(),
     );
   }
 
@@ -458,7 +484,8 @@ class LDSpanEvent {
 
   @override
   // ignore: avoid_equals_and_hash_code_on_mutable_classes
-  int get hashCode => Object.hashAll(_toList());
+  int get hashCode => Object.hashAll(_toList())
+;
 }
 
 /// A completed Dart span, forwarded to the native tracer so the native
@@ -518,8 +545,7 @@ class LDSpanData {
   }
 
   Object encode() {
-    return _toList();
-  }
+    return _toList();  }
 
   static LDSpanData decode(Object result) {
     result as List<Object?>;
@@ -530,8 +556,7 @@ class LDSpanData {
       traceId: result[3] as String?,
       spanId: result[4] as String?,
       parentSpanId: result[5] as String?,
-      attributes: (result[6] as Map<Object?, Object?>?)
-          ?.cast<String, Object?>(),
+      attributes: (result[6] as Map<Object?, Object?>?)?.cast<String, Object?>(),
       events: (result[7] as List<Object?>?)?.cast<LDSpanEvent?>(),
       statusCode: result[8] as int?,
     );
@@ -551,7 +576,8 @@ class LDSpanData {
 
   @override
   // ignore: avoid_equals_and_hash_code_on_mutable_classes
-  int get hashCode => Object.hashAll(_toList());
+  int get hashCode => Object.hashAll(_toList())
+;
 }
 
 /// A log record forwarded to the native logger so it is emitted as a real
@@ -580,12 +606,17 @@ class LDLogRecord {
   Map<String, Object?>? attributes;
 
   List<Object?> _toList() {
-    return <Object?>[message, severityNumber, traceId, spanId, attributes];
+    return <Object?>[
+      message,
+      severityNumber,
+      traceId,
+      spanId,
+      attributes,
+    ];
   }
 
   Object encode() {
-    return _toList();
-  }
+    return _toList();  }
 
   static LDLogRecord decode(Object result) {
     result as List<Object?>;
@@ -594,8 +625,7 @@ class LDLogRecord {
       severityNumber: result[1] as int?,
       traceId: result[2] as String?,
       spanId: result[3] as String?,
-      attributes: (result[4] as Map<Object?, Object?>?)
-          ?.cast<String, Object?>(),
+      attributes: (result[4] as Map<Object?, Object?>?)?.cast<String, Object?>(),
     );
   }
 
@@ -613,8 +643,10 @@ class LDLogRecord {
 
   @override
   // ignore: avoid_equals_and_hash_code_on_mutable_classes
-  int get hashCode => Object.hashAll(_toList());
+  int get hashCode => Object.hashAll(_toList())
+;
 }
+
 
 class _PigeonCodec extends StandardMessageCodec {
   const _PigeonCodec();
@@ -623,34 +655,34 @@ class _PigeonCodec extends StandardMessageCodec {
     if (value is int) {
       buffer.putUint8(4);
       buffer.putInt64(value);
-    } else if (value is LDInstrumentationOptions) {
+    }    else if (value is LDInstrumentationOptions) {
       buffer.putUint8(129);
       writeValue(buffer, value.encode());
-    } else if (value is LDTracesOptions) {
+    }    else if (value is LDTracesOptions) {
       buffer.putUint8(130);
       writeValue(buffer, value.encode());
-    } else if (value is LDAnalyticsOptions) {
+    }    else if (value is LDAnalyticsOptions) {
       buffer.putUint8(131);
       writeValue(buffer, value.encode());
-    } else if (value is LDObservabilityOptions) {
+    }    else if (value is LDObservabilityOptions) {
       buffer.putUint8(132);
       writeValue(buffer, value.encode());
-    } else if (value is LDPrivacyOptions) {
+    }    else if (value is LDPrivacyOptions) {
       buffer.putUint8(133);
       writeValue(buffer, value.encode());
-    } else if (value is LDSessionReplayOptions) {
+    }    else if (value is LDSessionReplayOptions) {
       buffer.putUint8(134);
       writeValue(buffer, value.encode());
-    } else if (value is LDStartResult) {
+    }    else if (value is LDStartResult) {
       buffer.putUint8(135);
       writeValue(buffer, value.encode());
-    } else if (value is LDSpanEvent) {
+    }    else if (value is LDSpanEvent) {
       buffer.putUint8(136);
       writeValue(buffer, value.encode());
-    } else if (value is LDSpanData) {
+    }    else if (value is LDSpanData) {
       buffer.putUint8(137);
       writeValue(buffer, value.encode());
-    } else if (value is LDLogRecord) {
+    }    else if (value is LDLogRecord) {
       buffer.putUint8(138);
       writeValue(buffer, value.encode());
     } else {
@@ -661,25 +693,25 @@ class _PigeonCodec extends StandardMessageCodec {
   @override
   Object? readValueOfType(int type, ReadBuffer buffer) {
     switch (type) {
-      case 129:
+      case 129: 
         return LDInstrumentationOptions.decode(readValue(buffer)!);
-      case 130:
+      case 130: 
         return LDTracesOptions.decode(readValue(buffer)!);
-      case 131:
+      case 131: 
         return LDAnalyticsOptions.decode(readValue(buffer)!);
-      case 132:
+      case 132: 
         return LDObservabilityOptions.decode(readValue(buffer)!);
-      case 133:
+      case 133: 
         return LDPrivacyOptions.decode(readValue(buffer)!);
-      case 134:
+      case 134: 
         return LDSessionReplayOptions.decode(readValue(buffer)!);
-      case 135:
+      case 135: 
         return LDStartResult.decode(readValue(buffer)!);
-      case 136:
+      case 136: 
         return LDSpanEvent.decode(readValue(buffer)!);
-      case 137:
+      case 137: 
         return LDSpanData.decode(readValue(buffer)!);
-      case 138:
+      case 138: 
         return LDLogRecord.decode(readValue(buffer)!);
       default:
         return super.readValueOfType(type, buffer);
@@ -691,36 +723,23 @@ class LDNativeApi {
   /// Constructor for [LDNativeApi].  The [binaryMessenger] named argument is
   /// available for dependency injection.  If it is left null, the default
   /// BinaryMessenger will be used which routes to the host platform.
-  LDNativeApi({
-    BinaryMessenger? binaryMessenger,
-    String messageChannelSuffix = '',
-  }) : pigeonVar_binaryMessenger = binaryMessenger,
-       pigeonVar_messageChannelSuffix = messageChannelSuffix.isNotEmpty
-           ? '.$messageChannelSuffix'
-           : '';
+  LDNativeApi({BinaryMessenger? binaryMessenger, String messageChannelSuffix = ''})
+      : pigeonVar_binaryMessenger = binaryMessenger,
+        pigeonVar_messageChannelSuffix = messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
   final BinaryMessenger? pigeonVar_binaryMessenger;
 
   static const MessageCodec<Object?> pigeonChannelCodec = _PigeonCodec();
 
   final String pigeonVar_messageChannelSuffix;
 
-  Future<LDStartResult> start(
-    String mobileKey,
-    LDObservabilityOptions observability,
-    LDSessionReplayOptions replay,
-    String observabilityVersion,
-  ) async {
-    final String pigeonVar_channelName =
-        'dev.flutter.pigeon.launchdarkly_flutter_observability.LDNativeApi.start$pigeonVar_messageChannelSuffix';
-    final BasicMessageChannel<Object?> pigeonVar_channel =
-        BasicMessageChannel<Object?>(
-          pigeonVar_channelName,
-          pigeonChannelCodec,
-          binaryMessenger: pigeonVar_binaryMessenger,
-        );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[mobileKey, observability, replay, observabilityVersion],
+  Future<LDStartResult> start(String mobileKey, LDObservabilityOptions observability, LDSessionReplayOptions replay, String observabilityVersion) async {
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.launchdarkly_flutter_observability.LDNativeApi.start$pigeonVar_messageChannelSuffix';
+    final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
     );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[mobileKey, observability, replay, observabilityVersion]);
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -744,17 +763,13 @@ class LDNativeApi {
   /// Forwards completed Dart spans to the native tracer. Native re-creates each
   /// span so the native pipeline stamps `session.id` and exports it.
   Future<void> exportSpans(List<LDSpanData> spans) async {
-    final String pigeonVar_channelName =
-        'dev.flutter.pigeon.launchdarkly_flutter_observability.LDNativeApi.exportSpans$pigeonVar_messageChannelSuffix';
-    final BasicMessageChannel<Object?> pigeonVar_channel =
-        BasicMessageChannel<Object?>(
-          pigeonVar_channelName,
-          pigeonChannelCodec,
-          binaryMessenger: pigeonVar_binaryMessenger,
-        );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[spans],
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.launchdarkly_flutter_observability.LDNativeApi.exportSpans$pigeonVar_messageChannelSuffix';
+    final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
     );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[spans]);
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -773,17 +788,13 @@ class LDNativeApi {
   /// Forwards a Dart log to the native logger so it is emitted as a native
   /// `LogRecord` with `session.id` and trace/span correlation.
   Future<void> recordLog(LDLogRecord log) async {
-    final String pigeonVar_channelName =
-        'dev.flutter.pigeon.launchdarkly_flutter_observability.LDNativeApi.recordLog$pigeonVar_messageChannelSuffix';
-    final BasicMessageChannel<Object?> pigeonVar_channel =
-        BasicMessageChannel<Object?>(
-          pigeonVar_channelName,
-          pigeonChannelCodec,
-          binaryMessenger: pigeonVar_binaryMessenger,
-        );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[log],
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.launchdarkly_flutter_observability.LDNativeApi.recordLog$pigeonVar_messageChannelSuffix';
+    final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
     );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[log]);
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -806,23 +817,45 @@ class LDNativeApi {
   /// kind -> key pairs (from the LaunchDarkly client's `afterTrack` hook) so the
   /// native `track` span is attributed to the same context the web SDK records;
   /// only the span is annotated, not the Session Replay `Track` payload.
-  Future<void> track(
-    String key,
-    Map<String, Object?>? data,
-    double? metricValue,
-    Map<String, String>? contextKeys,
-  ) async {
-    final String pigeonVar_channelName =
-        'dev.flutter.pigeon.launchdarkly_flutter_observability.LDNativeApi.track$pigeonVar_messageChannelSuffix';
-    final BasicMessageChannel<Object?> pigeonVar_channel =
-        BasicMessageChannel<Object?>(
-          pigeonVar_channelName,
-          pigeonChannelCodec,
-          binaryMessenger: pigeonVar_binaryMessenger,
-        );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[key, data, metricValue, contextKeys],
+  Future<void> track(String key, Map<String, Object?>? data, double? metricValue, Map<String, String>? contextKeys) async {
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.launchdarkly_flutter_observability.LDNativeApi.track$pigeonVar_messageChannelSuffix';
+    final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
     );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[key, data, metricValue, contextKeys]);
+    final List<Object?>? pigeonVar_replyList =
+        await pigeonVar_sendFuture as List<Object?>?;
+    if (pigeonVar_replyList == null) {
+      throw _createConnectionError(pigeonVar_channelName);
+    } else if (pigeonVar_replyList.length > 1) {
+      throw PlatformException(
+        code: pigeonVar_replyList[0]! as String,
+        message: pigeonVar_replyList[1] as String?,
+        details: pigeonVar_replyList[2],
+      );
+    } else {
+      return;
+    }
+  }
+
+  /// Forwards an `identify` to the native observability SDK and Session Replay.
+  /// Native observability caches `contextKeys` so manual `LDObserve.track` calls
+  /// (which carry no context) are attributed to the active context, and Session
+  /// Replay records who the user is on the active recording. `contextKeys`
+  /// carries the context's kind -> key pairs, `canonicalKey` the fully-qualified
+  /// key, and `completed` whether the identify finished successfully (native
+  /// ignores incomplete identifies). Mirrors MAUI's
+  /// `ObservabilityHook.AfterIdentify` /  `SessionReplayHook.AfterIdentify`.
+  Future<void> identify(Map<String, String> contextKeys, String canonicalKey, bool completed) async {
+    final String pigeonVar_channelName = 'dev.flutter.pigeon.launchdarkly_flutter_observability.LDNativeApi.identify$pigeonVar_messageChannelSuffix';
+    final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[contextKeys, canonicalKey, completed]);
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {

--- a/sdk/@launchdarkly/flutter/packages/observability/lib/src/platform/io/messages.g.dart
+++ b/sdk/@launchdarkly/flutter/packages/observability/lib/src/platform/io/messages.g.dart
@@ -14,20 +14,24 @@ PlatformException _createConnectionError(String channelName) {
     message: 'Unable to establish connection on channel: "$channelName".',
   );
 }
+
 bool _deepEquals(Object? a, Object? b) {
   if (a is List && b is List) {
     return a.length == b.length &&
-        a.indexed
-        .every(((int, dynamic) item) => _deepEquals(item.$2, b[item.$1]));
+        a.indexed.every(
+          ((int, dynamic) item) => _deepEquals(item.$2, b[item.$1]),
+        );
   }
   if (a is Map && b is Map) {
-    return a.length == b.length && a.entries.every((MapEntry<Object?, Object?> entry) =>
-        (b as Map<Object?, Object?>).containsKey(entry.key) &&
-        _deepEquals(entry.value, b[entry.key]));
+    return a.length == b.length &&
+        a.entries.every(
+          (MapEntry<Object?, Object?> entry) =>
+              (b as Map<Object?, Object?>).containsKey(entry.key) &&
+              _deepEquals(entry.value, b[entry.key]),
+        );
   }
   return a == b;
 }
-
 
 class LDInstrumentationOptions {
   LDInstrumentationOptions({
@@ -43,15 +47,12 @@ class LDInstrumentationOptions {
   bool? crashReporting;
 
   List<Object?> _toList() {
-    return <Object?>[
-      networkRequests,
-      launchTimes,
-      crashReporting,
-    ];
+    return <Object?>[networkRequests, launchTimes, crashReporting];
   }
 
   Object encode() {
-    return _toList();  }
+    return _toList();
+  }
 
   static LDInstrumentationOptions decode(Object result) {
     result as List<Object?>;
@@ -65,7 +66,8 @@ class LDInstrumentationOptions {
   @override
   // ignore: avoid_equals_and_hash_code_on_mutable_classes
   bool operator ==(Object other) {
-    if (other is! LDInstrumentationOptions || other.runtimeType != runtimeType) {
+    if (other is! LDInstrumentationOptions ||
+        other.runtimeType != runtimeType) {
       return false;
     }
     if (identical(this, other)) {
@@ -76,29 +78,23 @@ class LDInstrumentationOptions {
 
   @override
   // ignore: avoid_equals_and_hash_code_on_mutable_classes
-  int get hashCode => Object.hashAll(_toList())
-;
+  int get hashCode => Object.hashAll(_toList());
 }
 
 class LDTracesOptions {
-  LDTracesOptions({
-    this.includeErrors,
-    this.includeSpans,
-  });
+  LDTracesOptions({this.includeErrors, this.includeSpans});
 
   bool? includeErrors;
 
   bool? includeSpans;
 
   List<Object?> _toList() {
-    return <Object?>[
-      includeErrors,
-      includeSpans,
-    ];
+    return <Object?>[includeErrors, includeSpans];
   }
 
   Object encode() {
-    return _toList();  }
+    return _toList();
+  }
 
   static LDTracesOptions decode(Object result) {
     result as List<Object?>;
@@ -122,16 +118,11 @@ class LDTracesOptions {
 
   @override
   // ignore: avoid_equals_and_hash_code_on_mutable_classes
-  int get hashCode => Object.hashAll(_toList())
-;
+  int get hashCode => Object.hashAll(_toList());
 }
 
 class LDAnalyticsOptions {
-  LDAnalyticsOptions({
-    this.taps,
-    this.pageViews,
-    this.trackEvents,
-  });
+  LDAnalyticsOptions({this.taps, this.pageViews, this.trackEvents});
 
   bool? taps;
 
@@ -140,15 +131,12 @@ class LDAnalyticsOptions {
   bool? trackEvents;
 
   List<Object?> _toList() {
-    return <Object?>[
-      taps,
-      pageViews,
-      trackEvents,
-    ];
+    return <Object?>[taps, pageViews, trackEvents];
   }
 
   Object encode() {
-    return _toList();  }
+    return _toList();
+  }
 
   static LDAnalyticsOptions decode(Object result) {
     result as List<Object?>;
@@ -173,8 +161,7 @@ class LDAnalyticsOptions {
 
   @override
   // ignore: avoid_equals_and_hash_code_on_mutable_classes
-  int get hashCode => Object.hashAll(_toList())
-;
+  int get hashCode => Object.hashAll(_toList());
 }
 
 class LDObservabilityOptions {
@@ -243,7 +230,8 @@ class LDObservabilityOptions {
   }
 
   Object encode() {
-    return _toList();  }
+    return _toList();
+  }
 
   static LDObservabilityOptions decode(Object result) {
     result as List<Object?>;
@@ -254,8 +242,10 @@ class LDObservabilityOptions {
       otlpEndpoint: result[3] as String?,
       backendUrl: result[4] as String?,
       contextFriendlyName: result[5] as String?,
-      attributes: (result[6] as Map<Object?, Object?>?)?.cast<String, Object?>(),
-      customHeaders: (result[7] as Map<Object?, Object?>?)?.cast<String, String>(),
+      attributes: (result[6] as Map<Object?, Object?>?)
+          ?.cast<String, Object?>(),
+      customHeaders: (result[7] as Map<Object?, Object?>?)
+          ?.cast<String, String>(),
       sessionBackgroundTimeoutMillis: result[8] as int?,
       logsApiLevel: result[9] as int?,
       traces: result[10] as LDTracesOptions?,
@@ -279,8 +269,7 @@ class LDObservabilityOptions {
 
   @override
   // ignore: avoid_equals_and_hash_code_on_mutable_classes
-  int get hashCode => Object.hashAll(_toList())
-;
+  int get hashCode => Object.hashAll(_toList());
 }
 
 class LDPrivacyOptions {
@@ -313,7 +302,8 @@ class LDPrivacyOptions {
   }
 
   Object encode() {
-    return _toList();  }
+    return _toList();
+  }
 
   static LDPrivacyOptions decode(Object result) {
     result as List<Object?>;
@@ -340,8 +330,7 @@ class LDPrivacyOptions {
 
   @override
   // ignore: avoid_equals_and_hash_code_on_mutable_classes
-  int get hashCode => Object.hashAll(_toList())
-;
+  int get hashCode => Object.hashAll(_toList());
 }
 
 class LDSessionReplayOptions {
@@ -361,16 +350,12 @@ class LDSessionReplayOptions {
   LDPrivacyOptions? privacy;
 
   List<Object?> _toList() {
-    return <Object?>[
-      isEnabled,
-      serviceName,
-      frameRate,
-      privacy,
-    ];
+    return <Object?>[isEnabled, serviceName, frameRate, privacy];
   }
 
   Object encode() {
-    return _toList();  }
+    return _toList();
+  }
 
   static LDSessionReplayOptions decode(Object result) {
     result as List<Object?>;
@@ -396,31 +381,25 @@ class LDSessionReplayOptions {
 
   @override
   // ignore: avoid_equals_and_hash_code_on_mutable_classes
-  int get hashCode => Object.hashAll(_toList())
-;
+  int get hashCode => Object.hashAll(_toList());
 }
 
 class LDStartResult {
-  LDStartResult({
-    this.nativeVersion,
-  });
+  LDStartResult({this.nativeVersion});
 
   String? nativeVersion;
 
   List<Object?> _toList() {
-    return <Object?>[
-      nativeVersion,
-    ];
+    return <Object?>[nativeVersion];
   }
 
   Object encode() {
-    return _toList();  }
+    return _toList();
+  }
 
   static LDStartResult decode(Object result) {
     result as List<Object?>;
-    return LDStartResult(
-      nativeVersion: result[0] as String?,
-    );
+    return LDStartResult(nativeVersion: result[0] as String?);
   }
 
   @override
@@ -437,36 +416,31 @@ class LDStartResult {
 
   @override
   // ignore: avoid_equals_and_hash_code_on_mutable_classes
-  int get hashCode => Object.hashAll(_toList())
-;
+  int get hashCode => Object.hashAll(_toList());
 }
 
 /// An event recorded on a span, forwarded to the native tracer.
 class LDSpanEvent {
-  LDSpanEvent({
-    this.name,
-    this.attributes,
-  });
+  LDSpanEvent({this.name, this.attributes});
 
   String? name;
 
   Map<String, Object?>? attributes;
 
   List<Object?> _toList() {
-    return <Object?>[
-      name,
-      attributes,
-    ];
+    return <Object?>[name, attributes];
   }
 
   Object encode() {
-    return _toList();  }
+    return _toList();
+  }
 
   static LDSpanEvent decode(Object result) {
     result as List<Object?>;
     return LDSpanEvent(
       name: result[0] as String?,
-      attributes: (result[1] as Map<Object?, Object?>?)?.cast<String, Object?>(),
+      attributes: (result[1] as Map<Object?, Object?>?)
+          ?.cast<String, Object?>(),
     );
   }
 
@@ -484,8 +458,7 @@ class LDSpanEvent {
 
   @override
   // ignore: avoid_equals_and_hash_code_on_mutable_classes
-  int get hashCode => Object.hashAll(_toList())
-;
+  int get hashCode => Object.hashAll(_toList());
 }
 
 /// A completed Dart span, forwarded to the native tracer so the native
@@ -545,7 +518,8 @@ class LDSpanData {
   }
 
   Object encode() {
-    return _toList();  }
+    return _toList();
+  }
 
   static LDSpanData decode(Object result) {
     result as List<Object?>;
@@ -556,7 +530,8 @@ class LDSpanData {
       traceId: result[3] as String?,
       spanId: result[4] as String?,
       parentSpanId: result[5] as String?,
-      attributes: (result[6] as Map<Object?, Object?>?)?.cast<String, Object?>(),
+      attributes: (result[6] as Map<Object?, Object?>?)
+          ?.cast<String, Object?>(),
       events: (result[7] as List<Object?>?)?.cast<LDSpanEvent?>(),
       statusCode: result[8] as int?,
     );
@@ -576,8 +551,7 @@ class LDSpanData {
 
   @override
   // ignore: avoid_equals_and_hash_code_on_mutable_classes
-  int get hashCode => Object.hashAll(_toList())
-;
+  int get hashCode => Object.hashAll(_toList());
 }
 
 /// A log record forwarded to the native logger so it is emitted as a real
@@ -606,17 +580,12 @@ class LDLogRecord {
   Map<String, Object?>? attributes;
 
   List<Object?> _toList() {
-    return <Object?>[
-      message,
-      severityNumber,
-      traceId,
-      spanId,
-      attributes,
-    ];
+    return <Object?>[message, severityNumber, traceId, spanId, attributes];
   }
 
   Object encode() {
-    return _toList();  }
+    return _toList();
+  }
 
   static LDLogRecord decode(Object result) {
     result as List<Object?>;
@@ -625,7 +594,8 @@ class LDLogRecord {
       severityNumber: result[1] as int?,
       traceId: result[2] as String?,
       spanId: result[3] as String?,
-      attributes: (result[4] as Map<Object?, Object?>?)?.cast<String, Object?>(),
+      attributes: (result[4] as Map<Object?, Object?>?)
+          ?.cast<String, Object?>(),
     );
   }
 
@@ -643,10 +613,8 @@ class LDLogRecord {
 
   @override
   // ignore: avoid_equals_and_hash_code_on_mutable_classes
-  int get hashCode => Object.hashAll(_toList())
-;
+  int get hashCode => Object.hashAll(_toList());
 }
-
 
 class _PigeonCodec extends StandardMessageCodec {
   const _PigeonCodec();
@@ -655,34 +623,34 @@ class _PigeonCodec extends StandardMessageCodec {
     if (value is int) {
       buffer.putUint8(4);
       buffer.putInt64(value);
-    }    else if (value is LDInstrumentationOptions) {
+    } else if (value is LDInstrumentationOptions) {
       buffer.putUint8(129);
       writeValue(buffer, value.encode());
-    }    else if (value is LDTracesOptions) {
+    } else if (value is LDTracesOptions) {
       buffer.putUint8(130);
       writeValue(buffer, value.encode());
-    }    else if (value is LDAnalyticsOptions) {
+    } else if (value is LDAnalyticsOptions) {
       buffer.putUint8(131);
       writeValue(buffer, value.encode());
-    }    else if (value is LDObservabilityOptions) {
+    } else if (value is LDObservabilityOptions) {
       buffer.putUint8(132);
       writeValue(buffer, value.encode());
-    }    else if (value is LDPrivacyOptions) {
+    } else if (value is LDPrivacyOptions) {
       buffer.putUint8(133);
       writeValue(buffer, value.encode());
-    }    else if (value is LDSessionReplayOptions) {
+    } else if (value is LDSessionReplayOptions) {
       buffer.putUint8(134);
       writeValue(buffer, value.encode());
-    }    else if (value is LDStartResult) {
+    } else if (value is LDStartResult) {
       buffer.putUint8(135);
       writeValue(buffer, value.encode());
-    }    else if (value is LDSpanEvent) {
+    } else if (value is LDSpanEvent) {
       buffer.putUint8(136);
       writeValue(buffer, value.encode());
-    }    else if (value is LDSpanData) {
+    } else if (value is LDSpanData) {
       buffer.putUint8(137);
       writeValue(buffer, value.encode());
-    }    else if (value is LDLogRecord) {
+    } else if (value is LDLogRecord) {
       buffer.putUint8(138);
       writeValue(buffer, value.encode());
     } else {
@@ -693,25 +661,25 @@ class _PigeonCodec extends StandardMessageCodec {
   @override
   Object? readValueOfType(int type, ReadBuffer buffer) {
     switch (type) {
-      case 129: 
+      case 129:
         return LDInstrumentationOptions.decode(readValue(buffer)!);
-      case 130: 
+      case 130:
         return LDTracesOptions.decode(readValue(buffer)!);
-      case 131: 
+      case 131:
         return LDAnalyticsOptions.decode(readValue(buffer)!);
-      case 132: 
+      case 132:
         return LDObservabilityOptions.decode(readValue(buffer)!);
-      case 133: 
+      case 133:
         return LDPrivacyOptions.decode(readValue(buffer)!);
-      case 134: 
+      case 134:
         return LDSessionReplayOptions.decode(readValue(buffer)!);
-      case 135: 
+      case 135:
         return LDStartResult.decode(readValue(buffer)!);
-      case 136: 
+      case 136:
         return LDSpanEvent.decode(readValue(buffer)!);
-      case 137: 
+      case 137:
         return LDSpanData.decode(readValue(buffer)!);
-      case 138: 
+      case 138:
         return LDLogRecord.decode(readValue(buffer)!);
       default:
         return super.readValueOfType(type, buffer);
@@ -723,23 +691,36 @@ class LDNativeApi {
   /// Constructor for [LDNativeApi].  The [binaryMessenger] named argument is
   /// available for dependency injection.  If it is left null, the default
   /// BinaryMessenger will be used which routes to the host platform.
-  LDNativeApi({BinaryMessenger? binaryMessenger, String messageChannelSuffix = ''})
-      : pigeonVar_binaryMessenger = binaryMessenger,
-        pigeonVar_messageChannelSuffix = messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
+  LDNativeApi({
+    BinaryMessenger? binaryMessenger,
+    String messageChannelSuffix = '',
+  }) : pigeonVar_binaryMessenger = binaryMessenger,
+       pigeonVar_messageChannelSuffix = messageChannelSuffix.isNotEmpty
+           ? '.$messageChannelSuffix'
+           : '';
   final BinaryMessenger? pigeonVar_binaryMessenger;
 
   static const MessageCodec<Object?> pigeonChannelCodec = _PigeonCodec();
 
   final String pigeonVar_messageChannelSuffix;
 
-  Future<LDStartResult> start(String mobileKey, LDObservabilityOptions observability, LDSessionReplayOptions replay, String observabilityVersion) async {
-    final String pigeonVar_channelName = 'dev.flutter.pigeon.launchdarkly_flutter_observability.LDNativeApi.start$pigeonVar_messageChannelSuffix';
-    final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
+  Future<LDStartResult> start(
+    String mobileKey,
+    LDObservabilityOptions observability,
+    LDSessionReplayOptions replay,
+    String observabilityVersion,
+  ) async {
+    final String pigeonVar_channelName =
+        'dev.flutter.pigeon.launchdarkly_flutter_observability.LDNativeApi.start$pigeonVar_messageChannelSuffix';
+    final BasicMessageChannel<Object?> pigeonVar_channel =
+        BasicMessageChannel<Object?>(
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
+      <Object?>[mobileKey, observability, replay, observabilityVersion],
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[mobileKey, observability, replay, observabilityVersion]);
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -763,13 +744,17 @@ class LDNativeApi {
   /// Forwards completed Dart spans to the native tracer. Native re-creates each
   /// span so the native pipeline stamps `session.id` and exports it.
   Future<void> exportSpans(List<LDSpanData> spans) async {
-    final String pigeonVar_channelName = 'dev.flutter.pigeon.launchdarkly_flutter_observability.LDNativeApi.exportSpans$pigeonVar_messageChannelSuffix';
-    final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
+    final String pigeonVar_channelName =
+        'dev.flutter.pigeon.launchdarkly_flutter_observability.LDNativeApi.exportSpans$pigeonVar_messageChannelSuffix';
+    final BasicMessageChannel<Object?> pigeonVar_channel =
+        BasicMessageChannel<Object?>(
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
+      <Object?>[spans],
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[spans]);
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -788,13 +773,17 @@ class LDNativeApi {
   /// Forwards a Dart log to the native logger so it is emitted as a native
   /// `LogRecord` with `session.id` and trace/span correlation.
   Future<void> recordLog(LDLogRecord log) async {
-    final String pigeonVar_channelName = 'dev.flutter.pigeon.launchdarkly_flutter_observability.LDNativeApi.recordLog$pigeonVar_messageChannelSuffix';
-    final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
+    final String pigeonVar_channelName =
+        'dev.flutter.pigeon.launchdarkly_flutter_observability.LDNativeApi.recordLog$pigeonVar_messageChannelSuffix';
+    final BasicMessageChannel<Object?> pigeonVar_channel =
+        BasicMessageChannel<Object?>(
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
+      <Object?>[log],
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[log]);
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -817,14 +806,23 @@ class LDNativeApi {
   /// kind -> key pairs (from the LaunchDarkly client's `afterTrack` hook) so the
   /// native `track` span is attributed to the same context the web SDK records;
   /// only the span is annotated, not the Session Replay `Track` payload.
-  Future<void> track(String key, Map<String, Object?>? data, double? metricValue, Map<String, String>? contextKeys) async {
-    final String pigeonVar_channelName = 'dev.flutter.pigeon.launchdarkly_flutter_observability.LDNativeApi.track$pigeonVar_messageChannelSuffix';
-    final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
+  Future<void> track(
+    String key,
+    Map<String, Object?>? data,
+    double? metricValue,
+    Map<String, String>? contextKeys,
+  ) async {
+    final String pigeonVar_channelName =
+        'dev.flutter.pigeon.launchdarkly_flutter_observability.LDNativeApi.track$pigeonVar_messageChannelSuffix';
+    final BasicMessageChannel<Object?> pigeonVar_channel =
+        BasicMessageChannel<Object?>(
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
+      <Object?>[key, data, metricValue, contextKeys],
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[key, data, metricValue, contextKeys]);
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
@@ -848,14 +846,22 @@ class LDNativeApi {
   /// key, and `completed` whether the identify finished successfully (native
   /// ignores incomplete identifies). Mirrors MAUI's
   /// `ObservabilityHook.AfterIdentify` /  `SessionReplayHook.AfterIdentify`.
-  Future<void> identify(Map<String, String> contextKeys, String canonicalKey, bool completed) async {
-    final String pigeonVar_channelName = 'dev.flutter.pigeon.launchdarkly_flutter_observability.LDNativeApi.identify$pigeonVar_messageChannelSuffix';
-    final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
+  Future<void> identify(
+    Map<String, String> contextKeys,
+    String canonicalKey,
+    bool completed,
+  ) async {
+    final String pigeonVar_channelName =
+        'dev.flutter.pigeon.launchdarkly_flutter_observability.LDNativeApi.identify$pigeonVar_messageChannelSuffix';
+    final BasicMessageChannel<Object?> pigeonVar_channel =
+        BasicMessageChannel<Object?>(
+          pigeonVar_channelName,
+          pigeonChannelCodec,
+          binaryMessenger: pigeonVar_binaryMessenger,
+        );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
+      <Object?>[contextKeys, canonicalKey, completed],
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[contextKeys, canonicalKey, completed]);
     final List<Object?>? pigeonVar_replyList =
         await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {

--- a/sdk/@launchdarkly/flutter/packages/observability/lib/src/plugin/ld_observe_plugin.dart
+++ b/sdk/@launchdarkly/flutter/packages/observability/lib/src/plugin/ld_observe_plugin.dart
@@ -79,6 +79,28 @@ final class _ObservabilityHook extends Hook {
   }
 
   @override
+  UnmodifiableMapView<String, dynamic> afterIdentify(
+    IdentifySeriesContext hookContext,
+    UnmodifiableMapView<String, dynamic> data,
+    IdentifyResult result,
+  ) {
+    // Forward the identified context to the native observability SDK and Session
+    // Replay so the manual `LDObserve.track` path is attributed to the active
+    // context and the replay session records who the user is. Mirrors MAUI's
+    // `ObservabilityHook.AfterIdentify`. The native side ignores incomplete
+    // identifies, so the `completed` flag is forwarded as-is.
+    final context = hookContext.context;
+    if (context.valid) {
+      ObserveOtel.identify(
+        contextKeys: context.keys,
+        canonicalKey: context.canonicalKey,
+        completed: result is IdentifyComplete,
+      );
+    }
+    return data;
+  }
+
+  @override
   void afterTrack(TrackSeriesContext hookContext) {
     // Funnel through the single track emitter so the LaunchDarkly client's
     // track path and the manual LDObserve.track API stay consistent.

--- a/sdk/@launchdarkly/flutter/packages/observability/pigeons/messages.dart
+++ b/sdk/@launchdarkly/flutter/packages/observability/pigeons/messages.dart
@@ -159,4 +159,18 @@ abstract class LDNativeApi {
     double? metricValue,
     Map<String, String>? contextKeys,
   );
+
+  /// Forwards an `identify` to the native observability SDK and Session Replay.
+  /// Native observability caches `contextKeys` so manual `LDObserve.track` calls
+  /// (which carry no context) are attributed to the active context, and Session
+  /// Replay records who the user is on the active recording. `contextKeys`
+  /// carries the context's kind -> key pairs, `canonicalKey` the fully-qualified
+  /// key, and `completed` whether the identify finished successfully (native
+  /// ignores incomplete identifies). Mirrors MAUI's
+  /// `ObservabilityHook.AfterIdentify` /  `SessionReplayHook.AfterIdentify`.
+  void identify(
+    Map<String, String> contextKeys,
+    String canonicalKey,
+    bool completed,
+  );
 }

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/bridge/LDObserveBridge.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/bridge/LDObserveBridge.kt
@@ -1,7 +1,6 @@
 package com.launchdarkly.observability.bridge
 
 import com.launchdarkly.observability.sdk.LDObserve
-import com.launchdarkly.observability.sdk.LDReplay
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.common.Attributes
 
@@ -54,24 +53,5 @@ object LDObserveBridge {
             data?.toOtelAttributes() ?: Attributes.empty(),
             contextKeyBuilder.build(),
         )
-    }
-
-    /**
-     * Forwards an `identify` to native observability and Session Replay. The
-     * observability hook caches [contextKeys] so the manual [track] path is
-     * attributed to the active context, and Session Replay records who the user
-     * is on the active recording. [canonicalKey] is the context's
-     * fully-qualified key and [completed] whether the identify finished
-     * successfully; both downstreams ignore incomplete identifies. Lets hosts
-     * whose LaunchDarkly client lives outside this SDK (e.g. Flutter) drive
-     * identify the same way the in-process hooks do.
-     */
-    fun identify(
-        contextKeys: Map<String, String>,
-        canonicalKey: String,
-        completed: Boolean,
-    ) {
-        getObservabilityHookProxy()?.afterIdentify(contextKeys, canonicalKey, completed)
-        LDReplay.afterIdentify(contextKeys, canonicalKey, completed)
     }
 }

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/bridge/LDObserveBridge.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/bridge/LDObserveBridge.kt
@@ -1,6 +1,7 @@
 package com.launchdarkly.observability.bridge
 
 import com.launchdarkly.observability.sdk.LDObserve
+import com.launchdarkly.observability.sdk.LDReplay
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.common.Attributes
 
@@ -53,5 +54,24 @@ object LDObserveBridge {
             data?.toOtelAttributes() ?: Attributes.empty(),
             contextKeyBuilder.build(),
         )
+    }
+
+    /**
+     * Forwards an `identify` to native observability and Session Replay. The
+     * observability hook caches [contextKeys] so the manual [track] path is
+     * attributed to the active context, and Session Replay records who the user
+     * is on the active recording. [canonicalKey] is the context's
+     * fully-qualified key and [completed] whether the identify finished
+     * successfully; both downstreams ignore incomplete identifies. Lets hosts
+     * whose LaunchDarkly client lives outside this SDK (e.g. Flutter) drive
+     * identify the same way the in-process hooks do.
+     */
+    fun identify(
+        contextKeys: Map<String, String>,
+        canonicalKey: String,
+        completed: Boolean,
+    ) {
+        getObservabilityHookProxy()?.afterIdentify(contextKeys, canonicalKey, completed)
+        LDReplay.afterIdentify(contextKeys, canonicalKey, completed)
     }
 }


### PR DESCRIPTION
## Summary

Ports MAUI's identify behavior (`ObservabilityHook.AfterIdentify` / `SessionReplayHook.AfterIdentify`) to the Flutter observability SDK. There is no new customer-facing API: the observability plugin's hook reacts to `LDClient.identify(...)` and, on mobile, forwards the identified context to the native observability SDK and Session Replay so:

- the manual `LDObserve.track` path (which carries no context) is attributed to the active context, and
- the active Session Replay recording records who the user is.

This matches how MAUI's two native hooks forward `(contextKeys, canonicalKey, completed)` to the native observability + session-replay proxies.

## Changes

- **Pigeon bridge**: added `identify(contextKeys, canonicalKey, completed)` to `LDNativeApi` and regenerated the Dart/Kotlin/Swift bindings.
- **Dart**: new `IdentifyRecorder` abstraction with a native (io) impl that crosses the pigeon bridge and a no-op web/stub impl (the Dart web pipeline has no Session Replay or context-key caching). `Otel` builds/holds the identify recorder, `ObserveOtel.identify(...)` delegates to it, and `_ObservabilityHook.afterIdentify` invokes it (forwarding `completed = result is IdentifyComplete`).
- **Native plugins (Android + iOS)**: both forward to the existing public cross-platform hook proxies — the observability hook proxy (`getObservabilityHookProxy()` / `ObjcLDObserveBridge.getObservabilityHookProxy()`) and the session-replay hook proxy (`LDReplay.hookProxy` / `LDReplay.shared.hookProxy`). These are the same entry points React Native and MAUI already drive, so no bespoke combined bridge method is added and **`observability-android` is unchanged** (no new lib release / dependency bump needed). The pinned `~> 0.41.0` Swift SDK and `0.54.0` Android SDK already expose these proxies.
- **README**: documented that identify is forwarded automatically on mobile.

## Test plan

- [x] `flutter analyze` (no issues)
- [x] `flutter test` (147 passing)
- [ ] Manual: identify on the example app and confirm the Session Replay timeline records the user and subsequent `LDObserve.track` events are attributed to the context (iOS + Android)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how evaluation context and user identity flow into telemetry and Session Replay on mobile; behavior is aligned with MAUI/RN hook proxies but depends on correct identify completion handling and native SDK bumps.
> 
> **Overview**
> **Automatically forwards `LDClient.identify` to native observability and Session Replay on mobile**, matching MAUI—no new public API.
> 
> The observability plugin adds an **`afterIdentify` hook** that calls **`ObserveOtel.identify`**, which routes through a new **`IdentifyRecorder`** (native bridge on iOS/Android, no-op on web/stub). **`Otel` setup** now wires that recorder alongside track/log recorders.
> 
> The **Pigeon `LDNativeApi.identify`** method is added and regenerated; **Android and iOS** implementations call the existing **observability and Session Replay hook proxies** (`afterIdentify` with `contextKeys`, `canonicalKey`, `completed`). That caches context for **manual `LDObserve.track`** attribution and records the user on the **active replay**.
> 
> **Native dependency bumps**: Android observability **0.56.0**, iOS LaunchDarklyObservability/SessionReplay **~> 0.42.0**. The README notes identify is forwarded automatically. Example app changes are formatting only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f5e3ba630c9bd04c3430176961cb25375bf78ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->