### PR TITLE
fix(ruby): omit nil feature_flag.context.id for invalid contexts

### DIFF
--- a/sdk/@launchdarkly/observability-ruby/lib/launchdarkly_observability/hook.rb
+++ b/sdk/@launchdarkly/observability-ruby/lib/launchdarkly_observability/hook.rb
@@ -91,12 +91,23 @@ module LaunchDarklyObservability
         FEATURE_FLAG_PROVIDER_NAME => 'LaunchDarkly'
       }
 
-      context = series_context.context
-      if context
-        attrs[FEATURE_FLAG_CONTEXT_ID] = context.fully_qualified_key
-      end
+      attrs[FEATURE_FLAG_CONTEXT_ID] = context_id_for(series_context)
 
-      attrs
+      # OpenTelemetry rejects nil attribute values and logs an error for each
+      # one. Drop nils centrally so individual call sites cannot reintroduce the
+      # "invalid attribute value type NilClass" noise (e.g. an invalid context
+      # whose fully_qualified_key is nil).
+      attrs.compact
+    end
+
+    # Returns the fully-qualified context key, or nil if unavailable.
+    #
+    # An invalid context (e.g. a non-string context kind) is still a non-nil
+    # object but yields a nil fully_qualified_key. OpenTelemetry rejects nil
+    # attribute values ("invalid attribute value type NilClass"), so callers
+    # must omit the attribute entirely when this returns nil.
+    def context_id_for(series_context)
+      series_context.context&.fully_qualified_key
     end
 
     def serialize_value(value)
@@ -127,10 +138,7 @@ module LaunchDarklyObservability
         FEATURE_FLAG_PROVIDER_NAME => 'LaunchDarkly'
       }
 
-      context = series_context.context
-      if context
-        event_attributes[FEATURE_FLAG_CONTEXT_ID] = context.fully_qualified_key
-      end
+      event_attributes[FEATURE_FLAG_CONTEXT_ID] = context_id_for(series_context)
 
       if detail.variation_index
         event_attributes[FEATURE_FLAG_RESULT_VARIANT] = detail.variation_index.to_s
@@ -146,7 +154,9 @@ module LaunchDarklyObservability
         add_reason_event_details(event_attributes, reason)
       end
 
-      span.add_event(FEATURE_FLAG_EVENT_NAME, attributes: event_attributes)
+      # See build_before_attributes: drop nil values so a missing context id (or
+      # any future optional attribute) cannot emit a nil-attribute OTel error.
+      span.add_event(FEATURE_FLAG_EVENT_NAME, attributes: event_attributes.compact)
     end
 
     def add_reason_event_details(event_attributes, reason)

--- a/sdk/@launchdarkly/observability-ruby/test/hook_test.rb
+++ b/sdk/@launchdarkly/observability-ruby/test/hook_test.rb
@@ -192,6 +192,47 @@ class HookTest < Minitest::Test
     assert_equal 'org:org-1:user:user-1', span.attributes['feature_flag.context.id']
   end
 
