### PR TITLE
fix(highlight.run): make published TypeScript declarations resolvable

### DIFF
--- a/.changeset/fix-published-dts-types.md
+++ b/.changeset/fix-published-dts-types.md
@@ -1,5 +1,0 @@
----
-'highlight.run': patch
----
-
-Fix broken TypeScript declarations in the published package. The rolled-up `dist/index.d.ts` imported types from packages that are not runtime dependencies (`@opentelemetry/api`, `@highlight-run/rrweb-types`, `graphql-request`/`graphql`, `stacktrace-js`) and from an internal path alias (`client/types/observe`). Those specifiers are unresolvable in a consumer's `node_modules`, so importing the package failed type-checking whenever `skipLibCheck` was not enabled (TypeScript's default). Now `@opentelemetry/api` and `@highlight-run/rrweb-types` are inlined into the declaration bundle, `stacktrace-js` is a runtime dependency, the internal alias import is relative, and the internal GraphQL client (which dragged `graphql-request`/`graphql` into the public types) is kept off the public surface. This also fixes the re-exported types in `@launchdarkly/observability` and `@launchdarkly/session-replay`.

--- a/.changeset/fix-published-dts-types.md
+++ b/.changeset/fix-published-dts-types.md
@@ -1,0 +1,5 @@
+---
+'highlight.run': patch
+---
+
+Fix broken TypeScript declarations in the published package. The rolled-up `dist/index.d.ts` imported types from packages that are not runtime dependencies (`@opentelemetry/api`, `@highlight-run/rrweb-types`, `graphql-request`/`graphql`, `stacktrace-js`) and from an internal path alias (`client/types/observe`). Those specifiers are unresolvable in a consumer's `node_modules`, so importing the package failed type-checking whenever `skipLibCheck` was not enabled (TypeScript's default). Now `@opentelemetry/api` and `@highlight-run/rrweb-types` are inlined into the declaration bundle, `stacktrace-js` is a runtime dependency, the internal alias import is relative, and the internal GraphQL client (which dragged `graphql-request`/`graphql` into the public types) is kept off the public surface. This also fixes the re-exported types in `@launchdarkly/observability` and `@launchdarkly/session-replay`.

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -75,6 +75,13 @@ jobs:
                   NEXT_PUBLIC_HIGHLIGHT_PROJECT_ID: 1jdkoe52
                   REACT_APP_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
 
