### PR TITLE
feat(observability-next): add LaunchDarkly Next.js SDK

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,6 +1,7 @@
 {
 	"go": "1.1.1",
 	"sdk/@launchdarkly/observability": "1.1.15",
+	"sdk/@launchdarkly/observability-next": "0.1.0",
 	"sdk/@launchdarkly/observability-android": "0.57.0",
 	"sdk/@launchdarkly/flutter/packages/observability": "0.10.0",
 	"sdk/@launchdarkly/observability-dotnet": "1.2.0",

--- a/e2e/nextjs-ld/.eslintrc.json
+++ b/e2e/nextjs-ld/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+	"extends": "next/core-web-vitals"
+}

--- a/e2e/nextjs-ld/.gitignore
+++ b/e2e/nextjs-ld/.gitignore
@@ -1,0 +1,3 @@
+/.next/
+/node_modules
+next-env.d.ts

--- a/e2e/nextjs-ld/README.md
+++ b/e2e/nextjs-ld/README.md
@@ -1,0 +1,24 @@
+# nextjs-ld
+
+Example Next.js (App Router) app instrumented with
+[`@launchdarkly/observability-next`](../../sdk/@launchdarkly/observability-next).
+
+It runs the LaunchDarkly observability and session replay plugins in
+**standalone mode** — initialized directly from a LaunchDarkly SDK key, with no
+feature-flag client.
+
+## What it demonstrates
+
+- `src/app/layout.tsx` — `LDObservabilityInit` + `ErrorBoundary` (client)
+- `src/instrumentation.ts` — `registerObservability` (server)
+- `src/app/api/test/route.ts` — `AppRouterObservability` route wrapper
+- `src/app/error.tsx` — `appRouterSsrErrorHandler`
+- `middleware.ts` — `observabilityMiddleware`
+- `next.config.mjs` — `withLaunchDarklyConfig`
+
+## Run
+
+```bash
+# Set NEXT_PUBLIC_LAUNCHDARKLY_CLIENT_SIDE_ID and LAUNCHDARKLY_SDK_KEY in .env
+yarn workspace nextjs-ld dev
+```

--- a/e2e/nextjs-ld/middleware.ts
+++ b/e2e/nextjs-ld/middleware.ts
@@ -1,7 +1,7 @@
 import { observabilityMiddleware } from '@launchdarkly/observability-next/server'
-import { NextResponse } from 'next/server'
 
 export async function middleware(request: Request) {
-	await observabilityMiddleware(request)
-	return NextResponse.next()
+	// Return the response so the forwarded x-highlight-request header reaches
+	// downstream route handlers.
+	return observabilityMiddleware(request)
 }

--- a/e2e/nextjs-ld/middleware.ts
+++ b/e2e/nextjs-ld/middleware.ts
@@ -1,0 +1,7 @@
+import { observabilityMiddleware } from '@launchdarkly/observability-next/server'
+import { NextResponse } from 'next/server'
+
+export async function middleware(request: Request) {
+	await observabilityMiddleware(request)
+	return NextResponse.next()
+}

--- a/e2e/nextjs-ld/next.config.mjs
+++ b/e2e/nextjs-ld/next.config.mjs
@@ -1,0 +1,7 @@
+// next.config.mjs
+import { withLaunchDarklyConfig } from '@launchdarkly/observability-next/config'
+
+/** @type {import('next').NextConfig} */
+const nextConfig = {}
+
+export default withLaunchDarklyConfig(nextConfig)

--- a/e2e/nextjs-ld/package.json
+++ b/e2e/nextjs-ld/package.json
@@ -1,0 +1,24 @@
+{
+	"name": "nextjs-ld",
+	"version": "0.1.0",
+	"private": true,
+	"scripts": {
+		"dev": "next dev -p 3006",
+		"build": "next build",
+		"start": "next start -p 3006",
+		"lint": "next lint",
+		"typecheck": "tsc --noEmit"
+	},
+	"dependencies": {
+		"@launchdarkly/observability-next": "workspace:*",
+		"next": "^15.5.10",
+		"react": "^19.0.0",
+		"react-dom": "^19.0.0"
+	},
+	"devDependencies": {
+		"@types/node": "^22.13.5",
+		"@types/react": "^19.0.10",
+		"@types/react-dom": "^19.0.4",
+		"typescript": "^5.7.2"
+	}
+}

--- a/e2e/nextjs-ld/src/app/api/test/route.ts
+++ b/e2e/nextjs-ld/src/app/api/test/route.ts
@@ -1,0 +1,22 @@
+import { AppRouterObservability } from '@launchdarkly/observability-next/server'
+
+import { CONSTANTS } from '@/constants'
+
+const withObservability = AppRouterObservability({
+	sdkKey: CONSTANTS.LAUNCHDARKLY_SDK_KEY,
+	serviceName: 'nextjs-ld-backend',
+	environment: 'e2e-test',
+})
+
+export const GET = withObservability(async function GET(request: Request) {
+	const { searchParams } = new URL(request.url)
+	const success = searchParams.get('success') === 'true'
+
+	if (!success) {
+		throw new Error('Error: /api/test (App Router)')
+	}
+
+	return Response.json({ message: 'Success: /api/test' })
+})
+
+export const runtime = 'nodejs'

--- a/e2e/nextjs-ld/src/app/error.tsx
+++ b/e2e/nextjs-ld/src/app/error.tsx
@@ -1,0 +1,19 @@
+'use client' // Error components must be Client Components
+
+import {
+	AppRouterErrorProps,
+	appRouterSsrErrorHandler,
+} from '@launchdarkly/observability-next/ssr'
+
+export default appRouterSsrErrorHandler(
+	({ error, reset }: AppRouterErrorProps) => {
+		console.error(error)
+
+		return (
+			<div>
+				<h2>Something went wrong!</h2>
+				<button onClick={() => reset()}>Try again</button>
+			</div>
+		)
+	},
+)

--- a/e2e/nextjs-ld/src/app/layout.tsx
+++ b/e2e/nextjs-ld/src/app/layout.tsx
@@ -1,0 +1,32 @@
+import {
+	ErrorBoundary,
+	LDObservabilityInit,
+} from '@launchdarkly/observability-next/client'
+
+import { CONSTANTS } from '@/constants'
+
+export const metadata = {
+	title: 'LaunchDarkly Observability Next Demo',
+	description: 'Demonstrates @launchdarkly/observability-next',
+}
+
+export default function RootLayout({
+	children,
+}: {
+	children: React.ReactNode
+}) {
+	return (
+		<ErrorBoundary>
+			<LDObservabilityInit
+				sdkKey={CONSTANTS.LAUNCHDARKLY_CLIENT_SIDE_ID}
+				serviceName="nextjs-ld-frontend"
+				environment="e2e-test"
+				tracingOrigins
+				networkRecording={{ enabled: true, recordHeadersAndBody: true }}
+			/>
+			<html lang="en">
+				<body>{children}</body>
+			</html>
+		</ErrorBoundary>
+	)
+}

--- a/e2e/nextjs-ld/src/app/page.tsx
+++ b/e2e/nextjs-ld/src/app/page.tsx
@@ -1,0 +1,24 @@
+'use client'
+
+import { LDObserve } from '@launchdarkly/observability-next/client'
+
+export default function Home() {
+	return (
+		<main style={{ padding: 24, fontFamily: 'sans-serif' }}>
+			<h1>LaunchDarkly Observability + Next.js</h1>
+			<p>
+				This app is instrumented with{' '}
+				<code>@launchdarkly/observability-next</code> running in
+				standalone mode (no feature-flag client).
+			</p>
+			<button
+				onClick={() => LDObserve.recordError(new Error('manual error'))}
+			>
+				Record an error
+			</button>{' '}
+			<button onClick={() => fetch('/api/test?success=true')}>
+				Call traced API
+			</button>
+		</main>
+	)
+}

--- a/e2e/nextjs-ld/src/constants.ts
+++ b/e2e/nextjs-ld/src/constants.ts
@@ -1,0 +1,6 @@
+// Centralize env access so Next inlines the NEXT_PUBLIC_* values.
+export const CONSTANTS = {
+	LAUNCHDARKLY_CLIENT_SIDE_ID:
+		process.env.NEXT_PUBLIC_LAUNCHDARKLY_CLIENT_SIDE_ID ?? '',
+	LAUNCHDARKLY_SDK_KEY: process.env.LAUNCHDARKLY_SDK_KEY ?? '',
+}

--- a/e2e/nextjs-ld/src/instrumentation.ts
+++ b/e2e/nextjs-ld/src/instrumentation.ts
@@ -1,0 +1,11 @@
+import { CONSTANTS } from '@/constants'
+
+export async function register() {
+	const { registerObservability } =
+		await import('@launchdarkly/observability-next/server')
+	await registerObservability({
+		sdkKey: CONSTANTS.LAUNCHDARKLY_SDK_KEY,
+		serviceName: 'nextjs-ld-backend',
+		environment: 'e2e-test',
+	})
+}

--- a/e2e/nextjs-ld/tsconfig.json
+++ b/e2e/nextjs-ld/tsconfig.json
@@ -1,0 +1,28 @@
+{
+	"compilerOptions": {
+		"target": "es5",
+		"lib": ["dom", "dom.iterable", "esnext"],
+		"allowJs": true,
+		"skipLibCheck": true,
+		"strict": true,
+		"forceConsistentCasingInFileNames": true,
+		"noEmit": true,
+		"esModuleInterop": true,
+		"module": "esnext",
+		"moduleResolution": "bundler",
+		"resolveJsonModule": true,
+		"isolatedModules": true,
+		"jsx": "preserve",
+		"incremental": false,
+		"plugins": [{ "name": "next" }],
+		"paths": { "@/*": ["./src/*"] }
+	},
+	"include": [
+		"next-env.d.ts",
+		"**/*.ts",
+		"**/*.tsx",
+		".next/types/**/*.ts",
+		"next.config.mjs"
+	],
+	"exclude": ["node_modules"]
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -57,6 +57,13 @@
 			"include-v-in-tag": false,
 			"include-component-in-tag": true
 		},
