### PR TITLE
feat(flutter): propagate appLifecycle + appLaunch analytics options

### DIFF
--- a/analytics-taxonomy.md
+++ b/analytics-taxonomy.md
@@ -343,14 +343,14 @@ Identity resolution is **already implemented** and is out of scope for changes h
 
 ### 4.6 `app_launch` (mobile)
 
-App process launched. `event.launch_type` captures the **product milestone** of the launch — `relaunch` (a normal launch), `install` (first launch after a fresh install), or `update` (first launch after a version change). A return to the foreground from background (a "resume" / hot start) is **not** a launch and is captured by `app_foreground` (§4.7).
+App process launched. `event.launch_type` captures the **product milestone** of the launch — `relaunch` (a normal launch), `install` (first launch after a fresh install), or `update` (first launch after a version change); `unknown` is used when the app version can't be read, so the milestone can't be determined (and `version` is absent). A return to the foreground from background (a "resume" / hot start) is **not** a launch and is captured by `app_foreground` (§4.7).
 
 The **startup-performance** dimension (cold vs warm) is orthogonal to the product milestone and is recorded as an **OTel span event** on the launch span, not as a `launch_type` value. Emit an `app.start` span event carrying `start.type` (`cold` | `warm`); finer-grained startup phases may be added as additional span events. This aligns with Sentry (`app.start.cold` / `app.start.warm`) and the OpenTelemetry `AppStart` convention.
 
 | `event.*` field | Type | Required | Description |
 | --- | --- | --- | --- |
-| `event.launch_type` | enum | ✅ | `relaunch` (normal launch), `install` (first launch after fresh install), `update` (first launch after version change). |
-| `event.version` | string | ✅ | Current app version. |
+| `event.launch_type` | enum | ✅ | `relaunch` (normal launch), `install` (first launch after fresh install), `update` (first launch after version change), `unknown` (app version unreadable, so the milestone is indeterminable). |
+| `event.version` | string | ✅ | Current app version. Absent for `unknown` launches. |
 | `event.build` | string | ⛔ | Current build number. |
 | `event.previous_version` | string | ✅ for `update` | Version before the update. |
 | `event.referring_source` | string | ⛔ | `push`, `deep_link`, `icon`, `widget`, … |

--- a/analytics-taxonomy.md
+++ b/analytics-taxonomy.md
@@ -358,6 +358,8 @@ The **startup-performance** dimension (cold vs warm) is orthogonal to the produc
 
 > The `start.type` (cold/warm) lives on the `app.start` **span event**, not under `event.*`. `event.launch_type` answers "what kind of launch is this from the product's view"; the span event answers "how did the process start".
 
+> **Session Replay breadcrumb.** The `Launch` timeline breadcrumb carries the same product fields as the span, as a stringified-JSON custom-event payload (mirroring the `app_foreground` / `app_background` breadcrumb shape): `launch_type` (always) plus `version`, `build`, and `previous_version` when known. The startup-performance dimension (`start.type`) stays on the span event only.
+
 ```json
 {
   "span_name": "app_launch",

--- a/e2e/android/app/src/testCompose/java/com/example/androidobservability/DisablingConfigOptionsE2ETest.kt
+++ b/e2e/android/app/src/testCompose/java/com/example/androidobservability/DisablingConfigOptionsE2ETest.kt
@@ -162,7 +162,6 @@ class DisablingConfigOptionsE2ETest {
             tracesApi = ObservabilityOptions.TracesApi(includeErrors = false)
         )
         application.initForTest()
-        val tracesUrl = "http://localhost:${application.mockWebServer?.port}/v1/traces"
 
         triggerError()
         LDObserve.flush()
@@ -170,8 +169,11 @@ class DisablingConfigOptionsE2ETest {
 
         val spansExported = application.telemetryInspector?.spanExporter?.finishedSpanItems
 
-        assertFalse(requestsContainsUrl(tracesUrl))
-        assertEquals(0, spansExported?.size)
+        // includeErrors = false only drops the error span; regular spans still export because
+        // includeSpans defaults to true (e.g. the SDK's own `app_launch` analytics span emitted
+        // during init). So we assert specifically that no error span reached the exporter rather
+        // than that nothing at all was exported.
+        assertFalse(spansExported.orEmpty().any { it.name == ERROR_SPAN_NAME })
     }
 
     @Test
@@ -289,5 +291,6 @@ class DisablingConfigOptionsE2ETest {
     companion object {
         private const val TEST_LOG_MESSAGE = "test-log"
         private const val CRASH_INSTRUMENTATION_SCOPE = "io.opentelemetry.crash"
+        private const val ERROR_SPAN_NAME = "highlight.error"
     }
 }

--- a/e2e/android/app/src/testCompose/java/com/example/androidobservability/SamplingE2ETest.kt
+++ b/e2e/android/app/src/testCompose/java/com/example/androidobservability/SamplingE2ETest.kt
@@ -87,9 +87,12 @@ class SamplingE2ETest {
         LDObserve.flush()
         waitForTelemetryData(telemetryInspector = application.telemetryInspector, telemetryType = TelemetryType.SPANS)
 
-        val spansExported = telemetryInspector?.spanExporter?.finishedSpanItems?.map {
-            it.name
-        }
+        val spansExported = telemetryInspector?.spanExporter?.finishedSpanItems
+            ?.map { it.name }
+            // The SDK emits its own analytics spans during init (e.g. `app_launch`, and the
+            // `app_foreground`/`app_background` lifecycle spans). Filter them out so this test only
+            // observes the spans triggered by triggerSpans().
+            ?.filter { !it.startsWith("app_") }
 
         // Only first and final spans should be exported
         assertEquals(2, spansExported?.size)

--- a/sdk/@launchdarkly/flutter/packages/observability/README.md
+++ b/sdk/@launchdarkly/flutter/packages/observability/README.md
@@ -153,6 +153,8 @@ On `ObservabilityOptions`:
   - `taps` (`bool`): emit a span for each user tap. Tap detection is always enabled; this flag only controls whether a span is published. Supported on Android and iOS. Defaults to `true`.
   - `pageViews` (`bool`): emit spans for screen/page view lifecycle events. **Android-only** (no-op on iOS/web). Defaults to `true`.
   - `trackEvents` (`bool`): emit a span when a custom event is tracked. **Android-only** (no-op on iOS/web). Defaults to `true`.
+  - `appLifecycle` (`bool`): emit `app_foreground` / `app_background` spans as the app moves between foreground and background. **Mobile-only** (Android, iOS; no-op on web). Defaults to `true`.
+  - `appLaunch` (`bool`): emit an `app_launch` span (carrying the launch type — `install` / `update` / `relaunch` — and version fields) once per process launch. **Mobile-only** (Android, iOS; no-op on web). Defaults to `true`.
 - `instrumentation.crashReporting` (`bool`): report uncaught exceptions as errors. Defaults to `true`.
 
 On `SessionReplayOptions`:
@@ -169,8 +171,8 @@ LDObserve.init(
     traces: TracesOptions(includeErrors: true, includeSpans: true),
     metricsEnabled: true,
     // Shorthand for all analytics enabled; use AnalyticsOptions.disabled to
-    // turn it all off, or AnalyticsOptions(taps: …, pageViews: …, trackEvents: …)
-    // for fine-grained control.
+    // turn it all off, or AnalyticsOptions(taps: …, pageViews: …, trackEvents: …,
+    // appLifecycle: …, appLaunch: …) for fine-grained control.
     analytics: AnalyticsOptions.enabled,
     instrumentation: InstrumentationOptions(
       crashReporting: true,

--- a/sdk/@launchdarkly/flutter/packages/observability/README.md
+++ b/sdk/@launchdarkly/flutter/packages/observability/README.md
@@ -24,11 +24,6 @@ Add the package to your app's `pubspec.yaml`:
 flutter pub add launchdarkly_flutter_observability
 ```
 
