### PR TITLE
docs: add unit test status badge for Flutter SDK in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This repository houses the LaunchDarkly Observability and Session Replay SDKs ac
 | [LaunchDarkly.Observability](sdk/@launchdarkly/observability-dotnet/README.md) (.NET) | [![NuGet][o11y-nuget-badge]][o11y-nuget-link] | [![Actions Status][dotnet-ci-badge]][dotnet-ci] |
 | [launchdarkly-observability-android](sdk/@launchdarkly/observability-android/README.md) | [![Maven Central][o11y-android-badge]][o11y-android-link] | [![Actions Status][android-ci-badge]][android-ci] |
 | [launchdarkly-observability](sdk/@launchdarkly/observability-ruby/README.md) (Ruby) | [![Gem Version][o11y-ruby-badge]][o11y-ruby-link] | [![Actions Status][ruby-ci-badge]][ruby-ci] |
-| [launchdarkly_flutter_observability](sdk/@launchdarkly/flutter/packages/observability/README.md) | [![pub package][o11y-flutter-badge]][o11y-flutter-link] | — |
+| [launchdarkly_flutter_observability](sdk/@launchdarkly/flutter/packages/observability/README.md) | [![pub package][o11y-flutter-badge]][o11y-flutter-link] | [![Actions Status][flutter-ci-badge]][flutter-ci] |
 
 ## Getting started
 
@@ -80,3 +80,5 @@ We welcome PRs and issues on this repo. Please don't hesitate to file a ticket i
 [o11y-ruby-link]: https://rubygems.org/gems/launchdarkly-observability
 [ruby-ci-badge]: https://github.com/launchdarkly/observability-sdk/actions/workflows/ruby-plugin.yml/badge.svg
 [ruby-ci]: https://github.com/launchdarkly/observability-sdk/actions/workflows/ruby-plugin.yml
+[flutter-ci-badge]: https://github.com/launchdarkly/observability-sdk/actions/workflows/flutter-observability.yml/badge.svg
+[flutter-ci]: https://github.com/launchdarkly/observability-sdk/actions/workflows/flutter-observability.yml


### PR DESCRIPTION
## Summary

- The Flutter SDK already has a CI workflow (`.github/workflows/flutter-observability.yml`) that runs `flutter analyze` and unit tests, but the root `README.md` showed `—` in the Tests column.
- Adds the **Actions Status** badge for the Flutter workflow so the Flutter SDK matches every other SDK in the packages table.

## Changes

- Replace `—` with `[![Actions Status][flutter-ci-badge]][flutter-ci]` for the `launchdarkly_flutter_observability` row.
- Add `flutter-ci-badge` / `flutter-ci` link references pointing at the `flutter-observability.yml` workflow.

## Test plan

- [ ] Confirm the badge renders and links to the Flutter Observability workflow on the rendered README.

Made with [Cursor](https://cursor.com)