+		"sdk/@launchdarkly/observability-next": {
+			"package-name": "@launchdarkly/observability-next",
+			"release-type": "node",
+			"versioning": "default",
+			"include-v-in-tag": false,
+			"include-component-in-tag": true
+		},
 		"sdk/@launchdarkly/session-replay": {
 			"package-name": "@launchdarkly/session-replay",
 			"release-type": "node",

--- a/sdk/@launchdarkly/observability-next/README.md
+++ b/sdk/@launchdarkly/observability-next/README.md
@@ -95,11 +95,11 @@ export default PageRouterObservability({ sdkKey: process.env.LAUNCHDARKLY_SDK_KE
 
 ```ts
 import { observabilityMiddleware } from '@launchdarkly/observability-next/server'
-import { NextResponse } from 'next/server'
 
 export async function middleware(request: Request) {
-	await observabilityMiddleware(request)
-	return NextResponse.next()
+	// Return the response so the forwarded x-highlight-request header reaches
+	// downstream route handlers.
+	return observabilityMiddleware(request)
 }
 ```
 

--- a/sdk/@launchdarkly/observability-next/README.md
+++ b/sdk/@launchdarkly/observability-next/README.md
@@ -1,0 +1,152 @@
+# LaunchDarkly Observability SDK for Next.js
+
+[![NPM][o11y-next-npm-badge]][o11y-next-npm-link]
+
+**NB: APIs are subject to change until a 1.x version is released.**
+
+LaunchDarkly observability and session replay for Next.js apps — frontend and
+backend errors, logs, traces, metrics, and session replays.
+
+## Standalone mode
+
+There is no LaunchDarkly feature-flag SDK for Next.js, so this package runs the
+LaunchDarkly observability and session replay plugins in **standalone mode**:
+they are initialized directly from your LaunchDarkly SDK key (client-side ID)
+rather than being registered with a LaunchDarkly client. No feature-flag SDK is
+required.
+
+## Install
+
+```shell
+# npm
+npm i @launchdarkly/observability-next
+
+# yarn
+yarn add @launchdarkly/observability-next
+```
+
+## Usage
+
+### 1. Client (App Router) — `app/layout.tsx`
+
+```tsx
+import { LDObservabilityInit, ErrorBoundary } from '@launchdarkly/observability-next/client'
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+	return (
+		<ErrorBoundary>
+			<LDObservabilityInit
+				sdkKey={process.env.NEXT_PUBLIC_LAUNCHDARKLY_SDK_KEY}
+				serviceName="my-nextjs-frontend"
+				environment="production"
+				tracingOrigins
+				networkRecording={{ enabled: true, recordHeadersAndBody: true }}
+			/>
+			<html lang="en">
+				<body>{children}</body>
+			</html>
+		</ErrorBoundary>
+	)
+}
+```
+
+For the Pages Router, render `<LDObservabilityInit />` in `pages/_app.tsx`.
+
+### 2. Server instrumentation — `instrumentation.ts`
+
+```ts
+export async function register() {
+	const { registerObservability } = await import('@launchdarkly/observability-next/server')
+	await registerObservability({
+		sdkKey: process.env.LAUNCHDARKLY_SDK_KEY!,
+		serviceName: 'my-nextjs-backend',
+		environment: 'production',
+	})
+}
+```
+
+### 3. Wrap route handlers
+
+App Router:
+
+```ts
+import { AppRouterObservability } from '@launchdarkly/observability-next/server'
+
+const withObservability = AppRouterObservability({ sdkKey: process.env.LAUNCHDARKLY_SDK_KEY! })
+
+export const GET = withObservability(async (request) => {
+	return Response.json({ ok: true })
+})
+```
+
+Pages Router:
+
+```ts
+import { PageRouterObservability } from '@launchdarkly/observability-next/server'
+
+export default PageRouterObservability({ sdkKey: process.env.LAUNCHDARKLY_SDK_KEY! })(
+	async (req, res) => {
+		res.status(200).send('ok')
+	},
+)
+```
+
+### 4. Link backend traces to sessions — `middleware.ts`
+
+```ts
+import { observabilityMiddleware } from '@launchdarkly/observability-next/server'
+import { NextResponse } from 'next/server'
+
+export async function middleware(request: Request) {
+	await observabilityMiddleware(request)
+	return NextResponse.next()
+}
+```
+
+### 5. (Optional) Proxy + config — `next.config.mjs`
+
+```js
+import { withLaunchDarklyConfig } from '@launchdarkly/observability-next/config'
+
+/** @type {import('next').NextConfig} */
+const nextConfig = {}
+
+export default withLaunchDarklyConfig(nextConfig)
+```
+
+This sets up same-origin rewrites that proxy browser telemetry through your
+domain to LaunchDarkly (enabled by default). Disable with
+`{ configureLaunchDarklyProxy: false }`.
+
+### 6. (Optional) SSR error pages
+
+```tsx
+// App Router: app/error.tsx
+'use client'
+import { appRouterSsrErrorHandler } from '@launchdarkly/observability-next/ssr'
+
+export default appRouterSsrErrorHandler(({ error, reset }) => (
+	<button onClick={reset}>Try again</button>
+))
+```
+
+```tsx
+// Pages Router: pages/_error.tsx
+import { pageRouterCustomErrorHandler } from '@launchdarkly/observability-next/ssr'
+
+export default pageRouterCustomErrorHandler({
+	sdkKey: process.env.NEXT_PUBLIC_LAUNCHDARKLY_SDK_KEY,
+})
+```
+
+## Manual recording
+
+Use `LDObserve` / `LDRecord` directly:
+
+```ts
+import { LDObserve } from '@launchdarkly/observability-next/server' // or /client
+LDObserve.recordError(new Error('boom'))
+```
+
+[o11y-next-npm-badge]: https://img.shields.io/npm/v/@launchdarkly/observability-next.svg?style=flat-square
+[o11y-next-npm-link]: https://www.npmjs.com/package/@launchdarkly/observability-next

--- a/sdk/@launchdarkly/observability-next/bin/clean-dist.sh
+++ b/sdk/@launchdarkly/observability-next/bin/clean-dist.sh
@@ -1,0 +1,5 @@
+sed -i '/"use client";/d;' dist/next-client.js || sed -i '' '/"use client";/d;' dist/next-client.js
+sed -i '/"use client";/d;' dist/next-client.cjs || sed -i '' '/"use client";/d;' dist/next-client.cjs
+
+printf '%s \n%s' '"use client";' "$(cat dist/next-client.js)" > dist/next-client.js
+printf '%s \n%s' '"use client";' "$(cat dist/next-client.cjs)" > dist/next-client.cjs

--- a/sdk/@launchdarkly/observability-next/client.d.ts
+++ b/sdk/@launchdarkly/observability-next/client.d.ts
@@ -1,0 +1,1 @@
+export * from './dist/next-client'

--- a/sdk/@launchdarkly/observability-next/config.d.ts
+++ b/sdk/@launchdarkly/observability-next/config.d.ts
@@ -1,0 +1,1 @@
+export * from './dist/config'

--- a/sdk/@launchdarkly/observability-next/package.json
+++ b/sdk/@launchdarkly/observability-next/package.json
@@ -1,0 +1,95 @@
+{
+	"name": "@launchdarkly/observability-next",
+	"version": "0.1.0",
+	"description": "LaunchDarkly observability and session replay for Next.js. Capture frontend and backend errors, logs, traces, and session replays.",
+	"keywords": [
+		"launchdarkly",
+		"error monitoring",
+		"logging",
+		"tracing",
+		"metrics",
+		"debugging",
+		"observability",
+		"session replay",
+		"nextjs",
+		"next",
+		"library"
+	],
+	"homepage": "https://github.com/launchdarkly/observability-sdk/tree/main/sdk/@launchdarkly/observability-next#readme",
+	"bugs": {
+		"url": "https://github.com/launchdarkly/observability-sdk/issues",
+		"email": "support@launchdarkly.com"
+	},
+	"license": "Apache-2.0",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/launchdarkly/observability-sdk.git"
+	},
+	"files": [
+		"dist",
+		"client.d.ts",
+		"config.d.ts",
+		"server.d.ts",
+		"ssr.d.ts"
+	],
+	"exports": {
+		"./server": {
+			"types": "./dist/server.d.ts",
+			"edge": "./dist/server.edge.js",
+			"edge-light": "./dist/server.edge.js",
+			"worker": "./dist/server.edge.js",
+			"workerd": "./dist/server.edge.js",
+			"require": "./dist/server.cjs",
+			"import": "./dist/server.js"
+		},
+		"./client": {
+			"types": "./dist/next-client.d.ts",
+			"import": "./dist/next-client.js",
+			"require": "./dist/next-client.cjs"
+		},
+		"./config": {
+			"types": "./dist/config.d.ts",
+			"import": "./dist/config.js",
+			"require": "./dist/config.cjs"
+		},
+		"./ssr": {
+			"types": "./dist/ssr.d.ts",
+			"import": "./dist/ssr.js",
+			"require": "./dist/ssr.cjs"
+		}
+	},
+	"type": "module",
+	"publishConfig": {
+		"access": "public"
+	},
+	"scripts": {
+		"typegen": "tsc -d --emitDeclarationOnly",
+		"dev": "yarn build --watch",
+		"build": "rollup --config rollup.config.js && sh bin/clean-dist.sh"
+	},
+	"author": "",
+	"peerDependencies": {
+		"next": ">=14",
+		"react": ">=17"
+	},
+	"dependencies": {
+		"@launchdarkly/observability": "workspace:*",
+		"@launchdarkly/observability-node": "workspace:*",
+		"@launchdarkly/session-replay": "workspace:*",
+		"js-cookie": "^3.0.5"
+	},
+	"devDependencies": {
+		"@opentelemetry/api": "^1.9.0",
+		"@opentelemetry/semantic-conventions": "^1.34.0",
+		"@rollup/plugin-json": "^6.1.0",
+		"@rollup/plugin-terser": "^0.4.4",
+		"@rollup/plugin-typescript": "^11.1.5",
+		"@types/js-cookie": "^3",
+		"@types/node": "^20.14.7",
+		"@types/react": "^19.0.10",
+		"next": ">=14",
+		"react": "^19.0.0",
+		"rollup": "^4.4.1",
+		"typescript": "^5.0.4"
+	}
+}

--- a/sdk/@launchdarkly/observability-next/rollup.config.js
+++ b/sdk/@launchdarkly/observability-next/rollup.config.js
@@ -1,0 +1,47 @@
+import json from '@rollup/plugin-json'
+import terser from '@rollup/plugin-terser'
+import typescript from '@rollup/plugin-typescript'
+
+/** @type {import('rollup').RollupOptions} */
+const config = {
+	input: [
+		'src/next-client.tsx',
+		'src/config.ts',
+		'src/server.ts',
+		'src/server.edge.ts',
+		'src/ssr.tsx',
+	],
+	external: [
+		'@launchdarkly/observability',
+		'@launchdarkly/observability-node',
+		'@launchdarkly/session-replay',
+		'@opentelemetry/api',
+		'@opentelemetry/semantic-conventions',
+		'js-cookie',
+		'next',
+		'next/error.js',
+		'next/headers',
+		'react',
+		'react/jsx-runtime',
+	],
+	plugins: [json(), typescript(), terser()],
+	output: [
+		{
+			dir: 'dist',
+			format: 'cjs',
+			sourcemap: true,
+			entryFileNames: '[name].cjs',
+			exports: 'auto',
+		},
+		{
+			dir: 'dist',
+			format: 'es',
+			sourcemap: true,
+			entryFileNames: '[name].js',
+			exports: 'auto',
+		},
+	],
+	treeshake: 'smallest',
+}
+
+export default config

--- a/sdk/@launchdarkly/observability-next/server.d.ts
+++ b/sdk/@launchdarkly/observability-next/server.d.ts
@@ -1,0 +1,1 @@
+export * from './dist/server'

--- a/sdk/@launchdarkly/observability-next/src/config.ts
+++ b/sdk/@launchdarkly/observability-next/src/config.ts
@@ -1,0 +1,4 @@
+export {
+	withLaunchDarklyConfig,
+	type LaunchDarklyConfigOptions,
+} from './util/with-launchdarkly-config'

--- a/sdk/@launchdarkly/observability-next/src/error-boundary.tsx
+++ b/sdk/@launchdarkly/observability-next/src/error-boundary.tsx
@@ -1,0 +1,50 @@
+import { LDObserve } from '@launchdarkly/observability'
+import * as React from 'react'
+
+export interface ErrorBoundaryProps {
+	children?: React.ReactNode
+	/**
+	 * Rendered when a descendant throws. Either a node or a render function that
+	 * receives the captured error.
+	 */
+	fallback?: React.ReactNode | ((error: Error) => React.ReactNode)
+}
+
+export interface ErrorBoundaryState {
+	error: Error | null
+}
+
+/**
+ * A React error boundary that reports caught errors to LaunchDarkly via
+ * {@link LDObserve}. Unlike the Highlight error boundary, it does not depend on
+ * a global `window.H`; it talks to the standalone-initialized observability
+ * plugin directly.
+ */
+export class ErrorBoundary extends React.Component<
+	ErrorBoundaryProps,
+	ErrorBoundaryState
+> {
+	state: ErrorBoundaryState = { error: null }
+
+	static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+		return { error }
+	}
+
+	componentDidCatch(error: Error, info: React.ErrorInfo) {
+		LDObserve.recordError(error, error.message, {
+			'react.componentStack': info.componentStack ?? '',
+		})
+	}
+
+	render() {
+		const { error } = this.state
+		if (error) {
+			const { fallback } = this.props
+			if (typeof fallback === 'function') {
+				return <>{fallback(error)}</>
+			}
+			return <>{fallback ?? null}</>
+		}
+		return <>{this.props.children}</>
+	}
+}

--- a/sdk/@launchdarkly/observability-next/src/next-client.tsx
+++ b/sdk/@launchdarkly/observability-next/src/next-client.tsx
@@ -96,10 +96,29 @@ export function LDObservabilityInit({
 			application,
 		)
 
-		const session = LDRecord.getSession()
-		if (session?.sessionSecureID) {
-			Cookies.set('sessionSecureID', session.sessionSecureID)
+		// The session secure id only becomes available once the session replay
+		// SDK has finished loading, so LDRecord.getSession() returns null right
+		// after init. Poll briefly until it resolves, then persist it for
+		// observabilityMiddleware to forward as x-highlight-request. If replay
+		// never loads, there is no session to link and the cookie is left unset.
+		const persistSessionCookie = () => {
+			const sessionSecureID = LDRecord.getSession()?.sessionSecureID
+			if (sessionSecureID) {
+				Cookies.set('sessionSecureID', sessionSecureID)
+				return true
+			}
+			return false
 		}
+		if (persistSessionCookie()) {
+			return
+		}
+		let attempts = 0
+		const interval = setInterval(() => {
+			if (persistSessionCookie() || ++attempts >= 50) {
+				clearInterval(interval)
+			}
+		}, 100)
+		return () => clearInterval(interval)
 	}, []) // eslint-disable-line react-hooks/exhaustive-deps
 
 	return null

--- a/sdk/@launchdarkly/observability-next/src/next-client.tsx
+++ b/sdk/@launchdarkly/observability-next/src/next-client.tsx
@@ -1,0 +1,106 @@
+import Observability, {
+	LDObserve,
+	type ObserveOptions,
+} from '@launchdarkly/observability'
+import SessionReplay, {
+	LDRecord,
+	type RecordOptions,
+} from '@launchdarkly/session-replay'
+import Cookies from 'js-cookie'
+import { useEffect } from 'react'
+
+import { PROXY_BACKEND_PATH, PROXY_ENV_FLAG } from './util/proxy'
+import { ensureStandaloneInit, type LDApplicationInfo } from './util/standalone'
+
+export { ErrorBoundary } from './error-boundary'
+export type { ErrorBoundaryProps, ErrorBoundaryState } from './error-boundary'
+export { LDObserve, LDRecord }
+
+/**
+ * Options for {@link LDObservabilityInit}. Combines the browser observability and
+ * session replay options, plus the LaunchDarkly SDK key used to initialize them
+ * in standalone mode.
+ */
+export type LDObservabilityInitProps = ObserveOptions &
+	RecordOptions & {
+		/**
+		 * The LaunchDarkly client-side ID (SDK key) for the environment to send
+		 * telemetry to. Required for the SDK to initialize.
+		 */
+		sdkKey?: string
+		/**
+		 * Application metadata (id / version) tagged onto telemetry, mirroring
+		 * the `application` field of a LaunchDarkly client configuration.
+		 */
+		application?: LDApplicationInfo
+		/**
+		 * Hostnames on which the SDK should not initialize (e.g. local
+		 * development domains). If the current hostname includes any of these
+		 * substrings the SDK is skipped.
+		 */
+		excludedHostnames?: string[]
+	}
+
+/**
+ * Drop-in client component that boots LaunchDarkly observability and session
+ * replay for a Next.js app. Render it once near the root of your app (e.g. in
+ * `app/layout.tsx` or `pages/_app.tsx`).
+ *
+ * It runs the plugins in standalone mode — there is no LaunchDarkly feature-flag
+ * SDK for Next.js, so the plugins are initialized directly from the LaunchDarkly
+ * SDK key rather than registered with an LD client.
+ */
+export function LDObservabilityInit({
+	sdkKey,
+	application,
+	excludedHostnames = [],
+	...options
+}: LDObservabilityInitProps) {
+	useEffect(() => {
+		const shouldRender =
+			!!sdkKey &&
+			excludedHostnames.every(
+				(hostname) => !window.location.hostname.includes(hostname),
+			)
+
+		if (!shouldRender) {
+			return
+		}
+
+		let initOptions: LDObservabilityInitProps = { ...options }
+
+		const configureProxy = process.env[PROXY_ENV_FLAG] === 'true'
+		if (configureProxy) {
+			initOptions = {
+				...initOptions,
+				backendUrl: PROXY_BACKEND_PATH,
+				otel: {
+					...initOptions.otel,
+					otlpEndpoint: window.location.origin,
+				},
+			}
+		}
+
+		// Standalone init loads the LDObserve / LDRecord singletons. The shared
+		// guard keeps this idempotent across re-renders and bundles.
+		ensureStandaloneInit(
+			'observe',
+			() => new Observability(initOptions),
+			sdkKey,
+			application,
+		)
+		ensureStandaloneInit(
+			'record',
+			() => new SessionReplay(initOptions),
+			sdkKey,
+			application,
+		)
+
+		const session = LDRecord.getSession()
+		if (session?.sessionSecureID) {
+			Cookies.set('sessionSecureID', session.sessionSecureID)
+		}
+	}, []) // eslint-disable-line react-hooks/exhaustive-deps
+
+	return null
+}

--- a/sdk/@launchdarkly/observability-next/src/server.edge.ts
+++ b/sdk/@launchdarkly/observability-next/src/server.edge.ts
@@ -1,0 +1,24 @@
+import type { ObservabilityEnv } from './util/types'
+
+export { observabilityMiddleware } from './util/observability-middleware'
+export { isNodeJsRuntime } from './util/is-node-js-runtime'
+export type { ObservabilityEnv } from './util/types'
+
+/**
+ * No-op in the edge runtime. The OpenTelemetry-based node SDK that powers
+ * server-side observability is not edge-compatible, so initialization only
+ * happens in the Node.js runtime.
+ */
+export async function registerObservability(_: ObservabilityEnv) {}
+
+export function PageRouterObservability(_: ObservabilityEnv): never {
+	throw new Error('Do not use PageRouterObservability() in the edge runtime.')
+}
+
+export function AppRouterObservability(_: ObservabilityEnv): never {
+	throw new Error('Do not use AppRouterObservability() in the edge runtime.')
+}
+
+export function EdgeObservability(_: ObservabilityEnv): never {
+	throw new Error(`unsupported NEXT_RUNTIME: ${process.env.NEXT_RUNTIME}`)
+}

--- a/sdk/@launchdarkly/observability-next/src/server.edge.ts
+++ b/sdk/@launchdarkly/observability-next/src/server.edge.ts
@@ -4,6 +4,43 @@ export { observabilityMiddleware } from './util/observability-middleware'
 export { isNodeJsRuntime } from './util/is-node-js-runtime'
 export type { ObservabilityEnv } from './util/types'
 
+// `import type` is erased at build time, so referencing the node SDK here keeps
+// `server.edge.js` free of any runtime `@launchdarkly/observability-node`
+// import while letting the edge build expose the same `/server` surface as the
+// Node build.
+type Observe = import('@launchdarkly/observability-node').Observe
+type HandlersNamespace =
+	typeof import('@launchdarkly/observability-node').Handlers
+
+const edgeUnsupported = (name: string): never => {
+	throw new Error(
+		`${name} is not supported in the edge runtime. The OpenTelemetry-based ` +
+			`node SDK that powers server-side observability is not edge-compatible.`,
+	)
+}
+
+/**
+ * Edge-runtime stub for the manual-tracking singleton. Re-exported so importing
+ * `LDObserve` from `@launchdarkly/observability-next/server` in edge code
+ * resolves at bundle time (matching the Node build and `server.d.ts`); any
+ * access throws a clear error instead of failing as a missing export.
+ */
+export const LDObserve: Observe = new Proxy({} as Observe, {
+	get() {
+		return edgeUnsupported('LDObserve')
+	},
+})
+
+/**
+ * Edge-runtime stub for the request handlers. See {@link LDObserve} for why this
+ * is re-exported rather than omitted.
+ */
+export const Handlers: HandlersNamespace = new Proxy({} as HandlersNamespace, {
+	get() {
+		return edgeUnsupported('Handlers')
+	},
+})
+
 /**
  * No-op in the edge runtime. The OpenTelemetry-based node SDK that powers
  * server-side observability is not edge-compatible, so initialization only

--- a/sdk/@launchdarkly/observability-next/src/server.ts
+++ b/sdk/@launchdarkly/observability-next/src/server.ts
@@ -1,0 +1,51 @@
+import * as withObservabilityAppRouter from './util/with-observability-app-router'
+import * as withObservabilityPageRouter from './util/with-observability-page-router'
+
+import { isNodeJsRuntime } from './util/is-node-js-runtime'
+import type { ObservabilityEnv } from './util/types'
+
+export { Handlers, LDObserve } from '@launchdarkly/observability-node'
+export { observabilityMiddleware } from './util/observability-middleware'
+export { isNodeJsRuntime } from './util/is-node-js-runtime'
+export { registerObservability } from './util/register-observability'
+export type { ObservabilityEnv } from './util/types'
+
+type PageRouterObservabilityHandler = ReturnType<
+	typeof withObservabilityPageRouter.Highlight
+>
+
+/**
+ * Default Pages Router wrapper. Alias for {@link PageRouterObservability}.
+ */
+export const Observability = PageRouterObservability
+
+/**
+ * Wrap a Pages Router API handler to record LaunchDarkly traces. Only supported
+ * in the Node.js runtime.
+ */
+export function PageRouterObservability(
+	env: ObservabilityEnv,
+): PageRouterObservabilityHandler {
+	if (isNodeJsRuntime()) {
+		return withObservabilityPageRouter.Highlight(env)
+	}
+	throw new Error(`unidentified NEXT_RUNTIME: ${process.env.NEXT_RUNTIME}`)
+}
+
+/**
+ * Wrap an App Router route handler to record LaunchDarkly traces. Only supported
+ * in the Node.js runtime.
+ */
+export function AppRouterObservability(env: ObservabilityEnv) {
+	if (isNodeJsRuntime()) {
+		return withObservabilityAppRouter.Highlight(env)
+	}
+	throw new Error(`unidentified NEXT_RUNTIME: ${process.env.NEXT_RUNTIME}`)
+}
+
+/**
+ * Edge runtime is not yet supported by the LaunchDarkly observability node SDK.
+ */
+export function EdgeObservability(_: ObservabilityEnv): never {
+	throw new Error(`unsupported NEXT_RUNTIME: ${process.env.NEXT_RUNTIME}`)
+}

--- a/sdk/@launchdarkly/observability-next/src/ssr.tsx
+++ b/sdk/@launchdarkly/observability-next/src/ssr.tsx
@@ -1,0 +1,83 @@
+import Observability, {
+	LDObserve,
+	type ObserveOptions,
+} from '@launchdarkly/observability'
+import type { NextPageContext } from 'next'
+import NextError, { ErrorProps } from 'next/error.js'
+import React, { useEffect } from 'react'
+
+import { ensureStandaloneInit, type LDApplicationInfo } from './util/standalone'
+
+export { ErrorBoundary } from './error-boundary'
+export { LDObserve }
+
+export interface LDObservabilityInitProps extends ObserveOptions {
+	/** The LaunchDarkly client-side ID (SDK key). */
+	sdkKey?: string
+	/** Application metadata (id / version) tagged onto telemetry. */
+	application?: LDApplicationInfo
+}
+
+export type LDErrorProps = { errorMessage: string } & ErrorProps
+
+export function getLDErrorInitialProps({
+	res,
+	err,
+}: NextPageContext): LDErrorProps {
+	const statusCode = res?.statusCode ?? err?.statusCode ?? 500
+	const errorMessage =
+		res?.statusMessage ?? err?.message ?? 'An error occurred'
+
+	return { errorMessage, statusCode }
+}
+
+export type PageRouterErrorProps = LDErrorProps
+
+/**
+ * Pages Router custom `_error` page handler. Initializes observability in
+ * standalone mode (if not already running) and records the rendered error.
+ */
+export function pageRouterCustomErrorHandler(
+	initProps: LDObservabilityInitProps,
+	Child?: React.FC<LDErrorProps>,
+) {
+	const { sdkKey, application, ...options } = initProps
+
+	const handler = (props: LDErrorProps) => {
+		if (sdkKey) {
+			ensureStandaloneInit(
+				'observe',
+				() => new Observability(options),
+				sdkKey,
+				application,
+			)
+		}
+		LDObserve.recordError(new Error(props.errorMessage))
+
+		return Child ? <Child {...props} /> : <NextError {...props} />
+	}
+
+	handler.getInitialProps = getLDErrorInitialProps
+
+	return handler
+}
+
+export type AppRouterErrorProps = {
+	error: Error & { digest?: string }
+	reset: () => void
+}
+
+/**
+ * App Router `error.tsx` wrapper. Records the error to LaunchDarkly (which must
+ * already be initialized via {@link LDObservabilityInit}) and renders your error
+ * UI.
+ */
+export function appRouterSsrErrorHandler(Child: React.FC<AppRouterErrorProps>) {
+	return ({ error, reset }: AppRouterErrorProps) => {
+		useEffect(() => {
+			LDObserve.recordError(error)
+		}, [error])
+
+		return <Child error={error} reset={reset} />
+	}
+}

--- a/sdk/@launchdarkly/observability-next/src/ssr.tsx
+++ b/sdk/@launchdarkly/observability-next/src/ssr.tsx
@@ -44,15 +44,20 @@ export function pageRouterCustomErrorHandler(
 	const { sdkKey, application, ...options } = initProps
 
 	const handler = (props: LDErrorProps) => {
-		if (sdkKey) {
-			ensureStandaloneInit(
-				'observe',
-				() => new Observability(options),
-				sdkKey,
-				application,
-			)
-		}
-		LDObserve.recordError(new Error(props.errorMessage))
+		// Record inside an effect (keyed on the message) rather than during
+		// render so a re-render of the `_error` page does not emit duplicate
+		// error events for the same failure. Mirrors appRouterSsrErrorHandler.
+		useEffect(() => {
+			if (sdkKey) {
+				ensureStandaloneInit(
+					'observe',
+					() => new Observability(options),
+					sdkKey,
+					application,
+				)
+			}
+			LDObserve.recordError(new Error(props.errorMessage))
+		}, [props.errorMessage])
 
 		return Child ? <Child {...props} /> : <NextError {...props} />
 	}

--- a/sdk/@launchdarkly/observability-next/src/util/is-node-js-runtime.ts
+++ b/sdk/@launchdarkly/observability-next/src/util/is-node-js-runtime.ts
@@ -1,0 +1,6 @@
+export function isNodeJsRuntime() {
+	return (
+		typeof process.env.NEXT_RUNTIME === 'undefined' ||
+		process.env.NEXT_RUNTIME === 'nodejs'
+	)
+}

--- a/sdk/@launchdarkly/observability-next/src/util/observability-middleware.ts
+++ b/sdk/@launchdarkly/observability-next/src/util/observability-middleware.ts
@@ -1,0 +1,16 @@
+import { cookies } from 'next/headers'
+
+/**
+ * Next.js middleware helper that forwards the browser session id (stored in the
+ * `sessionSecureID` cookie by {@link LDObservabilityInit}) to your server as the
+ * `x-highlight-request` header, so backend traces can be linked to the session.
+ *
+ * Safe to run in the edge runtime — it only touches cookies and headers.
+ */
+export async function observabilityMiddleware(request: Request) {
+	const sessionSecureID = (await cookies()).get('sessionSecureID')?.value
+	const xHighlightRequest = request.headers.get('x-highlight-request')
+	if (!xHighlightRequest && sessionSecureID) {
+		request.headers.set('x-highlight-request', `${sessionSecureID}/`)
+	}
+}

--- a/sdk/@launchdarkly/observability-next/src/util/observability-middleware.ts
+++ b/sdk/@launchdarkly/observability-next/src/util/observability-middleware.ts
@@ -1,16 +1,30 @@
 import { cookies } from 'next/headers'
+import { NextResponse } from 'next/server'
 
 /**
  * Next.js middleware helper that forwards the browser session id (stored in the
  * `sessionSecureID` cookie by {@link LDObservabilityInit}) to your server as the
  * `x-highlight-request` header, so backend traces can be linked to the session.
  *
+ * Returns a {@link NextResponse} that carries the forwarded header through to
+ * downstream route handlers — Next.js only propagates request-header mutations
+ * when they are passed via `NextResponse.next({ request: { headers } })`, so
+ * your `middleware` must return this response:
+ *
+ * ```ts
+ * export async function middleware(request: Request) {
+ * 	return observabilityMiddleware(request)
+ * }
+ * ```
+ *
  * Safe to run in the edge runtime — it only touches cookies and headers.
  */
 export async function observabilityMiddleware(request: Request) {
+	const requestHeaders = new Headers(request.headers)
 	const sessionSecureID = (await cookies()).get('sessionSecureID')?.value
-	const xHighlightRequest = request.headers.get('x-highlight-request')
+	const xHighlightRequest = requestHeaders.get('x-highlight-request')
 	if (!xHighlightRequest && sessionSecureID) {
-		request.headers.set('x-highlight-request', `${sessionSecureID}/`)
+		requestHeaders.set('x-highlight-request', `${sessionSecureID}/`)
 	}
+	return NextResponse.next({ request: { headers: requestHeaders } })
 }

--- a/sdk/@launchdarkly/observability-next/src/util/proxy.ts
+++ b/sdk/@launchdarkly/observability-next/src/util/proxy.ts
@@ -1,0 +1,18 @@
+/**
+ * Shared constants describing the optional same-origin proxy that
+ * {@link withLaunchDarklyConfig} sets up and that the client reads. Proxying
+ * routes browser telemetry through your own domain so it is not blocked by ad
+ * blockers and so that requests share the page's origin.
+ */
+
+/** Env var (inlined by Next) signalling that the proxy rewrites are configured. */
+export const PROXY_ENV_FLAG = 'configureLaunchDarklyProxy'
+
+/** Same-origin path that proxies to the LaunchDarkly events ingest endpoint. */
+export const PROXY_BACKEND_PATH = '/highlight-events'
+
+/** Public LaunchDarkly endpoints that the proxy rewrites forward to. */
+export const LD_PUBLIC_BACKEND_URL =
+	'https://pub.observability.app.launchdarkly.com'
+export const LD_OTLP_ENDPOINT =
+	'https://otel.observability.app.launchdarkly.com'

--- a/sdk/@launchdarkly/observability-next/src/util/register-observability.ts
+++ b/sdk/@launchdarkly/observability-next/src/util/register-observability.ts
@@ -24,6 +24,11 @@ async function init(env: ObservabilityEnv) {
  * is a no-op (the OpenTelemetry-based node SDK is not edge-compatible). It is
  * idempotent and concurrency-safe, so route-handler wrappers can safely await
  * it on every request.
+ *
+ * `LDObserve` is a process-global singleton that can only be initialized once,
+ * so the first successful call wins and later calls reuse it. All callers
+ * (`instrumentation.ts` and any route wrappers) should therefore pass the same
+ * `env` — initialize once in `instrumentation.ts` for the canonical config.
  */
 export async function registerObservability(env: ObservabilityEnv) {
 	if (!isNodeJsRuntime()) {

--- a/sdk/@launchdarkly/observability-next/src/util/register-observability.ts
+++ b/sdk/@launchdarkly/observability-next/src/util/register-observability.ts
@@ -33,6 +33,12 @@ export async function registerObservability(env: ObservabilityEnv) {
 		return
 	}
 
-	initPromise ??= init(env)
+	// Cache the in-flight/successful init, but drop the cached promise if it
+	// rejects so a failed import or registration can be retried on a later
+	// call rather than poisoning every subsequent request.
+	initPromise ??= init(env).catch((err) => {
+		initPromise = undefined
+		throw err
+	})
 	return initPromise
 }

--- a/sdk/@launchdarkly/observability-next/src/util/register-observability.ts
+++ b/sdk/@launchdarkly/observability-next/src/util/register-observability.ts
@@ -1,0 +1,38 @@
+import { isNodeJsRuntime } from './is-node-js-runtime'
+import { standaloneMetadata, type StandalonePlugin } from './standalone'
+import type { ObservabilityEnv } from './types'
+
+let initPromise: Promise<void> | undefined
+
+async function init(env: ObservabilityEnv) {
+	// Import lazily so the OpenTelemetry/node dependencies are never pulled into
+	// an edge bundle.
+	const { Observability } = await import('@launchdarkly/observability-node')
+
+	const { sdkKey, ...options } = env
+	const plugin = new Observability(options) as unknown as StandalonePlugin
+	// `register` ignores the client argument and initializes LDObserve from the
+	// SDK key in the metadata. See util/standalone.ts.
+	plugin.register?.({}, standaloneMetadata(sdkKey))
+}
+
+/**
+ * Initialize the server-side LaunchDarkly observability plugin in standalone
+ * mode. Call this from your Next.js `instrumentation.ts` `register()` hook.
+ *
+ * Initialization only happens in the Node.js runtime; in the edge runtime this
+ * is a no-op (the OpenTelemetry-based node SDK is not edge-compatible). It is
+ * idempotent and concurrency-safe, so route-handler wrappers can safely await
+ * it on every request.
+ */
+export async function registerObservability(env: ObservabilityEnv) {
+	if (!isNodeJsRuntime()) {
+		console.info(
+			`LaunchDarkly observability not registered: NEXT_RUNTIME=${process.env.NEXT_RUNTIME}`,
+		)
+		return
+	}
+
+	initPromise ??= init(env)
+	return initPromise
+}

--- a/sdk/@launchdarkly/observability-next/src/util/sanitize-url.ts
+++ b/sdk/@launchdarkly/observability-next/src/util/sanitize-url.ts
@@ -1,0 +1,14 @@
+/**
+ * Strip the query string and fragment from a URL before it is used as an
+ * OpenTelemetry span name. Query params and hash fragments can carry secrets
+ * (OAuth tokens, auth codes, signed URLs); span names are exported to the
+ * tracing backend, so the high-cardinality, potentially-sensitive tail must be
+ * dropped. Works for both absolute URLs (`request.url`) and request-relative
+ * paths (`req.url` in the Pages Router).
+ */
+export function sanitizeSpanUrl(url: string | undefined): string {
+	if (!url) {
+		return ''
+	}
+	return url.split('#')[0].split('?')[0]
+}

--- a/sdk/@launchdarkly/observability-next/src/util/standalone.ts
+++ b/sdk/@launchdarkly/observability-next/src/util/standalone.ts
@@ -1,0 +1,83 @@
+import { SDK_NAME, SDK_VERSION } from './version'
+
+/**
+ * Application metadata that LaunchDarkly associates with telemetry. Mirrors the
+ * `application` field of the LaunchDarkly client configuration so that data sent
+ * in standalone mode is tagged identically to data sent through an LD client.
+ */
+export interface LDApplicationInfo {
+	id?: string
+	version?: string
+}
+
+/**
+ * The LaunchDarkly observability and session replay plugins are normally
+ * registered with a LaunchDarkly feature-flag client, which hands them an
+ * `LDPluginEnvironmentMetadata` object describing the environment (and crucially
+ * the SDK credential) during `getHooks`. There is no LaunchDarkly feature-flag
+ * SDK for Next.js, so this SDK runs the plugins in "standalone" mode: we build
+ * the same metadata object ourselves from the LaunchDarkly SDK key and invoke
+ * the plugin's `getHooks`, which performs the one-time initialization that loads
+ * the `LDObserve` / `LDRecord` singletons.
+ *
+ * The hooks returned by `getHooks` are only used for feature-flag evaluation and
+ * identify tracking, which cannot fire without an LD client, so they are
+ * discarded in standalone mode.
+ */
+export function standaloneMetadata(
+	sdkKey: string,
+	application?: LDApplicationInfo,
+) {
+	return {
+		sdk: {
+			name: SDK_NAME,
+			version: SDK_VERSION,
+		},
+		sdkKey,
+		clientSideId: sdkKey,
+		application,
+	}
+}
+
+/**
+ * A minimal structural type for a LaunchDarkly plugin so we can trigger
+ * standalone initialization without depending on a specific LD client SDK
+ * package. Both the browser plugins (`@launchdarkly/observability`,
+ * `@launchdarkly/session-replay`) and the node plugin
+ * (`@launchdarkly/observability-node`) satisfy this shape.
+ */
+export interface StandalonePlugin {
+	getHooks?(metadata: ReturnType<typeof standaloneMetadata>): unknown
+	register?(
+		client: unknown,
+		metadata: ReturnType<typeof standaloneMetadata>,
+	): void
+}
+
+interface InitRegistry {
+	[key: string]: boolean
+}
+declare var globalThis: { __ldObservabilityNext?: InitRegistry }
+
+/**
+ * Initialize a browser plugin in standalone mode exactly once. The guard is
+ * keyed on `globalThis` (where the LDObserve / LDRecord singletons also live) so
+ * that initialization is idempotent across this SDK's separate client and ssr
+ * bundles — e.g. when both `LDObservabilityInit` and a Pages Router `_error`
+ * page would otherwise init the same plugin.
+ */
+export function ensureStandaloneInit(
+	key: string,
+	createPlugin: () => StandalonePlugin,
+	sdkKey: string,
+	application?: LDApplicationInfo,
+) {
+	const registry = (globalThis.__ldObservabilityNext ??= {})
+	if (registry[key]) {
+		return
+	}
+	registry[key] = true
+
+	const plugin = createPlugin()
+	plugin.getHooks?.(standaloneMetadata(sdkKey, application))
+}

--- a/sdk/@launchdarkly/observability-next/src/util/standalone.ts
+++ b/sdk/@launchdarkly/observability-next/src/util/standalone.ts
@@ -76,8 +76,10 @@ export function ensureStandaloneInit(
 	if (registry[key]) {
 		return
 	}
-	registry[key] = true
 
 	const plugin = createPlugin()
 	plugin.getHooks?.(standaloneMetadata(sdkKey, application))
+	// Only mark the key initialized once init succeeds, so a throw from
+	// createPlugin / getHooks leaves the plugin retryable on the next call.
+	registry[key] = true
 }

--- a/sdk/@launchdarkly/observability-next/src/util/types.ts
+++ b/sdk/@launchdarkly/observability-next/src/util/types.ts
@@ -1,0 +1,11 @@
+import type { NodeOptions } from '@launchdarkly/observability-node'
+
+/**
+ * Configuration for the server-side LaunchDarkly observability plugin in
+ * Next.js. Extends the node {@link NodeOptions} with the LaunchDarkly SDK key
+ * required to initialize the plugin in standalone mode.
+ */
+export interface ObservabilityEnv extends NodeOptions {
+	/** The LaunchDarkly SDK key for the environment to send telemetry to. */
+	sdkKey: string
+}

--- a/sdk/@launchdarkly/observability-next/src/util/version.ts
+++ b/sdk/@launchdarkly/observability-next/src/util/version.ts
@@ -1,0 +1,7 @@
+export const SDK_NAME = '@launchdarkly/observability-next'
+
+// Keep in sync with package.json "version". Used only as informational
+// telemetry metadata (telemetry.sdk.version), so minor drift is harmless. It is
+// a literal (rather than an import of package.json) so the manifest is not
+// bundled into the browser client.
+export const SDK_VERSION = '0.1.0'

--- a/sdk/@launchdarkly/observability-next/src/util/with-launchdarkly-config.ts
+++ b/sdk/@launchdarkly/observability-next/src/util/with-launchdarkly-config.ts
@@ -1,0 +1,136 @@
+import { NextConfig } from 'next'
+import { Rewrite } from 'next/dist/lib/load-custom-routes'
+
+import {
+	LD_OTLP_ENDPOINT,
+	LD_PUBLIC_BACKEND_URL,
+	PROXY_BACKEND_PATH,
+	PROXY_ENV_FLAG,
+} from './proxy'
+
+export interface LaunchDarklyConfigOptions {
+	/**
+	 * Configures same-origin rewrites that proxy browser telemetry through your
+	 * own domain to LaunchDarkly. This avoids ad-blockers and keeps requests on
+	 * your origin. When enabled, {@link LDObservabilityInit} automatically routes
+	 * its requests through the proxy.
+	 * @default true
+	 */
+	configureLaunchDarklyProxy?: boolean
+}
+
+interface LaunchDarklyConfigOptionsDefault {
+	configureLaunchDarklyProxy: boolean
+}
+
+const getDefaultOpts = (
+	opts?: LaunchDarklyConfigOptions,
+): LaunchDarklyConfigOptionsDefault => ({
+	configureLaunchDarklyProxy: opts?.configureLaunchDarklyProxy ?? true,
+})
+
+type NextConfigObject = NextConfig
+type NextConfigFunction = (
+	phase: string,
+	{ defaultConfig }: { defaultConfig: any },
+) => NextConfig
+type NextConfigAsyncFunction = (
+	phase: string,
+	{ defaultConfig }: { defaultConfig: any },
+) => Promise<NextConfig>
+type NextConfigInput =
+	| NextConfigObject
+	| NextConfigFunction
+	| NextConfigAsyncFunction
+
+const getLaunchDarklyConfig = (
+	config: NextConfig,
+	opts?: LaunchDarklyConfigOptions,
+): NextConfig => {
+	const defaultOpts = getDefaultOpts(opts)
+
+	let newRewrites = config.rewrites
+	if (defaultOpts.configureLaunchDarklyProxy) {
+		const proxyRewrites: Rewrite[] = [
+			{
+				source: PROXY_BACKEND_PATH,
+				destination: LD_PUBLIC_BACKEND_URL,
+			},
+			{
+				source: '/v1/traces',
+				destination: `${LD_OTLP_ENDPOINT}/v1/traces`,
+			},
+			{
+				source: '/v1/metrics',
+				destination: `${LD_OTLP_ENDPOINT}/v1/metrics`,
+			},
+			{
+				source: '/v1/logs',
+				destination: `${LD_OTLP_ENDPOINT}/v1/logs`,
+			},
+		]
+
+		newRewrites = async () => {
+			let re:
+				| Rewrite[]
+				| {
+						beforeFiles?: Rewrite[]
+						afterFiles?: Rewrite[]
+						fallback?: Rewrite[]
+				  }
+			if (!config.rewrites) {
+				re = new Array<Rewrite>()
+			} else {
+				re = await config.rewrites()
+			}
+
+			if (!re || Array.isArray(re)) {
+				re = re ?? []
+				return re.concat(...proxyRewrites)
+			}
+			return {
+				beforeFiles: re.beforeFiles ?? [],
+				afterFiles: (re.afterFiles ?? []).concat(...proxyRewrites),
+				fallback: re.fallback ?? [],
+			}
+		}
+	}
+
+	return {
+		...config,
+		env: {
+			...config.env,
+			[PROXY_ENV_FLAG]: defaultOpts.configureLaunchDarklyProxy
+				? 'true'
+				: '',
+		},
+		rewrites: newRewrites,
+	}
+}
+
+export function withLaunchDarklyConfig(
+	config: NextConfigObject,
+	opts?: LaunchDarklyConfigOptions,
+): NextConfig
+export function withLaunchDarklyConfig(
+	config: NextConfigFunction | NextConfigAsyncFunction,
+	opts?: LaunchDarklyConfigOptions,
+): NextConfigAsyncFunction
+export function withLaunchDarklyConfig(
+	config: NextConfigInput,
+	opts?: LaunchDarklyConfigOptions,
+): NextConfig | NextConfigAsyncFunction {
+	if (typeof config === 'function') {
+		const phaseHandler: NextConfigAsyncFunction = async (
+			phase: string,
+			{ defaultConfig }: { defaultConfig: any },
+		): Promise<NextConfig> => {
+			const userNextConfigObject: NextConfig | Promise<NextConfig> =
+				config(phase, { defaultConfig })
+			const nc = await userNextConfigObject
+			return getLaunchDarklyConfig(nc, opts)
+		}
+		return phaseHandler
+	}
+	return getLaunchDarklyConfig(config, opts)
+}

--- a/sdk/@launchdarkly/observability-next/src/util/with-launchdarkly-config.ts
+++ b/sdk/@launchdarkly/observability-next/src/util/with-launchdarkly-config.ts
@@ -8,6 +8,20 @@ import {
 	PROXY_ENV_FLAG,
 } from './proxy'
 
+/**
+ * Packages that the LaunchDarkly observability node SDK relies on and that must
+ * be loaded natively at runtime rather than webpack-bundled. Bundling them
+ * breaks `require-in-the-middle`-based instrumentation (and therefore
+ * server-side tracing initialized via {@link registerObservability}).
+ */
+const LD_SERVER_EXTERNAL_PACKAGES = [
+	'@launchdarkly/observability-node',
+	'@launchdarkly/node-server-sdk-otel',
+	'@prisma/instrumentation',
+	'require-in-the-middle',
+	'import-in-the-middle',
+]
+
 export interface LaunchDarklyConfigOptions {
 	/**
 	 * Configures same-origin rewrites that proxy browser telemetry through your
@@ -96,6 +110,13 @@ const getLaunchDarklyConfig = (
 		}
 	}
 
+	const serverExternalPackages = Array.from(
+		new Set([
+			...(config.serverExternalPackages ?? []),
+			...LD_SERVER_EXTERNAL_PACKAGES,
+		]),
+	)
+
 	return {
 		...config,
 		env: {
@@ -105,6 +126,7 @@ const getLaunchDarklyConfig = (
 				: '',
 		},
 		rewrites: newRewrites,
+		serverExternalPackages,
 	}
 }
 

--- a/sdk/@launchdarkly/observability-next/src/util/with-observability-app-router.ts
+++ b/sdk/@launchdarkly/observability-next/src/util/with-observability-app-router.ts
@@ -1,6 +1,7 @@
 import { LDObserve } from '@launchdarkly/observability-node'
 
 import { registerObservability } from './register-observability'
+import { sanitizeSpanUrl } from './sanitize-url'
 import type { ObservabilityEnv } from './types'
 
 type NextContext = {
@@ -18,7 +19,7 @@ export function Highlight(env: ObservabilityEnv) {
 			await registerObservability(env)
 
 			return await LDObserve.runWithHeaders(
-				`${request.method?.toUpperCase()} - ${request.url}`,
+				`${request.method?.toUpperCase()} - ${sanitizeSpanUrl(request.url)}`,
 				// eslint-disable-next-line @typescript-eslint/no-explicit-any
 				request.headers as any,
 				async () => originalHandler(request, context),

--- a/sdk/@launchdarkly/observability-next/src/util/with-observability-app-router.ts
+++ b/sdk/@launchdarkly/observability-next/src/util/with-observability-app-router.ts
@@ -1,0 +1,27 @@
+import { LDObserve } from '@launchdarkly/observability-node'
+
+import { registerObservability } from './register-observability'
+import type { ObservabilityEnv } from './types'
+
+type NextContext = {
+	params: Promise<Record<string, string>>
+}
+type NextHandler = (request: Request, context: NextContext) => Promise<Response>
+
+/**
+ * Wraps an App Router route handler so that its execution runs inside a
+ * LaunchDarkly trace, with the session and request linked via incoming headers.
+ */
+export function Highlight(env: ObservabilityEnv) {
+	return (originalHandler: NextHandler) =>
+		async (request: Request, context: NextContext): Promise<Response> => {
+			await registerObservability(env)
+
+			return await LDObserve.runWithHeaders(
+				`${request.method?.toUpperCase()} - ${request.url}`,
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+				request.headers as any,
+				async () => originalHandler(request, context),
+			)
+		}
+}

--- a/sdk/@launchdarkly/observability-next/src/util/with-observability-page-router.ts
+++ b/sdk/@launchdarkly/observability-next/src/util/with-observability-page-router.ts
@@ -1,6 +1,7 @@
 import { LDObserve } from '@launchdarkly/observability-node'
 
 import { registerObservability } from './register-observability'
+import { sanitizeSpanUrl } from './sanitize-url'
 import type { ObservabilityEnv } from './types'
 
 import type { IncomingHttpHeaders } from 'http'
@@ -34,7 +35,7 @@ export const Highlight =
 			await registerObservability(env)
 
 			return await LDObserve.runWithHeaders(
-				`${req.method?.toUpperCase()} - ${req.url}`,
+				`${req.method?.toUpperCase()} - ${sanitizeSpanUrl(req.url)}`,
 				req.headers,
 				async () => {
 					return await originalHandler(req, res)

--- a/sdk/@launchdarkly/observability-next/src/util/with-observability-page-router.ts
+++ b/sdk/@launchdarkly/observability-next/src/util/with-observability-page-router.ts
@@ -1,0 +1,44 @@
+import { LDObserve } from '@launchdarkly/observability-node'
+
+import { registerObservability } from './register-observability'
+import type { ObservabilityEnv } from './types'
+
+import type { IncomingHttpHeaders } from 'http'
+
+export declare type HasHeaders = {
+	headers: IncomingHttpHeaders
+	method?: string
+	url?: string
+}
+export declare type HasStatus = {
+	readonly statusCode: number
+	readonly statusMessage: string
+	status: (statusCode: number) => HasStatus
+	send: (body: string) => void
+}
+export declare type ApiHandler<T extends HasHeaders, S extends HasStatus> = (
+	req: T,
+	res: S,
+) => unknown | Promise<unknown>
+
+/**
+ * Wraps a Pages Router API handler so that its execution runs inside a
+ * LaunchDarkly trace, with the session and request linked via incoming headers.
+ */
+export const Highlight =
+	(env: ObservabilityEnv) =>
+	<T extends HasHeaders, S extends HasStatus>(
+		originalHandler: ApiHandler<T, S>,
+	): ApiHandler<T, S> => {
+		return async (req, res) => {
+			await registerObservability(env)
+
+			return await LDObserve.runWithHeaders(
+				`${req.method?.toUpperCase()} - ${req.url}`,
+				req.headers,
+				async () => {
+					return await originalHandler(req, res)
+				},
+			)
+		}
+	}

--- a/sdk/@launchdarkly/observability-next/ssr.d.ts
+++ b/sdk/@launchdarkly/observability-next/ssr.d.ts
@@ -1,0 +1,1 @@
+export * from './dist/ssr'

--- a/sdk/@launchdarkly/observability-next/tsconfig.json
+++ b/sdk/@launchdarkly/observability-next/tsconfig.json
@@ -1,0 +1,23 @@
+{
+	"compilerOptions": {
+		"allowSyntheticDefaultImports": true,
+		"declaration": true,
+		"declarationMap": true,
+		"declarationDir": "dist",
+		"emitDeclarationOnly": true,
+		"esModuleInterop": true,
+		"forceConsistentCasingInFileNames": true,
+		"jsx": "react-jsx",
+		"lib": ["DOM", "ESNext"],
+		"target": "ESNext",
+		"module": "ESNext",
+		"moduleResolution": "Bundler",
+		"outDir": "dist",
+		"rootDir": "src",
+		"removeComments": true,
+		"resolveJsonModule": true,
+		"skipLibCheck": true,
+		"strict": true
+	},
+	"include": ["src/**/*"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -9206,6 +9206,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@launchdarkly/observability-next@workspace:*, @launchdarkly/observability-next@workspace:sdk/@launchdarkly/observability-next":
+  version: 0.0.0-use.local
+  resolution: "@launchdarkly/observability-next@workspace:sdk/@launchdarkly/observability-next"
+  dependencies:
+    "@launchdarkly/observability": "workspace:*"
+    "@launchdarkly/observability-node": "workspace:*"
+    "@launchdarkly/session-replay": "workspace:*"
+    "@opentelemetry/api": "npm:^1.9.0"
+    "@opentelemetry/semantic-conventions": "npm:^1.34.0"
+    "@rollup/plugin-json": "npm:^6.1.0"
+    "@rollup/plugin-terser": "npm:^0.4.4"
+    "@rollup/plugin-typescript": "npm:^11.1.5"
+    "@types/js-cookie": "npm:^3"
+    "@types/node": "npm:^20.14.7"
+    "@types/react": "npm:^19.0.10"
+    js-cookie: "npm:^3.0.5"
+    next: "npm:>=14"
+    react: "npm:^19.0.0"
+    rollup: "npm:^4.4.1"
+    typescript: "npm:^5.0.4"
+  peerDependencies:
+    next: ">=14"
+    react: ">=17"
+  languageName: unknown
+  linkType: soft
+
 "@launchdarkly/observability-node@workspace:*, @launchdarkly/observability-node@workspace:sdk/@launchdarkly/observability-node":
   version: 0.0.0-use.local
   resolution: "@launchdarkly/observability-node@workspace:sdk/@launchdarkly/observability-node"
@@ -10176,6 +10202,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@next/env@npm:16.2.9":
+  version: 16.2.9
+  resolution: "@next/env@npm:16.2.9"
+  checksum: 10/5cb54e8a956dbeb72eb5db966a7280fdc08693f4ffbd98c425a43f4d03abfa3c66868c1035b3203572990bdcd46d385eb8edcf41ee31dde5359743264001bce9
+  languageName: node
+  linkType: hard
+
 "@next/eslint-plugin-next@npm:15.5.11":
   version: 15.5.11
   resolution: "@next/eslint-plugin-next@npm:15.5.11"
@@ -10192,9 +10225,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@next/swc-darwin-arm64@npm:16.2.9":
+  version: 16.2.9
+  resolution: "@next/swc-darwin-arm64@npm:16.2.9"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@next/swc-darwin-x64@npm:15.5.18":
   version: 15.5.18
   resolution: "@next/swc-darwin-x64@npm:15.5.18"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@next/swc-darwin-x64@npm:16.2.9":
+  version: 16.2.9
+  resolution: "@next/swc-darwin-x64@npm:16.2.9"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
@@ -10206,9 +10253,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@next/swc-linux-arm64-gnu@npm:16.2.9":
+  version: 16.2.9
+  resolution: "@next/swc-linux-arm64-gnu@npm:16.2.9"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
 "@next/swc-linux-arm64-musl@npm:15.5.18":
   version: 15.5.18
   resolution: "@next/swc-linux-arm64-musl@npm:15.5.18"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@next/swc-linux-arm64-musl@npm:16.2.9":
+  version: 16.2.9
+  resolution: "@next/swc-linux-arm64-musl@npm:16.2.9"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
@@ -10220,9 +10281,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@next/swc-linux-x64-gnu@npm:16.2.9":
+  version: 16.2.9
+  resolution: "@next/swc-linux-x64-gnu@npm:16.2.9"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
 "@next/swc-linux-x64-musl@npm:15.5.18":
   version: 15.5.18
   resolution: "@next/swc-linux-x64-musl@npm:15.5.18"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@next/swc-linux-x64-musl@npm:16.2.9":
+  version: 16.2.9
+  resolution: "@next/swc-linux-x64-musl@npm:16.2.9"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
@@ -10234,9 +10309,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@next/swc-win32-arm64-msvc@npm:16.2.9":
+  version: 16.2.9
+  resolution: "@next/swc-win32-arm64-msvc@npm:16.2.9"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@next/swc-win32-x64-msvc@npm:15.5.18":
   version: 15.5.18
   resolution: "@next/swc-win32-x64-msvc@npm:15.5.18"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@next/swc-win32-x64-msvc@npm:16.2.9":
+  version: 16.2.9
+  resolution: "@next/swc-win32-x64-msvc@npm:16.2.9"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -20535,12 +20624,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"baseline-browser-mapping@npm:^2.9.0":
-  version: 2.9.19
-  resolution: "baseline-browser-mapping@npm:2.9.19"
+"baseline-browser-mapping@npm:^2.9.0, baseline-browser-mapping@npm:^2.9.19":
+  version: 2.10.37
+  resolution: "baseline-browser-mapping@npm:2.10.37"
   bin:
-    baseline-browser-mapping: dist/cli.js
-  checksum: 10/8d7bbb7fe3d1ad50e04b127c819ba6d059c01ed0d2a7a5fc3327e23a8c42855fa3a8b510550c1fe1e37916147e6a390243566d3ef85bf6130c8ddfe5cc3db530
+    baseline-browser-mapping: dist/cli.cjs
+  checksum: 10/5bf887e82a238ab2ec216283ab2c44291d5ad917b4c4d21bb88f466be513223bda20d746c2758cdb0be5b3dad1e52ee8b468dbc196096da92673d6904992af66
   languageName: node
   linkType: hard
 
@@ -36544,6 +36633,66 @@ __metadata:
   languageName: node
   linkType: hard
 
+"next@npm:>=14":
+  version: 16.2.9
+  resolution: "next@npm:16.2.9"
+  dependencies:
+    "@next/env": "npm:16.2.9"
+    "@next/swc-darwin-arm64": "npm:16.2.9"
+    "@next/swc-darwin-x64": "npm:16.2.9"
+    "@next/swc-linux-arm64-gnu": "npm:16.2.9"
+    "@next/swc-linux-arm64-musl": "npm:16.2.9"
+    "@next/swc-linux-x64-gnu": "npm:16.2.9"
+    "@next/swc-linux-x64-musl": "npm:16.2.9"
+    "@next/swc-win32-arm64-msvc": "npm:16.2.9"
+    "@next/swc-win32-x64-msvc": "npm:16.2.9"
+    "@swc/helpers": "npm:0.5.15"
+    baseline-browser-mapping: "npm:^2.9.19"
+    caniuse-lite: "npm:^1.0.30001579"
+    postcss: "npm:8.4.31"
+    sharp: "npm:^0.34.5"
+    styled-jsx: "npm:5.1.6"
+  peerDependencies:
+    "@opentelemetry/api": ^1.1.0
+    "@playwright/test": ^1.51.1
+    babel-plugin-react-compiler: "*"
+    react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+    react-dom: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+    sass: ^1.3.0
+  dependenciesMeta:
+    "@next/swc-darwin-arm64":
+      optional: true
+    "@next/swc-darwin-x64":
+      optional: true
+    "@next/swc-linux-arm64-gnu":
+      optional: true
+    "@next/swc-linux-arm64-musl":
+      optional: true
+    "@next/swc-linux-x64-gnu":
+      optional: true
+    "@next/swc-linux-x64-musl":
+      optional: true
+    "@next/swc-win32-arm64-msvc":
+      optional: true
+    "@next/swc-win32-x64-msvc":
+      optional: true
+    sharp:
+      optional: true
+  peerDependenciesMeta:
+    "@opentelemetry/api":
+      optional: true
+    "@playwright/test":
+      optional: true
+    babel-plugin-react-compiler:
+      optional: true
+    sass:
+      optional: true
+  bin:
+    next: dist/bin/next
+  checksum: 10/07903fdd4cc68beb7bff8f04f85bda52b3ebec6112702d6761e7e5d17fa2843ac12cd7cbdb369bfb5fadd6cd6b3620c22c9865cb46f8e7615134238ac1422672
+  languageName: node
+  linkType: hard
+
 "next@npm:^15.5.18":
   version: 15.5.18
   resolution: "next@npm:15.5.18"
@@ -36602,6 +36751,21 @@ __metadata:
   checksum: 10/3e4c11beb34b9c827a49db477429c3e6fc9c38e1e37734014082dd748d401772742705ef0d9752c0a5d1714a577b7937612869a8041069081c9930231017db93
   languageName: node
   linkType: hard
+
+"nextjs-ld@workspace:e2e/nextjs-ld":
+  version: 0.0.0-use.local
+  resolution: "nextjs-ld@workspace:e2e/nextjs-ld"
+  dependencies:
+    "@launchdarkly/observability-next": "workspace:*"
+    "@types/node": "npm:^22.13.5"
+    "@types/react": "npm:^19.0.10"
+    "@types/react-dom": "npm:^19.0.4"
+    next: "npm:^15.5.10"
+    react: "npm:^19.0.0"
+    react-dom: "npm:^19.0.0"
+    typescript: "npm:^5.7.2"
+  languageName: unknown
+  linkType: soft
 
 "nextjs@workspace:e2e/nextjs":
   version: 0.0.0-use.local


### PR DESCRIPTION
## Summary

Adds **`@launchdarkly/observability-next`** — a Next.js SDK that wraps the LaunchDarkly observability and session replay plugins, mirroring `@highlight-run/next` but remapped to LaunchDarkly concepts and endpoints.

Because there is **no LaunchDarkly feature-flag SDK for Next.js**, the plugins run in **standalone mode**: they are initialized directly from the LaunchDarkly SDK key rather than registered with a feature-flag client.

### How standalone init works
- **Browser**: `new Observe(opts).getHooks({ sdkKey, … })` triggers the plugin's one-time init that loads the `LDObserve` / `LDRecord` singletons. A `globalThis`-keyed guard keeps it idempotent across the separate client/ssr bundles.
- **Node**: `new Observability(opts).register({}, { sdkKey })` — `register` ignores the client arg and inits `LDObserve` from the SDK key. The init promise is cached for concurrency safety.

## Exports (mirror `@highlight-run/next`)

| Entry | Exports |
|---|---|
| `/client` | `LDObservabilityInit`, `ErrorBoundary`, `LDObserve`, `LDRecord` |
| `/server` | `registerObservability`, `AppRouterObservability`, `PageRouterObservability`, `observabilityMiddleware`, `LDObserve`, `Handlers` |
| `/config` | `withLaunchDarklyConfig` (proxy rewrites to `pub`/`otel.observability.app.launchdarkly.com`) |
| `/ssr` | `appRouterSsrErrorHandler`, `pageRouterCustomErrorHandler` |

The `/server` entry resolves to an edge-safe build (`server.edge`) in edge runtimes, so `observabilityMiddleware` never pulls the OpenTelemetry node SDK into an edge bundle.

## Also included
- `e2e/nextjs-ld` — example App Router app exercising every entry point.
- Registered the package with release-please (`release-please-config.json`, `.release-please-manifest.json`).

## Scope notes
- **Edge runtime** throws "unsupported" (the LD node SDK is OpenTelemetry/Node-based; no LD Cloudflare SDK exists yet).
- **Source-map upload** is omitted — there is no LaunchDarkly source-map uploader in the repo. `withLaunchDarklyConfig` handles the proxy rewrites.

## Testing
- `yarn turbo run build --filter @launchdarkly/observability-next` → 16/16 tasks pass (typegen + rollup for all entries).
- `yarn workspace nextjs-ld typecheck` → passes (validates the SDK's public API through its `exports`).
- Prettier clean across all new/changed files.
- Verified `server.edge.js` is free of `@launchdarkly/observability-node` references while `server.js` imports it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new public SDK surface that handles SDK keys, optional network/header recording, and server instrumentation across Node vs edge runtimes; risk is mainly integration and misconfiguration rather than changes to existing packages.
> 
> **Overview**
> Introduces **`@launchdarkly/observability-next` (0.1.0)** as a new Next.js integration for LaunchDarkly observability and session replay, wired for **standalone** initialization from SDK keys because there is no Next.js feature-flag client.
> 
> The package adds subpath exports for **client** (`LDObservabilityInit`, `ErrorBoundary`, `LDObserve`/`LDRecord`), **server** (`registerObservability`, App/Pages route wrappers, `observabilityMiddleware`, with a separate **edge** bundle that stubs Node-only APIs), **config** (`withLaunchDarklyConfig` for telemetry proxy rewrites and `serverExternalPackages`), and **ssr** error helpers. Implementation covers session-to-backend linking via cookies/`x-highlight-request`, optional same-origin proxying to LaunchDarkly ingest, idempotent standalone plugin init, and URL sanitization for span names.
> 
> Also adds **`e2e/nextjs-ld`** demonstrating the full App Router setup, registers the package in **release-please**, and updates **yarn.lock** for the new workspace.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24089fa5354adfe8ccb5571cc76ef6ccb3682ec3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->