-```yaml
-dependencies:
-  launchdarkly_flutter_observability: ^0.0.0
-```
-
 Then fetch dependencies:
 
 ```bash

--- a/sdk/@launchdarkly/flutter/packages/observability/android/src/main/kotlin/com/launchdarkly/launchdarkly_flutter_observability/LDNativeApiImpl.kt
+++ b/sdk/@launchdarkly/flutter/packages/observability/android/src/main/kotlin/com/launchdarkly/launchdarkly_flutter_observability/LDNativeApiImpl.kt
@@ -95,6 +95,8 @@ internal class LDNativeApiImpl(
                 taps = observability.analytics?.taps ?: true,
                 pageViews = observability.analytics?.pageViews ?: true,
                 trackEvents = observability.analytics?.trackEvents ?: true,
+                appLifecycle = observability.analytics?.appLifecycle ?: true,
+                appLaunch = observability.analytics?.appLaunch ?: true,
             ),
             instrumentations = ObservabilityOptions.Instrumentations(
                 crashReporting = observability.instrumentation?.crashReporting ?: true,

--- a/sdk/@launchdarkly/flutter/packages/observability/android/src/main/kotlin/com/launchdarkly/launchdarkly_flutter_observability/Messages.g.kt
+++ b/sdk/@launchdarkly/flutter/packages/observability/android/src/main/kotlin/com/launchdarkly/launchdarkly_flutter_observability/Messages.g.kt
@@ -147,7 +147,9 @@ data class LDTracesOptions (
 data class LDAnalyticsOptions (
   val taps: Boolean? = null,
   val pageViews: Boolean? = null,
-  val trackEvents: Boolean? = null
+  val trackEvents: Boolean? = null,
+  val appLifecycle: Boolean? = null,
+  val appLaunch: Boolean? = null
 )
  {
   companion object {
@@ -155,7 +157,9 @@ data class LDAnalyticsOptions (
       val taps = pigeonVar_list[0] as Boolean?
       val pageViews = pigeonVar_list[1] as Boolean?
       val trackEvents = pigeonVar_list[2] as Boolean?
-      return LDAnalyticsOptions(taps, pageViews, trackEvents)
+      val appLifecycle = pigeonVar_list[3] as Boolean?
+      val appLaunch = pigeonVar_list[4] as Boolean?
+      return LDAnalyticsOptions(taps, pageViews, trackEvents, appLifecycle, appLaunch)
     }
   }
   fun toList(): List<Any?> {
@@ -163,6 +167,8 @@ data class LDAnalyticsOptions (
       taps,
       pageViews,
       trackEvents,
+      appLifecycle,
+      appLaunch,
     )
   }
   override fun equals(other: Any?): Boolean {

--- a/sdk/@launchdarkly/flutter/packages/observability/ios/launchdarkly_flutter_observability/Sources/launchdarkly_flutter_observability/LDNativeApiImpl.swift
+++ b/sdk/@launchdarkly/flutter/packages/observability/ios/launchdarkly_flutter_observability/Sources/launchdarkly_flutter_observability/LDNativeApiImpl.swift
@@ -150,6 +150,8 @@ final class LDNativeApiImpl: NSObject, LDNativeApi {
         // `Instrumentation` defaults. pageViews is Android-only and ignored here.
         let tapsEnabled: Bool = observability.analytics?.taps ?? true
         let trackEventsEnabled: Bool = observability.analytics?.trackEvents ?? true
+        let appLifecycleEnabled: Bool = observability.analytics?.appLifecycle ?? true
+        let appLaunchEnabled: Bool = observability.analytics?.appLaunch ?? true
         let launchTimesEnabled: Bool = observability.instrumentation?.launchTimes ?? true
         let metricsEnabled: Bool = observability.metricsEnabled ?? true
 
@@ -185,7 +187,9 @@ final class LDNativeApiImpl: NSObject, LDNativeApi {
         // which the Dart side reaches by calling `track` on this bridge.
         let analytics = ObservabilityOptions.Analytics(
             taps: tapsEnabled ? .enabled : .disabled,
-            trackEvents: trackEventsEnabled ? .enabled : .disabled
+            trackEvents: trackEventsEnabled ? .enabled : .disabled,
+            appLifecycle: appLifecycleEnabled ? .enabled : .disabled,
+            appLaunch: appLaunchEnabled ? .enabled : .disabled
         )
 
         let observabilityOptions = ObservabilityOptions(

--- a/sdk/@launchdarkly/flutter/packages/observability/ios/launchdarkly_flutter_observability/Sources/launchdarkly_flutter_observability/Messages.g.swift
+++ b/sdk/@launchdarkly/flutter/packages/observability/ios/launchdarkly_flutter_observability/Sources/launchdarkly_flutter_observability/Messages.g.swift
@@ -195,6 +195,8 @@ struct LDAnalyticsOptions: Hashable {
   var taps: Bool? = nil
   var pageViews: Bool? = nil
   var trackEvents: Bool? = nil
+  var appLifecycle: Bool? = nil
+  var appLaunch: Bool? = nil
 
 
   // swift-format-ignore: AlwaysUseLowerCamelCase
@@ -202,11 +204,15 @@ struct LDAnalyticsOptions: Hashable {
     let taps: Bool? = nilOrValue(pigeonVar_list[0])
     let pageViews: Bool? = nilOrValue(pigeonVar_list[1])
     let trackEvents: Bool? = nilOrValue(pigeonVar_list[2])
+    let appLifecycle: Bool? = nilOrValue(pigeonVar_list[3])
+    let appLaunch: Bool? = nilOrValue(pigeonVar_list[4])
 
     return LDAnalyticsOptions(
       taps: taps,
       pageViews: pageViews,
-      trackEvents: trackEvents
+      trackEvents: trackEvents,
+      appLifecycle: appLifecycle,
+      appLaunch: appLaunch
     )
   }
   func toList() -> [Any?] {
@@ -214,6 +220,8 @@ struct LDAnalyticsOptions: Hashable {
       taps,
       pageViews,
       trackEvents,
+      appLifecycle,
+      appLaunch,
     ]
   }
   static func == (lhs: LDAnalyticsOptions, rhs: LDAnalyticsOptions) -> Bool {

--- a/sdk/@launchdarkly/flutter/packages/observability/lib/src/options/observability_options.dart
+++ b/sdk/@launchdarkly/flutter/packages/observability/lib/src/options/observability_options.dart
@@ -107,10 +107,22 @@ class AnalyticsOptions {
   /// `LDObserve.track` API. Defaults to `true`.
   final bool trackEvents;
 
+  /// Whether to emit app-lifecycle spans (`app_foreground` / `app_background`)
+  /// as the app moves between foreground and background. Mobile-only (iOS,
+  /// Android); a no-op elsewhere. Defaults to `true`.
+  final bool appLifecycle;
+
+  /// Whether to emit an `app_launch` span (carrying `event.launch_type` —
+  /// `install` / `update` / `relaunch` — and version fields) once per process
+  /// launch. Mobile-only (iOS, Android); a no-op elsewhere. Defaults to `true`.
+  final bool appLaunch;
+
   const AnalyticsOptions({
     this.taps = true,
     this.pageViews = true,
     this.trackEvents = true,
+    this.appLifecycle = true,
+    this.appLaunch = true,
   });
 
   /// All analytics telemetry enabled. Convenience mirroring Swift's
@@ -131,6 +143,8 @@ class AnalyticsOptions {
     taps: false,
     pageViews: false,
     trackEvents: false,
+    appLifecycle: false,
+    appLaunch: false,
   );
 }
 

--- a/sdk/@launchdarkly/flutter/packages/observability/lib/src/platform/io/messages.g.dart
+++ b/sdk/@launchdarkly/flutter/packages/observability/lib/src/platform/io/messages.g.dart
@@ -122,7 +122,13 @@ class LDTracesOptions {
 }
 
 class LDAnalyticsOptions {
-  LDAnalyticsOptions({this.taps, this.pageViews, this.trackEvents});
+  LDAnalyticsOptions({
+    this.taps,
+    this.pageViews,
+    this.trackEvents,
+    this.appLifecycle,
+    this.appLaunch,
+  });
 
   bool? taps;
 
@@ -130,8 +136,12 @@ class LDAnalyticsOptions {
 
   bool? trackEvents;
 
+  bool? appLifecycle;
+
+  bool? appLaunch;
+
   List<Object?> _toList() {
-    return <Object?>[taps, pageViews, trackEvents];
+    return <Object?>[taps, pageViews, trackEvents, appLifecycle, appLaunch];
   }
 
   Object encode() {
@@ -144,6 +154,8 @@ class LDAnalyticsOptions {
       taps: result[0] as bool?,
       pageViews: result[1] as bool?,
       trackEvents: result[2] as bool?,
+      appLifecycle: result[3] as bool?,
+      appLaunch: result[4] as bool?,
     );
   }
 

--- a/sdk/@launchdarkly/flutter/packages/observability/lib/src/platform/io/native_options_codec.dart
+++ b/sdk/@launchdarkly/flutter/packages/observability/lib/src/platform/io/native_options_codec.dart
@@ -37,6 +37,8 @@ extension AnalyticsOptionsWire on AnalyticsOptions {
     taps: taps,
     pageViews: pageViews,
     trackEvents: trackEvents,
+    appLifecycle: appLifecycle,
+    appLaunch: appLaunch,
   );
 }
 

--- a/sdk/@launchdarkly/flutter/packages/observability/pigeons/messages.dart
+++ b/sdk/@launchdarkly/flutter/packages/observability/pigeons/messages.dart
@@ -38,6 +38,8 @@ class LDAnalyticsOptions {
   bool? taps;
   bool? pageViews;
   bool? trackEvents;
+  bool? appLifecycle;
+  bool? appLaunch;
 }
 
 class LDObservabilityOptions {

--- a/sdk/@launchdarkly/flutter/packages/observability/test/native_options_codec_test.dart
+++ b/sdk/@launchdarkly/flutter/packages/observability/test/native_options_codec_test.dart
@@ -17,6 +17,8 @@ void main() {
       expect(wire.analytics?.taps, isTrue);
       expect(wire.analytics?.pageViews, isTrue);
       expect(wire.analytics?.trackEvents, isTrue);
+      expect(wire.analytics?.appLifecycle, isTrue);
+      expect(wire.analytics?.appLaunch, isTrue);
       expect(wire.instrumentation?.crashReporting, isTrue);
     });
 
@@ -31,6 +33,8 @@ void main() {
           taps: true,
           pageViews: false,
           trackEvents: false,
+          appLifecycle: false,
+          appLaunch: false,
         ),
         instrumentation: InstrumentationOptions(crashReporting: false),
       ).toWire();
@@ -44,6 +48,8 @@ void main() {
       expect(wire.analytics?.taps, isTrue);
       expect(wire.analytics?.pageViews, isFalse);
       expect(wire.analytics?.trackEvents, isFalse);
+      expect(wire.analytics?.appLifecycle, isFalse);
+      expect(wire.analytics?.appLaunch, isFalse);
       expect(wire.instrumentation?.crashReporting, isFalse);
     });
 

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/api/ObservabilityOptions.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/api/ObservabilityOptions.kt
@@ -161,7 +161,9 @@ data class ObservabilityOptions(
      * This class allows enabling or disabling specific automatic instrumentations.
      *
      * @property crashReporting If `true`, the plugin will automatically report any uncaught exceptions as errors.
-     * @property launchTime If `true`, the plugin will automatically measure and report the application's startup time as metrics.
+     * @property launchTime If `true`, emits legacy TTID/TTFD launch-time histogram metrics. The
+     *   `app.start` span event on `app_launch` (cold/warm via `start.type`) is always attached
+     *   when [Analytics.appLaunch] is enabled and is not gated by this flag.
      * @property userTaps If `true`, the plugin runs the tap-detection machinery, issuing tap events
      *   from the captured touch stream. Publishing those taps as `click` spans is governed
      *   separately by [Analytics.taps]; Session Replay capture is unaffected by either flag.

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/api/ObservabilityOptions.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/api/ObservabilityOptions.kt
@@ -133,6 +133,7 @@ data class ObservabilityOptions(
         val trackEvents: Boolean = true,
         val screenViews: Boolean = true,
         val appLifecycle: Boolean = true,
+        val appLaunch: Boolean = true,
     ) {
         /**
          * Java-friendly fluent builder for [Analytics].
@@ -145,6 +146,7 @@ data class ObservabilityOptions(
             fun trackEvents(trackEvents: Boolean) = apply { value = value.copy(trackEvents = trackEvents) }
             fun screenViews(screenViews: Boolean) = apply { value = value.copy(screenViews = screenViews) }
             fun appLifecycle(appLifecycle: Boolean) = apply { value = value.copy(appLifecycle = appLifecycle) }
+            fun appLaunch(appLaunch: Boolean) = apply { value = value.copy(appLaunch = appLaunch) }
 
             fun build() = value
         }

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/client/AppLaunchSignal.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/client/AppLaunchSignal.kt
@@ -28,6 +28,12 @@ data class AppLaunchSignal(
         RELAUNCH("relaunch"),
         INSTALL("install"),
         UPDATE("update"),
+
+        /**
+         * The current app version could not be read, so the launch milestone is indeterminable
+         * (nothing is persisted, so it can't be compared across launches).
+         */
+        UNKNOWN("unknown"),
     }
 
     enum class StartType(val wireValue: String) {

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/client/AppLaunchSignal.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/client/AppLaunchSignal.kt
@@ -1,0 +1,37 @@
+package com.launchdarkly.observability.client
+
+/**
+ * An app-launch analytics event broadcast to in-process consumers such as Session Replay.
+ *
+ * Drives both the taxonomy span (`app_launch`) and the Session Replay timeline breadcrumb
+ * (`Launch`). Emitted once per process launch. Mirrors [AppLifecycleSignal].
+ *
+ * @property launchType The product-milestone of the launch (`install` / `update` / `relaunch`),
+ *   orthogonal to the cold/warm startup-performance dimension carried by [startType].
+ * @property version Current app version (`PackageInfo.versionName`).
+ * @property build Current build number (`PackageInfo.longVersionCode`).
+ * @property previousVersion Version before an `update` launch; `null` otherwise.
+ * @property startType Cold vs warm process start, when known.
+ * @property startDurationMs Time from process start to launch detection, in milliseconds, when known.
+ * @property timestamp Event time, in milliseconds since epoch.
+ */
+data class AppLaunchSignal(
+    val launchType: LaunchType,
+    val version: String?,
+    val build: String?,
+    val previousVersion: String?,
+    val startType: StartType?,
+    val startDurationMs: Long?,
+    val timestamp: Long = System.currentTimeMillis(),
+) {
+    enum class LaunchType(val wireValue: String) {
+        RELAUNCH("relaunch"),
+        INSTALL("install"),
+        UPDATE("update"),
+    }
+
+    enum class StartType(val wireValue: String) {
+        COLD("cold"),
+        WARM("warm"),
+    }
+}

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/client/AppLaunchTracker.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/client/AppLaunchTracker.kt
@@ -84,6 +84,10 @@ class AppLaunchTracker(
         /** Classifies a launch relative to the stored version. Pure, for testability. */
         fun classify(storedVersion: String?, currentVersion: String?): AppLaunchSignal.LaunchType =
             when {
+                // Without a readable version there is nothing to persist or compare, so the
+                // milestone is indeterminable. Returning UNKNOWN (rather than INSTALL) avoids
+                // misclassifying every such relaunch as a fresh install.
+                currentVersion == null -> AppLaunchSignal.LaunchType.UNKNOWN
                 storedVersion == null -> AppLaunchSignal.LaunchType.INSTALL
                 storedVersion != currentVersion -> AppLaunchSignal.LaunchType.UPDATE
                 else -> AppLaunchSignal.LaunchType.RELAUNCH

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/client/AppLaunchTracker.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/client/AppLaunchTracker.kt
@@ -1,0 +1,92 @@
+package com.launchdarkly.observability.client
+
+import android.app.Application
+import android.content.Context
+import android.content.SharedPreferences
+import android.os.Build
+import android.os.Process
+import android.os.SystemClock
+
+/**
+ * Resolves the product-milestone of a launch (`install` / `update` / `relaunch`) and the cold/warm
+ * startup dimension, then emits a single [AppLaunchSignal] on [start].
+ *
+ * The launch type is derived by comparing the current app version against the last one persisted in
+ * [SharedPreferences]; the current version is recorded as a side effect so the next launch can be
+ * classified.
+ *
+ * Mirrors [AppLifecycleTracker]: the signal is emitted unconditionally (so the Session Replay
+ * `Launch` breadcrumb always fires); the `app_launch` span is gated separately by
+ * [com.launchdarkly.observability.api.ObservabilityOptions.Analytics.appLaunch].
+ *
+ * @param onSignal invoked once with the resolved launch signal.
+ * @param prefs version store; overridable for tests.
+ */
+class AppLaunchTracker(
+    private val application: Application,
+    private val onSignal: (AppLaunchSignal) -> Unit,
+    private val prefs: SharedPreferences =
+        application.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE),
+) {
+    private var emitted = false
+
+    fun start() {
+        if (emitted) return
+        emitted = true
+        onSignal(resolveSignal())
+    }
+
+    private fun resolveSignal(): AppLaunchSignal {
+        val (version, build) = resolveVersion()
+
+        val stored = prefs.getString(KEY_LAST_VERSION, null)
+        val launchType = classify(stored, version)
+        val previousVersion = if (launchType == AppLaunchSignal.LaunchType.UPDATE) stored else null
+        version?.let { prefs.edit().putString(KEY_LAST_VERSION, it).apply() }
+
+        // On Android the SDK initializes from a freshly created process, so an `app_launch` is a cold
+        // process start. (Warm/hot relate to activity recreation, captured by `app_foreground`.)
+        val startDurationMs = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            (SystemClock.uptimeMillis() - Process.getStartUptimeMillis()).takeIf { it >= 0 }
+        } else {
+            null
+        }
+
+        return AppLaunchSignal(
+            launchType = launchType,
+            version = version,
+            build = build,
+            previousVersion = previousVersion,
+            startType = AppLaunchSignal.StartType.COLD,
+            startDurationMs = startDurationMs,
+        )
+    }
+
+    private fun resolveVersion(): Pair<String?, String?> {
+        return try {
+            val info = application.packageManager.getPackageInfo(application.packageName, 0)
+            val build = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                info.longVersionCode.toString()
+            } else {
+                @Suppress("DEPRECATION")
+                info.versionCode.toString()
+            }
+            info.versionName to build
+        } catch (_: Exception) {
+            null to null
+        }
+    }
+
+    companion object {
+        const val PREFS_NAME = "com.launchdarkly.observability"
+        const val KEY_LAST_VERSION = "lastAppVersion"
+
+        /** Classifies a launch relative to the stored version. Pure, for testability. */
+        fun classify(storedVersion: String?, currentVersion: String?): AppLaunchSignal.LaunchType =
+            when {
+                storedVersion == null -> AppLaunchSignal.LaunchType.INSTALL
+                storedVersion != currentVersion -> AppLaunchSignal.LaunchType.UPDATE
+                else -> AppLaunchSignal.LaunchType.RELAUNCH
+            }
+    }
+}

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/client/ObservabilityContext.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/client/ObservabilityContext.kt
@@ -53,5 +53,6 @@ data class ObservabilityContext(
      * launch fires before any Session Replay subscriber exists; Session Replay reads it directly
      * when building the first wake-up batch to emit the `Launch` timeline breadcrumb.
      */
+
     var appLaunchSignal: AppLaunchSignal? = null,
 )

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/client/ObservabilityContext.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/client/ObservabilityContext.kt
@@ -47,4 +47,9 @@ data class ObservabilityContext(
      * timeline breadcrumbs.
      */
     var appLifecycleFlow: SharedFlow<AppLifecycleSignal>? = null,
+    /**
+     * Stream of app-launch signals (one per process launch) from the single emitter, owned by
+     * Observability. Session Replay consumes it to emit a `Launch` timeline breadcrumb.
+     */
+    var appLaunchFlow: SharedFlow<AppLaunchSignal>? = null,
 )

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/client/ObservabilityContext.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/client/ObservabilityContext.kt
@@ -48,8 +48,10 @@ data class ObservabilityContext(
      */
     var appLifecycleFlow: SharedFlow<AppLifecycleSignal>? = null,
     /**
-     * Stream of app-launch signals (one per process launch) from the single emitter, owned by
-     * Observability. Session Replay consumes it to emit a `Launch` timeline breadcrumb.
+     * The one-shot app-launch signal (resolved during Observability start, before Session Replay
+     * registers), owned by Observability. Cached synchronously rather than streamed because the
+     * launch fires before any Session Replay subscriber exists; Session Replay reads it directly
+     * when building the first wake-up batch to emit the `Launch` timeline breadcrumb.
      */
-    var appLaunchFlow: SharedFlow<AppLaunchSignal>? = null,
+    var appLaunchSignal: AppLaunchSignal? = null,
 )

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/client/ObservabilityService.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/client/ObservabilityService.kt
@@ -729,9 +729,9 @@ class ObservabilityService(
      * breadcrumb (always), then emits the taxonomy `app_launch` span only when gated on by
      * [ObservabilityOptions.Analytics.appLaunch] (and the global span flag).
      *
-     * The cold/warm startup-performance dimension is attached as an `app.start` span event, gated by
-     * [ObservabilityOptions.Instrumentations.launchTime] (the refactored home of the legacy
-     * launch-time metering).
+     * The cold/warm startup-performance dimension is attached as an `app.start` span event whenever
+     * [startType] is known (taxonomy §4.6). [ObservabilityOptions.Instrumentations.launchTime] only
+     * gates legacy TTID/TTFD histogram metrics, not this event.
      */
     private fun handleAppLaunchSignal(signal: AppLaunchSignal) {
         // Broadcast so Session Replay can emit a breadcrumb independent of the span flags below.
@@ -752,12 +752,10 @@ class ObservabilityService(
             .setSpanKind(SpanKind.CLIENT)
             .setAllAttributes(attrBuilder.build())
             .startSpan()
-        if (observabilityOptions.instrumentations.launchTime) {
-            signal.startType?.let { startType ->
-                val eventAttrs = Attributes.builder().put(START_TYPE, startType.wireValue)
-                signal.startDurationMs?.let { eventAttrs.put(START_DURATION_MS, it) }
-                span.addEvent(APP_START_EVENT_NAME, eventAttrs.build())
-            }
+        signal.startType?.let { startType ->
+            val eventAttrs = Attributes.builder().put(START_TYPE, startType.wireValue)
+            signal.startDurationMs?.let { eventAttrs.put(START_DURATION_MS, it) }
+            span.addEvent(APP_START_EVENT_NAME, eventAttrs.build())
         }
         span.end()
     }

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/client/ObservabilityService.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/client/ObservabilityService.kt
@@ -183,6 +183,24 @@ class ObservabilityService(
      */
     private val appLifecycleTracker = AppLifecycleTracker(onSignal = { signal -> handleAppLifecycleSignal(signal) })
 
+    /**
+     * Broadcasts the app-launch signal (one per process launch) so Session Replay can emit a
+     * `Launch` breadcrumb regardless of the span flags. Shared via [ObservabilityContext.appLaunchFlow].
+     */
+    private val _appLaunchFlow = MutableSharedFlow<AppLaunchSignal>(
+        extraBufferCapacity = 4,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST
+    )
+    val appLaunchFlow: SharedFlow<AppLaunchSignal> = _appLaunchFlow.asSharedFlow()
+
+    /**
+     * Resolves the launch type (install/update/relaunch) and cold/warm startup dimension once per
+     * process launch, routing it through [handleAppLaunchSignal]. Runs unconditionally so the
+     * Session Replay `Launch` breadcrumb is always available; the `app_launch` span is gated by
+     * [ObservabilityOptions.Analytics.appLaunch].
+     */
+    private val appLaunchTracker = AppLaunchTracker(application, onSignal = { signal -> handleAppLaunchSignal(signal) })
+
     //TODO: Evaluate if this class should have a close/shutdown method to close this scope
     private val scope = CoroutineScope(DispatcherProviderHolder.current.io + SupervisorJob())
 
@@ -278,6 +296,10 @@ class ObservabilityService(
         // App-lifecycle detection runs unconditionally so Session Replay breadcrumbs are always
         // available; the span itself is gated by analytics.appLifecycle inside the handler.
         appLifecycleTracker.start()
+
+        // App-launch detection runs unconditionally so the Session Replay `Launch` breadcrumb is
+        // always available; the `app_launch` span is gated by analytics.appLaunch inside the handler.
+        appLaunchTracker.start()
 
         batchWorker.start()
     }
@@ -702,6 +724,44 @@ class ObservabilityService(
             .end()
     }
 
+    /**
+     * Single funnel for the app-launch signal. Broadcasts it so Session Replay can record a `Launch`
+     * breadcrumb (always), then emits the taxonomy `app_launch` span only when gated on by
+     * [ObservabilityOptions.Analytics.appLaunch] (and the global span flag).
+     *
+     * The cold/warm startup-performance dimension is attached as an `app.start` span event, gated by
+     * [ObservabilityOptions.Instrumentations.launchTime] (the refactored home of the legacy
+     * launch-time metering).
+     */
+    private fun handleAppLaunchSignal(signal: AppLaunchSignal) {
+        // Broadcast so Session Replay can emit a breadcrumb independent of the span flags below.
+        _appLaunchFlow.tryEmit(signal)
+
+        if (!observabilityOptions.analytics.appLaunch) return
+        if (!observabilityOptions.tracesApi.includeSpans) return
+
+        val attrBuilder = Attributes.builder()
+        // Context keys first so the reserved `event.*` taxonomy fields always win.
+        attrBuilder.putAll(cachedContextKeyAttributes)
+        attrBuilder.put(EVENT_LAUNCH_TYPE, signal.launchType.wireValue)
+        signal.version?.let { attrBuilder.put(EVENT_VERSION, it) }
+        signal.build?.let { attrBuilder.put(EVENT_BUILD, it) }
+        signal.previousVersion?.let { attrBuilder.put(EVENT_PREVIOUS_VERSION, it) }
+
+        val span = otelTracer.spanBuilder(APP_LAUNCH_SPAN_NAME)
+            .setSpanKind(SpanKind.CLIENT)
+            .setAllAttributes(attrBuilder.build())
+            .startSpan()
+        if (observabilityOptions.instrumentations.launchTime) {
+            signal.startType?.let { startType ->
+                val eventAttrs = Attributes.builder().put(START_TYPE, startType.wireValue)
+                signal.startDurationMs?.let { eventAttrs.put(START_DURATION_MS, it) }
+                span.addEvent(APP_START_EVENT_NAME, eventAttrs.build())
+            }
+        }
+        span.end()
+    }
+
     override fun updateCachedContextKeys(contextKeys: Map<String, String>) {
         val builder = Attributes.builder()
         for ((k, v) in contextKeys) {
@@ -771,6 +831,8 @@ class ObservabilityService(
         const val SCREEN_VIEW_SPAN_NAME = "screen_view"
         const val APP_FOREGROUND_SPAN_NAME = "app_foreground"
         const val APP_BACKGROUND_SPAN_NAME = "app_background"
+        const val APP_LAUNCH_SPAN_NAME = "app_launch"
+        const val APP_START_EVENT_NAME = "app.start"
         const val SESSION_ID_ATTRIBUTE = "session.id"
 
         // `event.*` taxonomy attribute keys (see analytics-taxonomy.md).
@@ -787,6 +849,12 @@ class ObservabilityService(
         private val EVENT_PREVIOUS_SCREEN = AttributeKey.stringKey("event.previous_screen")
         private val EVENT_CATEGORY = AttributeKey.stringKey("event.category")
         private val EVENT_LIFECYCLE_STATE = AttributeKey.stringKey("event.lifecycle_state")
+        private val EVENT_LAUNCH_TYPE = AttributeKey.stringKey("event.launch_type")
+        private val EVENT_VERSION = AttributeKey.stringKey("event.version")
+        private val EVENT_BUILD = AttributeKey.stringKey("event.build")
+        private val EVENT_PREVIOUS_VERSION = AttributeKey.stringKey("event.previous_version")
+        private val START_TYPE = AttributeKey.stringKey("start.type")
+        private val START_DURATION_MS = AttributeKey.longKey("start.duration_ms")
 
         // Tap detection thresholds. Long-press timeout separates taps from long presses; the slop
         // (12px, matching the Session Replay move filter) separates taps from drags.

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/client/ObservabilityService.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/client/ObservabilityService.kt
@@ -186,8 +186,14 @@ class ObservabilityService(
     /**
      * Broadcasts the app-launch signal (one per process launch) so Session Replay can emit a
      * `Launch` breadcrumb regardless of the span flags. Shared via [ObservabilityContext.appLaunchFlow].
+     *
+     * `replay = 1`: the launch fires once during this service's init, before Session Replay
+     * subscribes in its own `initialize()`. The replay cache delivers that one-shot signal to the
+     * late subscriber so the `Launch` breadcrumb is not dropped (the span path is unaffected as it
+     * runs inline in [handleAppLaunchSignal]).
      */
     private val _appLaunchFlow = MutableSharedFlow<AppLaunchSignal>(
+        replay = 1,
         extraBufferCapacity = 4,
         onBufferOverflow = BufferOverflow.DROP_OLDEST
     )

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/client/ObservabilityService.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/client/ObservabilityService.kt
@@ -749,16 +749,25 @@ class ObservabilityService(
         signal.build?.let { attrBuilder.put(EVENT_BUILD, it) }
         signal.previousVersion?.let { attrBuilder.put(EVENT_PREVIOUS_VERSION, it) }
 
+        // The span represents the launch itself, not the (later) point where this handler runs after
+        // startup work. Anchor it to process start (the launch-detection time minus the measured
+        // startup duration) and end it at the launch-detection time carried by the signal, so
+        // analytics timestamps reflect the real startup window and aren't skewed by SDK init work.
+        val launchTimeMs = signal.timestamp
+        val spanStartMs = signal.startDurationMs?.let { launchTimeMs - it } ?: launchTimeMs
+
         val span = otelTracer.spanBuilder(APP_LAUNCH_SPAN_NAME)
             .setSpanKind(SpanKind.CLIENT)
             .setAllAttributes(attrBuilder.build())
+            .setStartTimestamp(spanStartMs, TimeUnit.MILLISECONDS)
             .startSpan()
         signal.startType?.let { startType ->
             val eventAttrs = Attributes.builder().put(START_TYPE, startType.wireValue)
             signal.startDurationMs?.let { eventAttrs.put(START_DURATION_MS, it) }
-            span.addEvent(APP_START_EVENT_NAME, eventAttrs.build())
+            // Place the event at the launch-detection time so it falls within the span window.
+            span.addEvent(APP_START_EVENT_NAME, eventAttrs.build(), launchTimeMs, TimeUnit.MILLISECONDS)
         }
-        span.end()
+        span.end(launchTimeMs, TimeUnit.MILLISECONDS)
     }
 
     override fun updateCachedContextKeys(contextKeys: Map<String, String>) {

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/client/ObservabilityService.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/client/ObservabilityService.kt
@@ -184,20 +184,13 @@ class ObservabilityService(
     private val appLifecycleTracker = AppLifecycleTracker(onSignal = { signal -> handleAppLifecycleSignal(signal) })
 
     /**
-     * Broadcasts the app-launch signal (one per process launch) so Session Replay can emit a
-     * `Launch` breadcrumb regardless of the span flags. Shared via [ObservabilityContext.appLaunchFlow].
-     *
-     * `replay = 1`: the launch fires once during this service's init, before Session Replay
-     * subscribes in its own `initialize()`. The replay cache delivers that one-shot signal to the
-     * late subscriber so the `Launch` breadcrumb is not dropped (the span path is unaffected as it
-     * runs inline in [handleAppLaunchSignal]).
+     * The one-shot app-launch signal, resolved synchronously during this service's `init` (before
+     * Session Replay registers). Cached here rather than streamed so Session Replay can read it
+     * directly when building its first wake-up batch — a stream would race the launch, which fires
+     * before any subscriber exists. Wired into [ObservabilityContext.appLaunchSignal].
      */
-    private val _appLaunchFlow = MutableSharedFlow<AppLaunchSignal>(
-        replay = 1,
-        extraBufferCapacity = 4,
-        onBufferOverflow = BufferOverflow.DROP_OLDEST
-    )
-    val appLaunchFlow: SharedFlow<AppLaunchSignal> = _appLaunchFlow.asSharedFlow()
+    var appLaunchSignal: AppLaunchSignal? = null
+        private set
 
     /**
      * Resolves the launch type (install/update/relaunch) and cold/warm startup dimension once per
@@ -740,8 +733,10 @@ class ObservabilityService(
      * gates legacy TTID/TTFD histogram metrics, not this event.
      */
     private fun handleAppLaunchSignal(signal: AppLaunchSignal) {
-        // Broadcast so Session Replay can emit a breadcrumb independent of the span flags below.
-        _appLaunchFlow.tryEmit(signal)
+        // Cache before the span flag checks so Session Replay can emit the `Launch` breadcrumb
+        // independent of the span flags below. Runs synchronously during init, so the signal is
+        // available before Session Replay reads it.
+        appLaunchSignal = signal
 
         if (!observabilityOptions.analytics.appLaunch) return
         if (!observabilityOptions.tracesApi.includeSpans) return

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/plugin/Observability.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/plugin/Observability.kt
@@ -121,6 +121,7 @@ class Observability(
         LDObserve.context?.screenViewManager = observabilityService.screenViewManager
         LDObserve.context?.trackFlow = observabilityService.trackFlow
         LDObserve.context?.appLifecycleFlow = observabilityService.appLifecycleFlow
+        LDObserve.context?.appLaunchFlow = observabilityService.appLaunchFlow
         LDObserve.init(observabilityService)
 
         observabilityHook.delegate = observabilityService.hookExporter

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/plugin/Observability.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/plugin/Observability.kt
@@ -121,7 +121,7 @@ class Observability(
         LDObserve.context?.screenViewManager = observabilityService.screenViewManager
         LDObserve.context?.trackFlow = observabilityService.trackFlow
         LDObserve.context?.appLifecycleFlow = observabilityService.appLifecycleFlow
-        LDObserve.context?.appLaunchFlow = observabilityService.appLaunchFlow
+        LDObserve.context?.appLaunchSignal = observabilityService.appLaunchSignal
         LDObserve.init(observabilityService)
 
         observabilityHook.delegate = observabilityService.hookExporter

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/RRWebTypes.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/RRWebTypes.kt
@@ -63,4 +63,5 @@ enum class RRWebCustomDataTag(val wireValue: String) {
     NAVIGATE("Navigate"),
     APP_FOREGROUND("Foreground"),
     APP_BACKGROUND("Background"),
+    APP_LAUNCH("Launch"),
 }

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/SessionReplayService.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/SessionReplayService.kt
@@ -91,6 +91,15 @@ class SessionReplayService(
     private var pendingIdentify: IdentifyItemPayload? = null
 
     /**
+     * The one-shot `Launch` breadcrumb. The launch signal fires during Observability start (before
+     * this service subscribes), so it is cached here and folded into the exporter's first wake-up
+     * batch rather than enqueued directly, which would race session initialization and drop the
+     * event. Written from the collector coroutine, read from the export coroutine.
+     */
+    @Volatile
+    private var pendingAppLaunch: AppLaunchItemPayload? = null
+
+    /**
      * Installs replay instrumentation. Idempotent.
      *
      * Returns `true` if the service is now installed (by this call or a previous one).
@@ -138,7 +147,8 @@ class SessionReplayService(
             serviceVersion = observabilityContext.options.serviceVersion,
             initialIdentifyItemPayload = initialIdentifyItemPayload,
             title = appName,
-            logger = logger
+            logger = logger,
+            appLaunchProvider = { pendingAppLaunch },
         )
         this@SessionReplayService.exporter = exporter
         batchWorker.addExporter(exporter)
@@ -228,17 +238,16 @@ class SessionReplayService(
             }
         }
 
-        // App-launch collector: the process launch from Observability becomes an rrweb `Launch`
-        // breadcrumb on the active recording.
+        // App-launch collector: the process launch fires once during Observability start, before
+        // this subscription is attached (delivered via the flow's replay cache). Enqueuing it
+        // directly would race session initialization, so cache it and let the exporter fold the
+        // `Launch` breadcrumb into the first wake-up batch (which runs after the session is inited).
         instrumentationScope.launch {
             observabilityContext.appLaunchFlow?.collect { signal ->
-                if (!_isEnabled.value) return@collect
-                eventQueue.send(
-                    AppLaunchItemPayload(
-                        launchType = signal.launchType.wireValue,
-                        timestamp = signal.timestamp,
-                        sessionId = sessionManager.getSessionId()
-                    )
+                pendingAppLaunch = AppLaunchItemPayload(
+                    launchType = signal.launchType.wireValue,
+                    timestamp = signal.timestamp,
+                    sessionId = null
                 )
             }
         }

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/SessionReplayService.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/SessionReplayService.kt
@@ -91,24 +91,6 @@ class SessionReplayService(
     private var pendingIdentify: IdentifyItemPayload? = null
 
     /**
-     * Builds the one-shot `Launch` breadcrumb from the signal Observability cached synchronously at
-     * start ([ObservabilityContext.appLaunchSignal]). Read directly (not via a collector) so the
-     * exporter's first wake-up batch can't race an async subscription and drop the event. Returns
-     * `null` if no launch was resolved.
-     */
-    private fun pendingAppLaunch(): AppLaunchItemPayload? =
-        observabilityContext.appLaunchSignal?.let { signal ->
-            AppLaunchItemPayload(
-                launchType = signal.launchType.wireValue,
-                version = signal.version,
-                build = signal.build,
-                previousVersion = signal.previousVersion,
-                timestamp = signal.timestamp,
-                sessionId = null
-            )
-        }
-
-    /**
      * Installs replay instrumentation. Idempotent.
      *
      * Returns `true` if the service is now installed (by this call or a previous one).
@@ -149,6 +131,19 @@ class SessionReplayService(
         } catch (_: Exception) {
             "Android app"
         }
+        // The launch signal is resolved during Observability init (before this runs), so build the
+        // `Launch` breadcrumb once here on the main thread and inject it — the exporter never reads
+        // the shared context on its background export thread.
+        val initialAppLaunchItemPayload = observabilityContext.appLaunchSignal?.let { signal ->
+            AppLaunchItemPayload(
+                launchType = signal.launchType.wireValue,
+                version = signal.version,
+                build = signal.build,
+                previousVersion = signal.previousVersion,
+                timestamp = signal.timestamp,
+                sessionId = null
+            )
+        }
         val exporter = SessionReplayExporter(
             organizationVerboseId = observabilityContext.sdkKey,
             backendUrl = observabilityContext.options.backendUrl,
@@ -157,7 +152,7 @@ class SessionReplayService(
             initialIdentifyItemPayload = initialIdentifyItemPayload,
             title = appName,
             logger = logger,
-            appLaunchProvider = { pendingAppLaunch() },
+            initialAppLaunchItemPayload = initialAppLaunchItemPayload,
         )
         this@SessionReplayService.exporter = exporter
         batchWorker.addExporter(exporter)
@@ -248,8 +243,8 @@ class SessionReplayService(
         }
 
         // The `Launch` breadcrumb is not collected here: Observability resolves the launch signal
-        // synchronously at start (before this service registers) and caches it on the context, so
-        // the exporter reads it directly via `appLaunchProvider` when building the wake-up batch.
+        // synchronously at start (before this service registers), so it is read once in
+        // `initialize()` and injected into the exporter, which emits it on the first wake-up batch.
     }
 
     /**

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/SessionReplayService.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/SessionReplayService.kt
@@ -13,6 +13,7 @@ import com.launchdarkly.observability.replay.capture.CaptureManager
 import com.launchdarkly.observability.replay.capture.ImageCaptureService
 import com.launchdarkly.observability.replay.capture.ImageCaptureServicing
 import com.launchdarkly.observability.replay.exporter.AppLifecycleItemPayload
+import com.launchdarkly.observability.replay.exporter.AppLaunchItemPayload
 import com.launchdarkly.observability.replay.exporter.IdentifyItemPayload
 import com.launchdarkly.observability.replay.exporter.ImageItemPayload
 import com.launchdarkly.observability.replay.exporter.InteractionItemPayload
@@ -224,6 +225,21 @@ class SessionReplayService(
                 if (signal.kind == AppLifecycleSignal.Kind.BACKGROUND) {
                     batchWorker.flush()
                 }
+            }
+        }
+
+        // App-launch collector: the process launch from Observability becomes an rrweb `Launch`
+        // breadcrumb on the active recording.
+        instrumentationScope.launch {
+            observabilityContext.appLaunchFlow?.collect { signal ->
+                if (!_isEnabled.value) return@collect
+                eventQueue.send(
+                    AppLaunchItemPayload(
+                        launchType = signal.launchType.wireValue,
+                        timestamp = signal.timestamp,
+                        sessionId = sessionManager.getSessionId()
+                    )
+                )
             }
         }
     }

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/SessionReplayService.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/SessionReplayService.kt
@@ -246,6 +246,9 @@ class SessionReplayService(
             observabilityContext.appLaunchFlow?.collect { signal ->
                 pendingAppLaunch = AppLaunchItemPayload(
                     launchType = signal.launchType.wireValue,
+                    version = signal.version,
+                    build = signal.build,
+                    previousVersion = signal.previousVersion,
                     timestamp = signal.timestamp,
                     sessionId = null
                 )

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/SessionReplayService.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/SessionReplayService.kt
@@ -91,13 +91,22 @@ class SessionReplayService(
     private var pendingIdentify: IdentifyItemPayload? = null
 
     /**
-     * The one-shot `Launch` breadcrumb. The launch signal fires during Observability start (before
-     * this service subscribes), so it is cached here and folded into the exporter's first wake-up
-     * batch rather than enqueued directly, which would race session initialization and drop the
-     * event. Written from the collector coroutine, read from the export coroutine.
+     * Builds the one-shot `Launch` breadcrumb from the signal Observability cached synchronously at
+     * start ([ObservabilityContext.appLaunchSignal]). Read directly (not via a collector) so the
+     * exporter's first wake-up batch can't race an async subscription and drop the event. Returns
+     * `null` if no launch was resolved.
      */
-    @Volatile
-    private var pendingAppLaunch: AppLaunchItemPayload? = null
+    private fun pendingAppLaunch(): AppLaunchItemPayload? =
+        observabilityContext.appLaunchSignal?.let { signal ->
+            AppLaunchItemPayload(
+                launchType = signal.launchType.wireValue,
+                version = signal.version,
+                build = signal.build,
+                previousVersion = signal.previousVersion,
+                timestamp = signal.timestamp,
+                sessionId = null
+            )
+        }
 
     /**
      * Installs replay instrumentation. Idempotent.
@@ -148,7 +157,7 @@ class SessionReplayService(
             initialIdentifyItemPayload = initialIdentifyItemPayload,
             title = appName,
             logger = logger,
-            appLaunchProvider = { pendingAppLaunch },
+            appLaunchProvider = { pendingAppLaunch() },
         )
         this@SessionReplayService.exporter = exporter
         batchWorker.addExporter(exporter)
@@ -238,22 +247,9 @@ class SessionReplayService(
             }
         }
 
-        // App-launch collector: the process launch fires once during Observability start, before
-        // this subscription is attached (delivered via the flow's replay cache). Enqueuing it
-        // directly would race session initialization, so cache it and let the exporter fold the
-        // `Launch` breadcrumb into the first wake-up batch (which runs after the session is inited).
-        instrumentationScope.launch {
-            observabilityContext.appLaunchFlow?.collect { signal ->
-                pendingAppLaunch = AppLaunchItemPayload(
-                    launchType = signal.launchType.wireValue,
-                    version = signal.version,
-                    build = signal.build,
-                    previousVersion = signal.previousVersion,
-                    timestamp = signal.timestamp,
-                    sessionId = null
-                )
-            }
-        }
+        // The `Launch` breadcrumb is not collected here: Observability resolves the launch signal
+        // synchronously at start (before this service registers) and caches it on the context, so
+        // the exporter reads it directly via `appLaunchProvider` when building the wake-up batch.
     }
 
     /**

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/exporter/AppLaunchItemPayload.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/exporter/AppLaunchItemPayload.kt
@@ -11,10 +11,16 @@ import com.launchdarkly.observability.replay.transport.EventQueueItemPayload
  * active recording, independent of the corresponding `app_launch` span.
  *
  * @property launchType The product launch type (`install` / `update` / `relaunch`).
+ * @property version Current app version, when known.
+ * @property build Current build number, when known.
+ * @property previousVersion Version before an `update` launch; `null` otherwise.
  * @property sessionId The replay session this event belongs to.
  */
 data class AppLaunchItemPayload(
     val launchType: String?,
+    val version: String?,
+    val build: String?,
+    val previousVersion: String?,
     override val timestamp: Long,
     val sessionId: String?
 ) : EventQueueItemPayload {

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/exporter/AppLaunchItemPayload.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/exporter/AppLaunchItemPayload.kt
@@ -1,0 +1,28 @@
+package com.launchdarkly.observability.replay.exporter
+
+import com.launchdarkly.observability.replay.RRWebCustomDataTag
+import com.launchdarkly.observability.replay.transport.EventExporting
+import com.launchdarkly.observability.replay.transport.EventQueueItemPayload
+
+/**
+ * Session-replay queue item for an app launch, rendered as an rrweb `Launch` custom event.
+ *
+ * Mirrors the analytics taxonomy `app_launch` event: each process launch emits a breadcrumb on the
+ * active recording, independent of the corresponding `app_launch` span.
+ *
+ * @property launchType The product launch type (`install` / `update` / `relaunch`).
+ * @property sessionId The replay session this event belongs to.
+ */
+data class AppLaunchItemPayload(
+    val launchType: String?,
+    override val timestamp: Long,
+    val sessionId: String?
+) : EventQueueItemPayload {
+
+    val tag: RRWebCustomDataTag = RRWebCustomDataTag.APP_LAUNCH
+
+    override val exporterClass: Class<out EventExporting>
+        get() = SessionReplayExporter::class.java
+
+    override fun cost(): Int = 100
+}

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/exporter/IdentifyItemPayload.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/exporter/IdentifyItemPayload.kt
@@ -69,6 +69,7 @@ data class IdentifyItemPayload(
             val canonicalKey = canonicalKeyOverride ?: ldContext?.fullyQualifiedKey ?: "unknown"
             attributes["key"] = contextFriendlyName ?: canonicalKey
             attributes["canonicalKey"] = canonicalKey
+            attributes["userIdentifier"] = contextFriendlyName ?: canonicalKey
 
             return IdentifyItemPayload(
                 attributes = attributes,

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/exporter/IdentifyItemPayload.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/exporter/IdentifyItemPayload.kt
@@ -67,9 +67,10 @@ data class IdentifyItemPayload(
             }
 
             val canonicalKey = canonicalKeyOverride ?: ldContext?.fullyQualifiedKey ?: "unknown"
-            attributes["key"] = contextFriendlyName ?: canonicalKey
+            val displayKey = contextFriendlyName ?: canonicalKey
+            attributes["key"] = displayKey
             attributes["canonicalKey"] = canonicalKey
-            attributes["userIdentifier"] = contextFriendlyName ?: canonicalKey
+            attributes["userIdentifier"] = displayKey
 
             return IdentifyItemPayload(
                 attributes = attributes,

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/exporter/RRWebEventGenerator.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/exporter/RRWebEventGenerator.kt
@@ -503,6 +503,9 @@ class RRWebEventGenerator(
         val payloadJSONString = try {
             buildJsonObject {
                 payload.launchType?.let { put("launch_type", it) }
+                payload.version?.let { put("version", it) }
+                payload.build?.let { put("build", it) }
+                payload.previousVersion?.let { put("previous_version", it) }
             }.toString()
         } catch (_: Exception) {
             return null

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/exporter/RRWebEventGenerator.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/exporter/RRWebEventGenerator.kt
@@ -524,16 +524,21 @@ class RRWebEventGenerator(
     /**
      * Generates a "Reload" custom event and a sequence of "wake-up" interaction events.
      * Used by [SessionReplayExporter] to re-trigger player playback after session resumption.
+     *
+     * When [appLaunch] is provided, the one-shot `Launch` breadcrumb is folded into this batch
+     * instead of being enqueued via the live collector: the launch signal fires during SDK start
+     * before Session Replay subscribes, and enqueuing it directly would race session
+     * initialization. Emitting it here guarantees it lands on an already-initialized session.
      */
-    fun generateWakeUpEvents(timestamp: Long): List<Event> {
+    fun generateWakeUpEvents(timestamp: Long, appLaunch: AppLaunchItemPayload? = null): List<Event> {
         val imageId = imageNodeId ?: return emptyList()
 
-        return listOf(
-            generateReloadEvent(timestamp),
-            // artificial mouse down/up to wake up player
-            generateMouseInteractionEvent(EventType.INCREMENTAL_SNAPSHOT, RRWebMouseInteraction.MOUSE_DOWN, imageId, timestamp),
-            generateMouseInteractionEvent(EventType.INCREMENTAL_SNAPSHOT, RRWebMouseInteraction.MOUSE_UP, imageId, timestamp)
-        )
+        val events = mutableListOf(generateReloadEvent(timestamp))
+        appLaunch?.let { payload -> generateAppLaunchEvent(payload)?.let(events::add) }
+        // artificial mouse down/up to wake up player
+        events += generateMouseInteractionEvent(EventType.INCREMENTAL_SNAPSHOT, RRWebMouseInteraction.MOUSE_DOWN, imageId, timestamp)
+        events += generateMouseInteractionEvent(EventType.INCREMENTAL_SNAPSHOT, RRWebMouseInteraction.MOUSE_UP, imageId, timestamp)
+        return events
     }
 
     private fun generateReloadEvent(timestamp: Long): Event {

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/exporter/RRWebEventGenerator.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/exporter/RRWebEventGenerator.kt
@@ -496,6 +496,32 @@ class RRWebEventGenerator(
     }
 
     /**
+     * Generates a `Launch` custom event. The payload is a stringified JSON `{ "launch_type" }`
+     * (mirroring the app-lifecycle breadcrumb).
+     */
+    fun generateAppLaunchEvent(payload: AppLaunchItemPayload): Event? {
+        val payloadJSONString = try {
+            buildJsonObject {
+                payload.launchType?.let { put("launch_type", it) }
+            }.toString()
+        } catch (_: Exception) {
+            return null
+        }
+
+        val customData = buildJsonObject {
+            put("tag", JsonPrimitive(payload.tag.wireValue))
+            put("payload", JsonPrimitive(payloadJSONString))
+        }
+
+        return Event(
+            type = EventType.CUSTOM,
+            timestamp = payload.timestamp,
+            sid = nextSid(),
+            data = EventDataUnion.CustomEventDataWrapper(customData)
+        )
+    }
+
+    /**
      * Generates a "Reload" custom event and a sequence of "wake-up" interaction events.
      * Used by [SessionReplayExporter] to re-trigger player playback after session resumption.
      */

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/exporter/SessionReplayExporter.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/exporter/SessionReplayExporter.kt
@@ -129,6 +129,15 @@ class SessionReplayExporter(
                             }
                         }
 
+                        is AppLaunchItemPayload -> {
+                            val sessionId = payload.sessionId ?: lastCaptureSnapshot.sessionId
+                            sessionId?.let { sessionId ->
+                                eventGenerator.generateAppLaunchEvent(payload)?.let { launchEvent ->
+                                    eventsBySession.getOrPut(sessionId) { mutableListOf() }.add(launchEvent)
+                                }
+                            }
+                        }
+
                         else -> {
                             // Noop
                         }

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/exporter/SessionReplayExporter.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/exporter/SessionReplayExporter.kt
@@ -34,7 +34,13 @@ class SessionReplayExporter(
     private val injectedReplayApiService: SessionReplayApiService? = null,
     private val logger: ObserveLogger,
     private val canvasBufferLimit: Int = RRWEB_CANVAS_BUFFER_LIMIT,
-    canvasDrawEntourage: Int = RRWEB_CANVAS_DRAW_ENTOURAGE
+    canvasDrawEntourage: Int = RRWEB_CANVAS_DRAW_ENTOURAGE,
+    /**
+     * Supplies the one-shot `Launch` breadcrumb (resolved during SDK start, before Session Replay
+     * subscribes) so it can be folded into the first wake-up batch instead of being enqueued early
+     * and racing session initialization. Returns `null` once there is no pending launch.
+     */
+    private val appLaunchProvider: () -> AppLaunchItemPayload? = { null },
 ) : EventExporting {
     private val exportMutex = Mutex()
 
@@ -181,7 +187,7 @@ class SessionReplayExporter(
         try {
             if (shouldWakeUpSession) {
                 val lastEventTimestamp = events.lastOrNull()?.timestamp ?: 0L
-                val wakeUpEvents = eventGenerator.generateWakeUpEvents(lastEventTimestamp)
+                val wakeUpEvents = eventGenerator.generateWakeUpEvents(lastEventTimestamp, appLaunchProvider())
                 if (wakeUpEvents.isNotEmpty()) {
                     // we need a separate payload to wake up player
                     replayApiService.pushPayload(sessionId, "${nextPayloadId()}", wakeUpEvents)

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/exporter/SessionReplayExporter.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/exporter/SessionReplayExporter.kt
@@ -36,11 +36,12 @@ class SessionReplayExporter(
     private val canvasBufferLimit: Int = RRWEB_CANVAS_BUFFER_LIMIT,
     canvasDrawEntourage: Int = RRWEB_CANVAS_DRAW_ENTOURAGE,
     /**
-     * Supplies the one-shot `Launch` breadcrumb (resolved during SDK start, before Session Replay
-     * subscribes) so it can be folded into the first wake-up batch instead of being enqueued early
-     * and racing session initialization. Returns `null` once there is no pending launch.
+     * The one-shot `Launch` breadcrumb, resolved during SDK start (before Session Replay subscribes)
+     * and injected here so it can be folded into the first wake-up batch instead of being enqueued
+     * early and racing session initialization. Owned by the exporter (guarded by [exportMutex]) so it
+     * is never read from the shared context on the export thread.
      */
-    private val appLaunchProvider: () -> AppLaunchItemPayload? = { null },
+    initialAppLaunchItemPayload: AppLaunchItemPayload? = null,
 ) : EventExporting {
     private val exportMutex = Mutex()
 
@@ -56,6 +57,9 @@ class SessionReplayExporter(
         )
 
     private var identifyItemPayload = initialIdentifyItemPayload
+    // `val` (never reassigned) so its constructor write is safely published to the export coroutine
+    // that reads it in `wakeUpEvents` (JMM final-field guarantee), independent of any lock.
+    private val appLaunchItemPayload = initialAppLaunchItemPayload
     // TODO: O11Y-624 - need to implement sid, payloadId reset when multiple sessions occur in one application process lifecycle.
     private var payloadIdCounter = 0
     private var shouldWakeUpSession = true
@@ -187,7 +191,7 @@ class SessionReplayExporter(
         try {
             if (shouldWakeUpSession) {
                 val lastEventTimestamp = events.lastOrNull()?.timestamp ?: 0L
-                val wakeUpEvents = eventGenerator.generateWakeUpEvents(lastEventTimestamp, appLaunchProvider())
+                val wakeUpEvents = eventGenerator.generateWakeUpEvents(lastEventTimestamp, appLaunchItemPayload)
                 if (wakeUpEvents.isNotEmpty()) {
                     // we need a separate payload to wake up player
                     replayApiService.pushPayload(sessionId, "${nextPayloadId()}", wakeUpEvents)

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/sdk/LDObserve.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/sdk/LDObserve.kt
@@ -194,7 +194,7 @@ class LDObserve(private val client: Observe) : Observe {
             obsContext.screenViewManager = service.screenViewManager
             obsContext.trackFlow = service.trackFlow
             obsContext.appLifecycleFlow = service.appLifecycleFlow
-            obsContext.appLaunchFlow = service.appLaunchFlow
+            obsContext.appLaunchSignal = service.appLaunchSignal
             context = obsContext
             init(service)
         }

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/sdk/LDObserve.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/sdk/LDObserve.kt
@@ -194,6 +194,7 @@ class LDObserve(private val client: Observe) : Observe {
             obsContext.screenViewManager = service.screenViewManager
             obsContext.trackFlow = service.trackFlow
             obsContext.appLifecycleFlow = service.appLifecycleFlow
+            obsContext.appLaunchFlow = service.appLaunchFlow
             context = obsContext
             init(service)
         }

--- a/sdk/@launchdarkly/observability-android/lib/src/test/kotlin/com/launchdarkly/observability/client/AppLaunchTrackerTest.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/test/kotlin/com/launchdarkly/observability/client/AppLaunchTrackerTest.kt
@@ -1,0 +1,30 @@
+package com.launchdarkly.observability.client
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class AppLaunchTrackerTest {
+    @Test
+    fun `no stored version is an install`() {
+        assertEquals(
+            AppLaunchSignal.LaunchType.INSTALL,
+            AppLaunchTracker.classify(storedVersion = null, currentVersion = "1.0.0")
+        )
+    }
+
+    @Test
+    fun `same version is a relaunch`() {
+        assertEquals(
+            AppLaunchSignal.LaunchType.RELAUNCH,
+            AppLaunchTracker.classify(storedVersion = "1.0.0", currentVersion = "1.0.0")
+        )
+    }
+
+    @Test
+    fun `changed version is an update`() {
+        assertEquals(
+            AppLaunchSignal.LaunchType.UPDATE,
+            AppLaunchTracker.classify(storedVersion = "1.0.0", currentVersion = "1.1.0")
+        )
+    }
+}

--- a/sdk/@launchdarkly/observability-android/lib/src/test/kotlin/com/launchdarkly/observability/client/AppLaunchTrackerTest.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/test/kotlin/com/launchdarkly/observability/client/AppLaunchTrackerTest.kt
@@ -27,4 +27,20 @@ class AppLaunchTrackerTest {
             AppLaunchTracker.classify(storedVersion = "1.0.0", currentVersion = "1.1.0")
         )
     }
+
+    @Test
+    fun `unreadable current version is unknown`() {
+        assertEquals(
+            AppLaunchSignal.LaunchType.UNKNOWN,
+            AppLaunchTracker.classify(storedVersion = null, currentVersion = null)
+        )
+    }
+
+    @Test
+    fun `unreadable current version is unknown even with a stored version`() {
+        assertEquals(
+            AppLaunchSignal.LaunchType.UNKNOWN,
+            AppLaunchTracker.classify(storedVersion = "1.0.0", currentVersion = null)
+        )
+    }
 }


### PR DESCRIPTION
## Summary
Propagates the mobile app-lifecycle analytics flags through the Flutter plugin down to the native iOS/Android SDKs. The native SDKs support `analytics.appLifecycle` and `analytics.appLaunch`, but the Flutter bridge never sent them, so native defaults always applied.

- `AnalyticsOptions` (Dart): adds `appLifecycle` and `appLaunch` (default `true`; both included in the `disabled` preset) and maps them in `toWire`.
- Pigeon: extends `LDAnalyticsOptions` with the two fields (appended at indices 3/4 to preserve positional wire compatibility) and regenerates the Dart/Kotlin/Swift sources.
- Native: iOS and Android `LDNativeApiImpl` now read both flags and pass them to `ObservabilityOptions.Analytics(...)`.
- Docs/tests: README option list + codec unit test (defaults + custom propagation).

`appLaunch` gates the new `app_launch` span + `Launch` Session Replay breadcrumb; `appLifecycle` gates the `app_foreground`/`app_background` spans. Both are mobile-only (no-op on web).

## Dependency note
The native bridge now calls `Analytics(appLifecycle:…, appLaunch:…)`, so building the example app requires native SDK versions that expose these fields:
- iOS — `swift-launchdarkly-observability` PR #221
- Android — `observability-sdk` PR #620

## Test plan
- [x] `dart run pigeon` regenerated cleanly (then `dart format`-ted to match committed style)
- [x] `flutter analyze lib test` — no issues
- [x] `flutter test test/native_options_codec_test.dart` — passes (defaults + custom)
- [ ] Example app builds against the released native SDKs and toggling the flags gates the spans

Made with [Cursor](https://cursor.com)