### PR TITLE
fix: include userIdentifier in Session Replay Identify payload

### DIFF
--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/exporter/IdentifyItemPayload.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/exporter/IdentifyItemPayload.kt
@@ -69,6 +69,7 @@ data class IdentifyItemPayload(
             val canonicalKey = canonicalKeyOverride ?: ldContext?.fullyQualifiedKey ?: "unknown"
             attributes["key"] = contextFriendlyName ?: canonicalKey
             attributes["canonicalKey"] = canonicalKey
+            attributes["userIdentifier"] = contextFriendlyName ?: canonicalKey
 
             return IdentifyItemPayload(
                 attributes = attributes,

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/exporter/IdentifyItemPayload.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/exporter/IdentifyItemPayload.kt
@@ -67,9 +67,10 @@ data class IdentifyItemPayload(
             }
 
             val canonicalKey = canonicalKeyOverride ?: ldContext?.fullyQualifiedKey ?: "unknown"
-            attributes["key"] = contextFriendlyName ?: canonicalKey
+            val displayKey = contextFriendlyName ?: canonicalKey
+            attributes["key"] = displayKey
             attributes["canonicalKey"] = canonicalKey
-            attributes["userIdentifier"] = contextFriendlyName ?: canonicalKey
+            attributes["userIdentifier"] = displayKey
 
             return IdentifyItemPayload(
                 attributes = attributes,


### PR DESCRIPTION
## Summary
- Mobile `Identify` Session Replay events rendered an empty description in the session player. The player resolves a description from `email || name || userIdentifier`, but the SDK only emitted `key` and `canonicalKey`.
- Emit `userIdentifier` (friendly name when set, otherwise the canonical key) in the Identify payload so mobile identifies show a description, matching the web `Identify` payload shape (`{ userIdentifier, ...userObject }`) without any frontend changes.

## Notes
- `email`/`name` are intentionally not plumbed: they aren't available at the identify hook call site (only `contextKeys` + `canonicalKey` are forwarded), and `userIdentifier` is sufficient to fix the empty-description bug.

## Test plan
- [ ] Build the Android lib
- [ ] Trigger an identify and confirm the Session Replay Identify event renders a non-empty description in the session player

Made with [Cursor](https://cursor.com)