+            # Guard against shipping unresolvable types: install the freshly
+            # built package into a clean consumer and type-check it with
+            # skipLibCheck:false. Runs before publish so a broken .d.ts blocks
+            # the release. See scripts/check-published-types.mjs.
+            - name: Verify published types resolve in a clean consumer
+              run: node scripts/check-published-types.mjs
+
             - name: Configure yarn npm registry credentials
               if: github.ref == 'refs/heads/main'
               run: |

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
 	"scripts": {
 		"build": "yarn turbo run build --filter '!@highlight-run/rrweb-web-extension' --filter '!nextjs'",
 		"build:sdk": "yarn turbo run build --filter '@launchdarkly/*' --filter 'highlight.run'",
+		"check:published-types": "node scripts/check-published-types.mjs",
 		"docs": "yarn turbo run docs",
 		"e2e:cloudflare": "yarn turbo run dev --filter cloudflare-worker...",
 		"e2e:express": "yarn turbo run dev --filter express...",

--- a/scripts/check-published-types.mjs
+++ b/scripts/check-published-types.mjs
@@ -1,0 +1,199 @@
+#!/usr/bin/env node
+// Guard against shipping broken TypeScript declarations.
+//
+// Why this exists:
+//   `highlight.run` (and the thin `@launchdarkly/observability` /
+//   `@launchdarkly/session-replay` wrappers that re-export it) bundles its
+//   implementation into a single rolled-up `dist/index.d.ts`. If that
+//   declaration file `import`s a type from a package that is NOT a declared
+//   runtime dependency (e.g. a dev-only or workspace package), or from an
+//   internal path alias (e.g. `client/types/observe`), the import is
+//   unresolvable in a consumer's `node_modules`. Consumers whose tsconfig does
+//   not set `skipLibCheck: true` (the TypeScript default is `false`) then get
+//   type-check errors just by importing our package.
+//
+//   The in-repo `tsc` never catches this: inside the monorepo every dev
+//   dependency and path alias resolves. The only faithful test is to install
+//   the packed tarball into a clean project that has ONLY the declared runtime
+//   dependencies, then type-check an import of it.
+//
+// What this does:
+//   1. `npm pack` the freshly built package (uses its `files`/`dist`).
+//   2. Install the tarball into a temp project OUTSIDE the monorepo, so npm
+//      installs only the package's declared dependencies — exactly what a real
+//      consumer gets. No workspace/devDependency leakage.
+//   3. Type-check a tiny consumer that imports the public API, with
+//      `skipLibCheck: false`, under both `bundler` and classic `node` module
+//      resolution.
+//
+// Run after the build (the declaration file must already exist):
+//   node scripts/check-published-types.mjs
+
+import { execFileSync } from 'node:child_process'
+import {
+	mkdtempSync,
+	mkdirSync,
+	writeFileSync,
+	existsSync,
+	rmSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+
+// Pin the compiler so the check is deterministic across CI runs.
+const TYPESCRIPT_VERSION = '5.8.3'
+
+// Packages to verify. `highlight.run` holds the entire generated type surface;
+// the `@launchdarkly/*` wrappers below just re-export from it, so their own
+// declaration files are trivial. We test `highlight.run` because all of its
+// runtime dependencies are published to npm, so its tarball installs cleanly
+// in isolation. `imports` is what the consumer file imports from the package.
+const PACKAGES = [
+	{
+		dir: 'sdk/highlight-run',
+		name: 'highlight.run',
+		dts: 'dist/index.d.ts',
+		consumer: [
+			`import { Observe, LDObserve, LDRecord, H } from 'highlight.run'`,
+			`import type { ObserveOptions, RecordOptions } from 'highlight.run'`,
+			`const _opts: ObserveOptions = {}`,
+			`void [Observe, LDObserve, LDRecord, H, _opts]`,
+			`export type _RecordOptions = RecordOptions`,
+		].join('\n'),
+	},
+]
+
+// Resolution modes a consumer is likely to use:
+//   - `bundler`: the modern Vite / Next / esbuild default.
+//   - `node`:    classic Node (node10) resolution, still common.
+// Both surface a missing/unresolvable declaration import as TS2307.
+//
+// `node16`/`nodenext` are intentionally NOT exercised: `@launchdarkly/js-client-sdk`
+// (a real, required dependency) currently ships ESM declarations with
+// extensionless relative imports, which node16/nodenext reject (TS2834). That
+// noise originates in a dependency we do not control here and would mask the
+// signal this guard exists to catch.
+const RESOLUTION_MODES = {
+	bundler: { module: 'ESNext', moduleResolution: 'bundler' },
+	node: {
+		module: 'CommonJS',
+		moduleResolution: 'node',
+		esModuleInterop: true,
+	},
+}
+
+function run(cmd, args, opts = {}) {
+	return execFileSync(cmd, args, { encoding: 'utf8', stdio: 'pipe', ...opts })
+}
+
+let failed = false
+
+for (const pkg of PACKAGES) {
+	const pkgDir = join(repoRoot, pkg.dir)
+	const dtsPath = join(pkgDir, pkg.dts)
+	if (!existsSync(dtsPath)) {
+		console.error(
+			`✗ ${pkg.name}: declaration file not found at ${pkg.dts}. ` +
+				`Run the build first (it generates dist/**/*.d.ts).`,
+		)
+		failed = true
+		continue
+	}
+
+	// Temp project lives outside the repo so npm does not treat it as part of
+	// the yarn workspace (which would leak monorepo dependencies).
+	const work = mkdtempSync(join(tmpdir(), 'ld-types-check-'))
+	try {
+		const packOut = run('npm', [
+			'pack',
+			pkgDir,
+			'--pack-destination',
+			work,
+			'--json',
+		])
+		const tarball = join(work, JSON.parse(packOut)[0].filename)
+
+		writeFileSync(
+			join(work, 'package.json'),
+			JSON.stringify(
+				{ name: 'consumer', version: '0.0.0', private: true },
+				null,
+				2,
+			),
+		)
+		// `--ignore-scripts` keeps the check hermetic and fast; we only need the
+		// declared dependency tree on disk, not their build steps.
+		run(
+			'npm',
+			[
+				'install',
+				'--no-audit',
+				'--no-fund',
+				'--ignore-scripts',
+				tarball,
+				`typescript@${TYPESCRIPT_VERSION}`,
+			],
+			{
+				cwd: work,
+			},
+		)
+
+		const srcDir = join(work, 'src')
+		mkdirSync(srcDir)
+		writeFileSync(join(srcDir, 'index.ts'), pkg.consumer + '\n')
+
+		for (const [mode, modeOptions] of Object.entries(RESOLUTION_MODES)) {
+			writeFileSync(
+				join(work, 'tsconfig.json'),
+				JSON.stringify(
+					{
+						compilerOptions: {
+							target: 'ESNext',
+							strict: true,
+							noEmit: true,
+							// The whole point: do NOT skip checking library
+							// (node_modules) declaration files.
+							skipLibCheck: false,
+							lib: ['ESNext', 'DOM', 'DOM.Iterable'],
+							...modeOptions,
+						},
+						include: ['src'],
+					},
+					null,
+					2,
+				),
+			)
+			try {
+				run(
+					join(work, 'node_modules', '.bin', 'tsc'),
+					['--project', 'tsconfig.json'],
+					{
+						cwd: work,
+					},
+				)
+				console.log(
+					`✓ ${pkg.name}: type-checks cleanly (moduleResolution: ${mode})`,
+				)
+			} catch (err) {
+				failed = true
+				const out = `${err.stdout || ''}${err.stderr || ''}`.trim()
+				console.error(
+					`✗ ${pkg.name}: consumer type-check FAILED (moduleResolution: ${mode}).\n` +
+						`  A published .d.ts imports something that is not resolvable in a clean install.\n` +
+						out.replace(/^/gm, '  '),
+				)
+			}
+		}
+	} finally {
+		rmSync(work, { recursive: true, force: true })
+	}
+}
+
+if (failed) {
+	console.error('\nPublished-type check failed. See errors above.')
+	process.exit(1)
+}
+console.log('\nAll published types resolve in a clean consumer install.')

--- a/sdk/highlight-run/package.json
+++ b/sdk/highlight-run/package.json
@@ -82,7 +82,8 @@
 	],
 	"dependencies": {
 		"@launchdarkly/js-client-sdk": "^4.0.0",
-		"imurmurhash": "^0.1.4"
+		"imurmurhash": "^0.1.4",
+		"stacktrace-js": "2.0.2"
 	},
 	"devDependencies": {
 		"@graphql-codegen/cli": "^5.0.0",
@@ -127,7 +128,6 @@
 		"prettier": "^3.3.3",
 		"readdirp": "^3.6.0",
 		"size-limit": "^8.1.0",
-		"stacktrace-js": "2.0.2",
 		"tslib": "^2.6.2",
 		"typedoc": "^0.28.4",
 		"typescript": "^5.0.4",

--- a/sdk/highlight-run/src/__tests__/sdk.test.ts
+++ b/sdk/highlight-run/src/__tests__/sdk.test.ts
@@ -9,6 +9,36 @@ import { globalStorage } from '../client/utils/storage'
 import { Record } from '../plugins/record'
 import * as otel from '../client/otel'
 
+// `graphqlSDK` is an ECMAScript-private field on the SDK classes (so its
+// GraphQL types don't leak into the published declarations), which means tests
+// can no longer assign it directly. Stub the only seam — the generated
+// `getSdk` factory — so the classes never hit the network during unit tests.
+vi.mock('../client/graph/generated/operations', async (importOriginal) => {
+	const actual =
+		await importOriginal<
+			typeof import('../client/graph/generated/operations')
+		>()
+	return {
+		...actual,
+		getSdk: () => ({
+			initializeSession: vi.fn().mockResolvedValue({
+				initializeSession: {
+					secure_id: 'test-session',
+					project_id: '1',
+				},
+			}),
+			GetSamplingConfig: vi
+				.fn()
+				.mockResolvedValue({ sampling: undefined }),
+			PushSessionEvents: vi.fn().mockResolvedValue({}),
+			pushMetrics: vi.fn().mockResolvedValue({}),
+			identifySession: vi.fn().mockResolvedValue({}),
+			addSessionProperties: vi.fn().mockResolvedValue({}),
+			addSessionFeedback: vi.fn().mockResolvedValue({}),
+		}),
+	}
+})
+
 describe('SDK', () => {
 	let observe: typeof LDObserve
 	let record: typeof LDRecord
@@ -34,15 +64,7 @@ describe('SDK', () => {
 			sessionSecureID: 'test-session',
 		})
 
-		// Mock the graphqlSDK and initializeSession function
-		recordImpl.graphqlSDK = {
-			initializeSession: vi.fn().mockResolvedValue({
-				initializeSession: {
-					secure_id: 'test-session',
-					project_id: '1',
-				},
-			}),
-		} as any
+		// graphqlSDK is stubbed via the vi.mock of getSdk above.
 		observe.load(observeImpl)
 		record.load(recordImpl)
 	})

--- a/sdk/highlight-run/src/client/index.tsx
+++ b/sdk/highlight-run/src/client/index.tsx
@@ -128,7 +128,7 @@ import { CustomSampler } from './otel/sampling/CustomSampler'
 import randomUuidV4 from './utils/randomUuidV4'
 import { LDContext } from '@launchdarkly/js-client-sdk'
 import { MaskInputOptions } from './types/record'
-import { ProductAnalyticsEvents } from 'client/types/observe'
+import { ProductAnalyticsEvents } from './types/observe'
 
 export const HighlightWarning = (context: string, msg: any) => {
 	console.warn(`Highlight Warning: (${context}): `, { output: msg })
@@ -194,7 +194,10 @@ export class Highlight {
 	isRunningOnHighlight!: boolean
 	/** Verbose project ID that is exposed to users. Legacy users may still be using ints. */
 	organizationID!: string
-	graphqlSDK!: Sdk
+	// ECMAScript-private (#) so the internal GraphQL SDK type — which
+	// references graphql-request / graphql — does not leak into the published
+	// declaration file and break consumer type-checking.
+	#graphqlSDK!: Sdk
 	events!: eventWithTime[]
 	sessionData!: SessionData
 	ready!: boolean
@@ -431,7 +434,7 @@ export class Highlight {
 		const client = new GraphQLClient(`${this._backendUrl}`, {
 			headers: {},
 		})
-		this.graphqlSDK = getSdk(client, getGraphQLRequestWrapper())
+		this.#graphqlSDK = getSdk(client, getGraphQLRequestWrapper())
 		this.environment = options.environment ?? 'production'
 		this.appVersion = options.appVersion
 		this.serviceName = options.serviceName ?? ''
@@ -701,7 +704,7 @@ export class Highlight {
 				// wait for 'cross-origin iframe ready' message
 				await this._setupCrossOriginIframe()
 			} else {
-				const gr = await this.graphqlSDK.initializeSession({
+				const gr = await this.#graphqlSDK.initializeSession({
 					organization_verbose_id: this.organizationID,
 					enable_strict_privacy: this.privacySetting === 'strict',
 					privacy_setting: this.privacySetting,

--- a/sdk/highlight-run/src/client/otel/index.ts
+++ b/sdk/highlight-run/src/client/otel/index.ts
@@ -62,7 +62,7 @@ import version from '../../version'
 
 import { ExportSampler } from './sampling/ExportSampler'
 import { getPersistentSessionSecureID } from '../utils/sessionStorage/highlightSession'
-import { ProductAnalyticsEvents } from 'client/types/observe'
+import { ProductAnalyticsEvents } from '../types/observe'
 
 export type Callback = (span?: Span) => any
 

--- a/sdk/highlight-run/src/client/otel/user-interaction.ts
+++ b/sdk/highlight-run/src/client/otel/user-interaction.ts
@@ -13,7 +13,7 @@ import {
 import { SpanData } from '@opentelemetry/instrumentation-user-interaction/build/src/internal-types'
 import { getElementXPath } from '@opentelemetry/sdk-trace-web'
 import { AsyncTask } from '@opentelemetry/instrumentation-user-interaction/build/esnext/internal-types'
-import { ProductAnalyticsEvents } from 'client/types/observe'
+import { ProductAnalyticsEvents } from '../types/observe'
 import * as SemanticAttributes from '@opentelemetry/semantic-conventions'
 const ZONE_CONTEXT_KEY = 'OT_ZONE_CONTEXT'
 const EVENT_NAVIGATION_NAME = 'Navigation:'

--- a/sdk/highlight-run/src/sdk/observe.ts
+++ b/sdk/highlight-run/src/sdk/observe.ts
@@ -108,7 +108,10 @@ export class ObserveSDK implements Observe {
 	private readonly sampler: ExportSampler = new CustomSampler()
 	private _started = false
 	private _ldContextKeys: Attributes | undefined
-	private graphqlSDK!: Sdk
+	// ECMAScript-private (#) so the internal GraphQL SDK type — which
+	// references graphql-request / graphql — does not leak into the published
+	// declaration file and break consumer type-checking.
+	#graphqlSDK!: Sdk
 	constructor(
 		options: ObserveOptions & {
 			projectId: string
@@ -203,7 +206,7 @@ export class ObserveSDK implements Observe {
 				headers: {},
 			},
 		)
-		this.graphqlSDK = getSdk(client, getGraphQLRequestWrapper())
+		this.#graphqlSDK = getSdk(client, getGraphQLRequestWrapper())
 		await this.configureSampling()
 		this.setupListeners()
 	}
@@ -218,7 +221,7 @@ export class ObserveSDK implements Observe {
 
 	private async configureSampling() {
 		try {
-			const res = await this.graphqlSDK.GetSamplingConfig({
+			const res = await this.#graphqlSDK.GetSamplingConfig({
 				organization_verbose_id: `${this.organizationID}`,
 			})
 			this.sampler.setConfig(res.sampling)

--- a/sdk/highlight-run/src/sdk/record.ts
+++ b/sdk/highlight-run/src/sdk/record.ts
@@ -109,7 +109,10 @@ export class RecordSDK implements Record {
 	isRunningOnHighlight!: boolean
 	/** Verbose project ID that is exposed to users. Legacy users may still be using ints. */
 	organizationID!: string
-	graphqlSDK!: Sdk
+	// ECMAScript-private (#) so the internal GraphQL SDK type — which
+	// references graphql-request / graphql — does not leak into the published
+	// declaration file and break consumer type-checking.
+	#graphqlSDK!: Sdk
 	events!: eventWithTime[]
 	sessionData!: SessionData
 	ready!: boolean
@@ -317,7 +320,7 @@ export class RecordSDK implements Record {
 		const client = new GraphQLClient(`${this._backendUrl}`, {
 			headers: {},
 		})
-		this.graphqlSDK = getSdk(client, getGraphQLRequestWrapper())
+		this.#graphqlSDK = getSdk(client, getGraphQLRequestWrapper())
 		this.environment = options.environment ?? 'production'
 		this.appVersion = options.appVersion
 		this.serviceName = options.serviceName ?? 'browser'
@@ -487,7 +490,7 @@ export class RecordSDK implements Record {
 				// wait for 'cross-origin iframe ready' message
 				await this._setupCrossOriginIframe()
 			} else {
-				const gr = await this.graphqlSDK.initializeSession({
+				const gr = await this.#graphqlSDK.initializeSession({
 					organization_verbose_id: this.organizationID,
 					enable_strict_privacy: this.privacySetting === 'strict',
 					privacy_setting: this.privacySetting,

--- a/sdk/highlight-run/vite.config.ts
+++ b/sdk/highlight-run/vite.config.ts
@@ -20,6 +20,28 @@ export default defineConfig({
 			declarationOnly: process.env.FORMAT === 'd.ts',
 			rollupTypes: true,
 			strictOutput: true,
+			// Inline the types of these dependencies into the rolled-up
+			// declaration file. They are bundled into the JS output (or are
+			// workspace packages) and are NOT declared as runtime dependencies,
+			// so without bundling, their `.d.ts` imports leak into the published
+			// types as unresolvable bare specifiers and break consumer
+			// type-checking when `skipLibCheck` is off (TypeScript's default).
+			//
+			// Intentionally NOT bundled:
+			//   - `@launchdarkly/js-client-sdk`: a real runtime dependency, so
+			//     its types resolve via the consumer's node_modules.
+			//   - `stacktrace-js`: api-extractor cannot follow its `StackFrame`
+			//     symbol ("Unable to follow symbol"), so it is declared as a
+			//     runtime dependency instead (see package.json).
+			//   - `graphql-request` / `graphql`: not bundled because their own
+			//     declarations are not self-contained (they pull in `graphql`,
+			//     `cross-fetch`, ...). Instead these types are kept out of the
+			//     public surface entirely — the internal `graphqlSDK` fields
+			//     that referenced them are now ECMAScript-private (`#`).
+			bundledPackages: [
+				'@opentelemetry/api',
+				'@highlight-run/rrweb-types',
+			],
 		}),
 	],
 	build: {


### PR DESCRIPTION
## Problem

Importing `@launchdarkly/observability` (or `@launchdarkly/session-replay`, or `highlight.run` directly) breaks consumer type-checking whenever `skipLibCheck` is not set to `true` — and `false` is TypeScript's default. A customer hit this.

Root cause is in `highlight.run`'s published `dist/index.d.ts` (the `@launchdarkly/*` packages are thin re-export wrappers over it). The rolled-up declaration file `import`s types from specifiers that don't exist in a consumer's `node_modules`:

| Specifier in published `.d.ts` | Why it's unresolvable |
|---|---|
| `@opentelemetry/api` | dev-only dep, not declared as runtime dep |
| `@highlight-run/rrweb-types` | workspace dep, not published as a matching runtime dep |
| `graphql-request` + `graphql-request/build/cjs/types` | dev-only dep; the deep subpath isn't in its `exports` map either |
| `stacktrace-js` | dev-only dep |
| `client/types/observe` | **internal `baseUrl` path alias that leaked into the published types — not a package at all** |

In-repo `tsc` never catches this because inside the monorepo every devDependency and the `baseUrl` alias resolve. The only faithful test is a clean consumer install (see the new CI guard).

## Fix

- **Inline `@opentelemetry/api` and `@highlight-run/rrweb-types`** into the declaration via `vite-plugin-dts` `bundledPackages`.
- **Declare `stacktrace-js` a runtime dependency.** api-extractor can't follow its `export =` namespace `StackFrame` symbol, so it can't be bundled; making it a real dep means the existing `import { StackFrame } from 'stacktrace-js'` resolves (same mechanism that already makes `@launchdarkly/js-client-sdk` work).
- **Make the three `client/types/observe` imports relative**, so the `baseUrl` alias stops leaking.
- **Keep the internal GraphQL client off the public surface.** The `graphqlSDK` fields on the SDK classes are now ECMAScript-private (`#graphqlSDK`). They were the only thing dragging `graphql-request` (and transitively `graphql`, `cross-fetch`, `@graphql-typed-document-node/core`) into the public types. Bundling `graphql-request` instead just relocates the leak — its own declarations aren't self-contained, and the deep `build/cjs/types` import isn't resolvable under `bundler`/`node16` regardless. Making the field `#`-private removes the whole chain. The sdk unit test now stubs the generated `getSdk` factory instead of assigning the (now private) field.

## CI guard

`scripts/check-published-types.mjs` (new step in `turbo.yml`, before publish) packs the freshly built package, installs it into a clean consumer **outside** the monorepo (so only declared runtime deps are present), and type-checks an import with `skipLibCheck: false` under both `bundler` and classic `node` resolution. It fails the build if any declaration import is unresolvable. This is what caught a first iteration of this PR where bundling `graphql-request` had relocated the leak — the guard is doing its job. Run locally with `yarn check:published-types` after a build.

(`node16`/`nodenext` are intentionally not exercised: `@launchdarkly/js-client-sdk` currently ships ESM declarations with extensionless relative imports that those modes reject (TS2834) — unrelated noise from a dep we don't control here.)

## Notes

- The customer mentioned `observability-node`, but that package is independent (it does **not** depend on `highlight.run`) and is unaffected. The broken package is the browser SDK `@launchdarkly/observability`.
- The changeset bumps `highlight.run` (patch); the `workspace:*` wrappers `@launchdarkly/observability` and `@launchdarkly/session-replay` need to republish against the fixed `highlight.run` for consumers to pick up the corrected types — please confirm the release pipeline cascades those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches published SDK types and adds a runtime dependency (`stacktrace-js`); runtime behavior is largely unchanged but a bad release would break downstream TypeScript until republished.
> 
> **Overview**
> Fixes consumer TypeScript failures when importing `highlight.run` / `@launchdarkly/*` browser SDKs with default `skipLibCheck: false`. The rolled-up `dist/index.d.ts` was importing types from dev-only deps, workspace packages, internal path aliases, and public `graphqlSDK` fields that dragged in `graphql-request`.
> 
> **Declaration surface:** `vite-plugin-dts` now **bundles** `@opentelemetry/api` and `@highlight-run/rrweb-types` into the published types. **`stacktrace-js`** moves from devDependency to **runtime dependency** so its types resolve in clean installs. **`client/types/observe`** imports are switched to **relative** paths so `baseUrl` aliases do not leak. Internal GraphQL clients on `Highlight`, `ObserveSDK`, and `RecordSDK` use **`#graphqlSDK`** so GraphQL types stay off the public API.
> 
> **CI:** New **`scripts/check-published-types.mjs`** packs the built package, installs it in a temp consumer outside the monorepo, and runs `tsc` with `skipLibCheck: false` under `bundler` and `node` resolution—wired into **`turbo.yml`** before publish and as **`yarn check:published-types`**.
> 
> **Tests:** SDK unit tests mock **`getSdk`** instead of assigning the now-private `graphqlSDK` field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d35558106b02e4076ad28915b87f79e9b65f679f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->