### PR TITLE
ci: add placeholder publish script to bootstrap new npm packages

### DIFF
--- a/contributing/publishing.md
+++ b/contributing/publishing.md
@@ -1,0 +1,52 @@
+# Publishing npm packages
+
+`@launchdarkly/*` packages in this monorepo are published by the
+[`turbo.yml`](../.github/workflows/turbo.yml) workflow using npm's
+[trusted publishing (OIDC)](https://docs.npmjs.com/trusted-publishers) —
+no long-lived npm token. Publishing runs on every push to `main` (and via
+manual `workflow_dispatch`) through [`scripts/publish-npm.sh`](../scripts/publish-npm.sh),
+which packs and publishes each publishable `@launchdarkly/*` workspace.
+
+## Publishing a brand-new package for the first time
+
+OIDC trusted publishing can only be configured on a package that **already
+exists** on npm. The first CI publish of a new package therefore fails with:
+
+```
+npm error code E404
+npm error 404 Not Found - PUT https://registry.npmjs.org/@launchdarkly%2f<pkg> - Not found
+```
+
+To establish the package before enabling OIDC, do this once:
+
+### 1. Publish a placeholder
+
+```
+./scripts/publish-placeholder-package.sh sdk/@launchdarkly/<your-package>
+```
+
+The script logs you in/out of npm internally and publishes an empty `0.0.0`
+version under the `snapshot` dist-tag, so it never becomes `latest`. You must
+have publish rights to the `@launchdarkly` npm org.
+
+### 2. Configure trusted publishing on npmjs
+
+Follow
+[the npm docs](https://docs.npmjs.com/trusted-publishers#configuring-trusted-publishing)
+on the new package's Settings page, using these values:
+
+| Field             | Value               |
+| ----------------- | ------------------- |
+| Publisher         | GitHub Actions      |
+| Organization      | `launchdarkly`      |
+| Repository        | `observability-sdk` |
+| Workflow filename | `turbo.yml`         |
+
+### 3. Mark the package public
+
+On npmjs, set the package's access to public.
+
+### 4. Release
+
+Re-run the failed `Monorepo` publish (push to `main` or re-run the job). CI
+now publishes the real version over the `0.0.0` placeholder via OIDC.

--- a/scripts/publish-placeholder-package.sh
+++ b/scripts/publish-placeholder-package.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# Publishes a placeholder package to npmjs so that OIDC trusted publishing
+# can be configured. See contributing/publishing.md for details.
+#
+# npm's trusted publishing (OIDC) can only be configured on a package that
+# already exists. A brand-new @launchdarkly/* package therefore fails its
+# first CI publish with a 404 (PUT .../@launchdarkly%2f<pkg> - Not found).
+# Run this once to establish the package, then configure trusted publishing.
+#
+# Usage:
+#   ./scripts/publish-placeholder-package.sh sdk/@launchdarkly/observability-next
+
+set -e
+
+if [ -z "$1" ]; then
+  echo "Usage: $0 <workspace-path>"
+  echo "Example: $0 sdk/@launchdarkly/observability-next"
+  exit 1
+fi
+
+WORKSPACE_PATH="$1"
+
+if [ ! -f "$WORKSPACE_PATH/package.json" ]; then
+  echo "Error: $WORKSPACE_PATH/package.json not found"
+  exit 1
+fi
+
+PACKAGE_NAME=$(./scripts/package-name.sh "$WORKSPACE_PATH")
+echo "Publishing placeholder for: $PACKAGE_NAME"
+
+# We must ensure that we are not publishing a placeholder to a package that already
+# exists on npm.
+if npm view "$PACKAGE_NAME" --json &>/dev/null; then
+  echo "Package $PACKAGE_NAME already exists on npm. Skipping placeholder publish."
+  exit 0
+fi
+
+TEMP_DIR=$(mktemp -d)
+
+cleanup() {
+  echo "Cleaning up temp directory..."
+  rm -rf "$TEMP_DIR"
+  echo "Logging out of npm..."
+  npm logout 2>/dev/null || true
+}
+trap cleanup EXIT
+
+echo "Logging in to npm..."
+npm login
+
+cat > "$TEMP_DIR/package.json" <<EOF
+{
+  "name": "$PACKAGE_NAME",
+  "version": "0.0.0",
+  "description": ""
+}
+EOF
+
+# Publish under the 'snapshot' tag so the empty placeholder does not become
+# the 'latest' version that consumers would install.
+echo "Publishing $PACKAGE_NAME@0.0.0 with tag 'snapshot'..."
+npm publish --tag snapshot --access public "$TEMP_DIR"
+
+echo ""
+echo "Successfully published $PACKAGE_NAME@0.0.0"
+echo ""
+echo "Next steps:"
+echo "  1. Configure trusted publishing on npmjs:"
+echo "     https://docs.npmjs.com/trusted-publishers#configuring-trusted-publishing"
+echo "     Publisher:          GitHub Actions"
+echo "     Organization:       launchdarkly"
+echo "     Repository:         observability-sdk"
+echo "     Workflow filename:  turbo.yml"
+echo "  2. Mark the package as public on npmjs"
+echo "  3. Re-run the failed Monorepo publish (push to main or re-run the job)"


### PR DESCRIPTION
## Problem

The `Monorepo` publish job [failed](https://github.com/launchdarkly/observability-sdk/actions/runs/27785679693/job/82221626654) on the first release of `@launchdarkly/observability-next`:

```
npm error code E404
npm error 404 Not Found - PUT https://registry.npmjs.org/@launchdarkly%2fobservability-next - Not found
```

npm [trusted publishing (OIDC)](https://docs.npmjs.com/trusted-publishers) can only be configured on a package that **already exists** on npm, so a brand-new package's first CI publish always 404s. The package has to be established once before OIDC can take over.

## Fix

Reuses the approach from [`js-core`](https://github.com/launchdarkly/js-core/blob/main/contributing/publishing.md#initial-package-publishing):

- `scripts/publish-placeholder-package.sh` — ports js-core's script (reusing this repo's existing `scripts/package-name.sh`). Publishes an empty `0.0.0` placeholder under the `snapshot` dist-tag so it never becomes `latest`; handles `npm login`/`logout` internally and no-ops if the package already exists.
- `contributing/publishing.md` — documents the one-time bootstrap and the OIDC trusted-publisher values for this repo (workflow `turbo.yml`, repo `observability-sdk`).

## Remaining manual steps (require npm org admin)

This PR adds the tooling/docs. To actually unblock `observability-next`, someone with `@launchdarkly` npm publish rights still needs to:

1. `./scripts/publish-placeholder-package.sh sdk/@launchdarkly/observability-next`
2. Configure trusted publishing on npmjs (Publisher: GitHub Actions, Org: `launchdarkly`, Repo: `observability-sdk`, Workflow: `turbo.yml`)
3. Mark the package public
4. Re-run the failed publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs plus an optional manual script only; no changes to CI publish logic or application runtime.
> 
> **Overview**
> Adds a **one-time bootstrap path** for new `@launchdarkly/*` packages so OIDC trusted publishing can be configured after the package exists on npm (avoiding the first CI `E404`).
> 
> **`scripts/publish-placeholder-package.sh`** publishes an empty `0.0.0` under the `snapshot` tag (not `latest`), resolves the name via `package-name.sh`, skips if the package already exists, and handles `npm login`/`logout` in a temp dir.
> 
> **`contributing/publishing.md`** documents the full flow: run the script, set trusted publisher (`turbo.yml`, `observability-sdk`), make the package public, then re-run the Monorepo publish.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28bcc78b4e0ba822551e77352cecff7a60f7b29a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->