+  # Regression: an invalid context (e.g. a non-string kind) is a non-nil
+  # object whose fully_qualified_key is nil. Setting a nil OTel attribute
+  # raised "OpenTelemetry error: invalid attribute value type NilClass for
+  # key 'feature_flag.context.id'" on every evaluation. The attribute must be
+  # omitted instead.
+  def test_invalid_context_omits_context_id_attribute
+    invalid_context = LaunchDarkly::LDContext.create({ key: 'k', kind: 123 })
+    refute invalid_context.valid?
+    assert_nil invalid_context.fully_qualified_key
+
+    series_context = LaunchDarkly::Interfaces::Hooks::EvaluationSeriesContext.new(
+      'my-flag', invalid_context, false, :variation
+    )
+
+    # Capture OpenTelemetry's error channel. Setting an attribute to nil does not
+    # raise and does not set the attribute (OTel drops it) — the only observable
+    # symptom is an "invalid attribute value type NilClass" error logged here,
+    # which is exactly the noise the customer saw on every evaluation.
+    captured = StringIO.new
+    original_logger = OpenTelemetry.logger
+    OpenTelemetry.logger = ::Logger.new(captured)
+    begin
+      data = @hook.before_evaluation(series_context, {})
+      @hook.after_evaluation(series_context, data, create_evaluation_detail)
+    ensure
+      OpenTelemetry.logger = original_logger
+    end
+
+    refute_match(/invalid .*attribute value type NilClass/, captured.string,
+                 'must not emit an OTel nil-attribute error for an invalid context')
+    refute_match(/feature_flag\.context\.id/, captured.string)
+
+    span = @exporter.finished_spans.first
+    refute_nil span
+    refute span.attributes.key?('feature_flag.context.id')
+
+    flag_event = span.events.find { |e| e.name == 'feature_flag' }
+    refute_nil flag_event
+    refute flag_event.attributes.key?('feature_flag.context.id')
+  end
+
   def test_nil_context_does_not_raise_and_still_records_event
     series_context = LaunchDarkly::Interfaces::Hooks::EvaluationSeriesContext.new(
       'my-flag', nil, false, :variation


### PR DESCRIPTION
## What

When a flag is evaluated with an **invalid context**, the observability plugin's evaluation hook sets `feature_flag.context.id` to `nil`. OpenTelemetry rejects nil attribute values, so it logs an error on every such evaluation — twice (once on the `evaluation` span, once on the `feature_flag` event):

```
OpenTelemetry error: invalid span attribute value type NilClass for key 'feature_flag.context.id' on span 'evaluation'
OpenTelemetry error: invalid event attribute value type NilClass for key 'feature_flag.context.id' on span 'evaluation'
```

This guards on the key itself via `series_context.context&.fully_qualified_key` and `.compact`s the span/event attribute hashes so nil values are dropped centrally — before they reach OTel — for this and any future optional attribute.

## Root cause

The old guard only checked the context object was non-nil:

```ruby
context = series_context.context
if context
  attrs[FEATURE_FLAG_CONTEXT_ID] = context.fully_qualified_key
end
```

But an invalid context (e.g. an empty/missing `key` or a non-string `kind`) is a *present* `LDContext` object whose `fully_qualified_key` is `nil` (`create_invalid_context` → `new(nil, nil, nil, …)` in the server SDK). So we handed OTel a nil value. The fix omits the attribute entirely when the key is unavailable.

## Impact

Cosmetic — telemetry still exports and lands normally (routing is by the `launchdarkly.project_id` resource attribute, not this per-span attribute). But it's noisy in customer logs, and the nil is also a signal that those specific evaluations are running against an invalid context (and therefore falling back to the flag's default value).

## Reported by

Surfaced by a customer integrating the Ruby plugin on Rails after their upgrade — last remaining log noise once auto-instrumentation was working.

## Test plan

- Adds a regression test that captures the OTel error channel and reproduces the exact log lines without the fix.
- `bundle exec rake test` → 115 runs, 338 assertions, 0 failures.

## Follow-up (not in this PR)

`launchdarkly-server-sdk-otel`'s `tracing_hook.rb` has the same nil-context pattern (`evaluation_series_context.context.fully_qualified_key` with no guard). Separate gem; worth a matching fix if/when that surfaces.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Telemetry-only change that omits optional span/event attributes; no evaluation, auth, or export routing behavior changes.
> 
> **Overview**
> Stops OpenTelemetry from logging **invalid attribute value type NilClass** on every flag evaluation when the context is invalid but still a non-nil `LDContext` (e.g. non-string `kind`), where `fully_qualified_key` is nil.
> 
> The evaluation hook no longer gates on `context` alone; it resolves the id via **`context_id_for`** (`series_context.context&.fully_qualified_key`) and **`.compact`s** span and `feature_flag` event attribute hashes in **`build_before_attributes`** and **`add_feature_flag_event`** so nil optional fields are omitted before they reach OTel.
> 
> Adds a regression test that captures the OTel logger and asserts `feature_flag.context.id` is absent on the span and event for invalid contexts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56253e5c678efcac92a609229ce2fba537c075c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->