### PR TITLE
feat: add GraphQL operation attributes to instrumented spans

### DIFF
--- a/sdk/@launchdarkly/observability-node/package.json
+++ b/sdk/@launchdarkly/observability-node/package.json
@@ -50,6 +50,7 @@
 		"@opentelemetry/exporter-metrics-otlp-http": "^0.203.0",
 		"@opentelemetry/exporter-trace-otlp-http": "^0.203.0",
 		"@opentelemetry/instrumentation": "^0.203.0",
+		"@opentelemetry/instrumentation-pg": "^0.69.0",
 		"@opentelemetry/otlp-exporter-base": "^0.203.0",
 		"@opentelemetry/otlp-transformer": "^0.203.0",
 		"@opentelemetry/resources": "^2.0.1",

--- a/sdk/@launchdarkly/observability-react-native/src/listeners/network-listener/network-listener.test.ts
+++ b/sdk/@launchdarkly/observability-react-native/src/listeners/network-listener/network-listener.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi } from 'vitest'
+import { Span } from '@opentelemetry/api'
+import { FetchHook } from './network-listener'
+import { NetworkRecordingOptions } from '../../api/Options'
+
+const createMockSpan = () => {
+	const attributes: Record<string, unknown> = {}
+	let name = 'HTTP POST'
+	const span = {
+		setAttribute: vi.fn((key: string, value: unknown) => {
+			attributes[key] = value
+			return span
+		}),
+		updateName: vi.fn((newName: string) => {
+			name = newName
+			return span
+		}),
+	}
+	return {
+		span: span as unknown as Span,
+		attributes,
+		updateName: span.updateName,
+		getName: () => name,
+	}
+}
+
+// Body recording disabled: GraphQL naming must still happen because it reads
+// only the low-sensitivity operation name/type, never stores the body.
+const recording: NetworkRecordingOptions = { recordHeadersAndBody: false }
+
+describe('FetchHook GraphQL span naming', () => {
+	it('renames a GraphQL fetch and sets semconv attributes', () => {
+		const { span, attributes, getName } = createMockSpan()
+		const body = JSON.stringify({
+			query: 'query GetUser($id: ID!) { user(id: $id) { id } }',
+			operationName: 'GetUser',
+		})
+
+		FetchHook(recording, [])(
+			span,
+			{ body } as RequestInit,
+			undefined as any,
+		)
+
+		expect(attributes['graphql.operation.name']).toBe('GetUser')
+		expect(attributes['graphql.operation.type']).toBe('query')
+		expect(getName()).toBe('query GetUser')
+	})
+
+	it('infers the type for an anonymous query with no operation name', () => {
+		const { span, attributes, getName } = createMockSpan()
+		const body = JSON.stringify({ query: '{ viewer { id } }' })
+
+		FetchHook(recording, [])(
+			span,
+			{ body } as RequestInit,
+			undefined as any,
+		)
+
+		expect(attributes['graphql.operation.type']).toBe('query')
+		expect(attributes['graphql.operation.name']).toBeUndefined()
+		expect(getName()).toBe('query')
+	})
+
+	it('leaves a non-GraphQL fetch untouched', () => {
+		const { span, attributes, updateName } = createMockSpan()
+		const body = JSON.stringify({ hello: 'world' })
+
+		FetchHook(recording, [])(
+			span,
+			{ body } as RequestInit,
+			undefined as any,
+		)
+
+		expect(attributes['graphql.operation.name']).toBeUndefined()
+		expect(updateName).not.toHaveBeenCalled()
+	})
+})

--- a/sdk/@launchdarkly/observability-react-native/src/listeners/network-listener/network-listener.test.ts
+++ b/sdk/@launchdarkly/observability-react-native/src/listeners/network-listener/network-listener.test.ts
@@ -5,32 +5,24 @@ import { NetworkRecordingOptions } from '../../api/Options'
 
 const createMockSpan = () => {
 	const attributes: Record<string, unknown> = {}
-	let name = 'HTTP POST'
+	const updateName = vi.fn()
 	const span = {
 		setAttribute: vi.fn((key: string, value: unknown) => {
 			attributes[key] = value
 			return span
 		}),
-		updateName: vi.fn((newName: string) => {
-			name = newName
-			return span
-		}),
+		updateName,
 	}
-	return {
-		span: span as unknown as Span,
-		attributes,
-		updateName: span.updateName,
-		getName: () => name,
-	}
+	return { span: span as unknown as Span, attributes, updateName }
 }
 
-// Body recording disabled: GraphQL naming must still happen because it reads
+// Body recording disabled: GraphQL tagging must still happen because it reads
 // only the low-sensitivity operation name/type, never stores the body.
 const recording: NetworkRecordingOptions = { recordHeadersAndBody: false }
 
-describe('FetchHook GraphQL span naming', () => {
-	it('renames a GraphQL fetch and sets semconv attributes', () => {
-		const { span, attributes, getName } = createMockSpan()
+describe('FetchHook GraphQL operation attributes', () => {
+	it('sets semconv attributes for a GraphQL fetch without renaming the span', () => {
+		const { span, attributes, updateName } = createMockSpan()
 		const body = JSON.stringify({
 			query: 'query GetUser($id: ID!) { user(id: $id) { id } }',
 			operationName: 'GetUser',
@@ -44,11 +36,12 @@ describe('FetchHook GraphQL span naming', () => {
 
 		expect(attributes['graphql.operation.name']).toBe('GetUser')
 		expect(attributes['graphql.operation.type']).toBe('query')
-		expect(getName()).toBe('query GetUser')
+		// The OTel-generated span name is left as-is (low cardinality).
+		expect(updateName).not.toHaveBeenCalled()
 	})
 
 	it('infers the type for an anonymous query with no operation name', () => {
-		const { span, attributes, getName } = createMockSpan()
+		const { span, attributes, updateName } = createMockSpan()
 		const body = JSON.stringify({ query: '{ viewer { id } }' })
 
 		FetchHook(recording, [])(
@@ -59,7 +52,7 @@ describe('FetchHook GraphQL span naming', () => {
 
 		expect(attributes['graphql.operation.type']).toBe('query')
 		expect(attributes['graphql.operation.name']).toBeUndefined()
-		expect(getName()).toBe('query')
+		expect(updateName).not.toHaveBeenCalled()
 	})
 
 	it('leaves a non-GraphQL fetch untouched', () => {

--- a/sdk/@launchdarkly/observability-react-native/src/listeners/network-listener/network-listener.test.ts
+++ b/sdk/@launchdarkly/observability-react-native/src/listeners/network-listener/network-listener.test.ts
@@ -16,8 +16,7 @@ const createMockSpan = () => {
 	return { span: span as unknown as Span, attributes, updateName }
 }
 
-// Body recording disabled: GraphQL tagging must still happen because it reads
-// only the low-sensitivity operation name/type, never stores the body.
+// Body recording off: tagging must still run.
 const recording: NetworkRecordingOptions = { recordHeadersAndBody: false }
 
 describe('FetchHook GraphQL operation attributes', () => {
@@ -36,7 +35,6 @@ describe('FetchHook GraphQL operation attributes', () => {
 
 		expect(attributes['graphql.operation.name']).toBe('GetUser')
 		expect(attributes['graphql.operation.type']).toBe('query')
-		// The OTel-generated span name is left as-is (low cardinality).
 		expect(updateName).not.toHaveBeenCalled()
 	})
 

--- a/sdk/@launchdarkly/observability-react-native/src/listeners/network-listener/network-listener.ts
+++ b/sdk/@launchdarkly/observability-react-native/src/listeners/network-listener/network-listener.ts
@@ -27,9 +27,11 @@ const applyNetworkAttributes = (
 		return
 	}
 
-	// Give GraphQL requests a useful span name derived from the operation in the
-	// request body. Every GraphQL call hits the same endpoint, so the default
-	// OTel name ("HTTP POST" / "POST /graphql") carries no signal. This runs
+	// Tag GraphQL requests with their operation as OTel semconv attributes so
+	// the UI can show which operation ran — every GraphQL call hits the same
+	// endpoint, so the span name alone is unhelpful. We deliberately leave the
+	// low-cardinality OTel span name as-is (per the HTTP/GraphQL conventions)
+	// and let the UI format the display name from these attributes. This runs
 	// regardless of `recordHeadersAndBody`: the operation name/type are
 	// low-sensitivity and we only read them from the body, never store it.
 	const gql = parseGraphQLOperation(requestBody)
@@ -40,11 +42,6 @@ const applyNetworkAttributes = (
 		if (gql.type) {
 			span.setAttribute('graphql.operation.type', gql.type)
 		}
-		span.updateName(
-			gql.name
-				? `${gql.type ?? 'query'} ${gql.name}`
-				: (gql.type ?? 'graphql'),
-		)
 	}
 
 	if (!recording.recordHeadersAndBody) {

--- a/sdk/@launchdarkly/observability-react-native/src/listeners/network-listener/network-listener.ts
+++ b/sdk/@launchdarkly/observability-react-native/src/listeners/network-listener/network-listener.ts
@@ -27,13 +27,9 @@ const applyNetworkAttributes = (
 		return
 	}
 
-	// Tag GraphQL requests with their operation as OTel semconv attributes so
-	// the UI can show which operation ran — every GraphQL call hits the same
-	// endpoint, so the span name alone is unhelpful. We deliberately leave the
-	// low-cardinality OTel span name as-is (per the HTTP/GraphQL conventions)
-	// and let the UI format the display name from these attributes. This runs
-	// regardless of `recordHeadersAndBody`: the operation name/type are
-	// low-sensitivity and we only read them from the body, never store it.
+	// Tag GraphQL requests with operation attributes (the UI builds the display
+	// name from them); runs even when body recording is off since the operation
+	// name/type are low-sensitivity and the body isn't stored.
 	const gql = parseGraphQLOperation(requestBody)
 	if (gql) {
 		if (gql.name) {

--- a/sdk/@launchdarkly/observability-react-native/src/listeners/network-listener/network-listener.ts
+++ b/sdk/@launchdarkly/observability-react-native/src/listeners/network-listener/network-listener.ts
@@ -1,4 +1,5 @@
 import { Span } from '@opentelemetry/api'
+import { parseGraphQLOperation } from '@launchdarkly/observability-shared'
 import { FetchCustomAttributeFunction } from '@opentelemetry/instrumentation-fetch'
 import { NetworkRecordingOptions } from '../../api/Options'
 import { sanitizeHeaders, sanitizeUrl } from './utils/network-sanitizer'
@@ -24,6 +25,26 @@ const applyNetworkAttributes = (
 
 	if (urlBlocklist.some((blocked) => url.toLowerCase().includes(blocked))) {
 		return
+	}
+
+	// Give GraphQL requests a useful span name derived from the operation in the
+	// request body. Every GraphQL call hits the same endpoint, so the default
+	// OTel name ("HTTP POST" / "POST /graphql") carries no signal. This runs
+	// regardless of `recordHeadersAndBody`: the operation name/type are
+	// low-sensitivity and we only read them from the body, never store it.
+	const gql = parseGraphQLOperation(requestBody)
+	if (gql) {
+		if (gql.name) {
+			span.setAttribute('graphql.operation.name', gql.name)
+		}
+		if (gql.type) {
+			span.setAttribute('graphql.operation.type', gql.type)
+		}
+		span.updateName(
+			gql.name
+				? `${gql.type ?? 'query'} ${gql.name}`
+				: (gql.type ?? 'graphql'),
+		)
 	}
 
 	if (!recording.recordHeadersAndBody) {

--- a/sdk/@launchdarkly/observability-shared/src/index.ts
+++ b/sdk/@launchdarkly/observability-shared/src/index.ts
@@ -2,6 +2,11 @@ export { RECORD_ATTRIBUTE } from './instrumentation/constants'
 export { CustomTraceContextPropagator } from './instrumentation/propagator'
 export type { TracingOrigins } from './instrumentation/types'
 export { getCorsUrlsPattern } from './instrumentation/utils'
+export { parseGraphQLOperation } from './instrumentation/graphql'
+export type {
+	GraphQLOperation,
+	GraphQLOperationType,
+} from './instrumentation/graphql'
 export { CustomSampler } from './sampling/CustomSampler'
 export type { ExportSampler } from './sampling/ExportSampler'
 export type { SamplingResult } from './sampling/ExportSampler'

--- a/sdk/@launchdarkly/observability-shared/src/instrumentation/graphql.test.ts
+++ b/sdk/@launchdarkly/observability-shared/src/instrumentation/graphql.test.ts
@@ -44,6 +44,28 @@ describe('parseGraphQLOperation', () => {
 		})
 	})
 
+	it('takes the type from the named operation in a mixed document', () => {
+		const body = JSON.stringify({
+			query: 'query GetUser { user { id } }\nmutation UpdateUser { updateUser { id } }',
+			operationName: 'UpdateUser',
+		})
+		expect(parseGraphQLOperation(body)).toEqual({
+			name: 'UpdateUser',
+			type: 'mutation',
+		})
+	})
+
+	it('falls back to the first operation when operationName is not in the document', () => {
+		const body = JSON.stringify({
+			query: 'mutation UpdateUser { updateUser { id } }',
+			operationName: 'Missing',
+		})
+		expect(parseGraphQLOperation(body)).toEqual({
+			name: 'Missing',
+			type: 'mutation',
+		})
+	})
+
 	it('parses the name from the document when operationName is absent', () => {
 		const body = JSON.stringify({
 			query: 'query GetTeams { teams { id } }',

--- a/sdk/@launchdarkly/observability-shared/src/instrumentation/graphql.test.ts
+++ b/sdk/@launchdarkly/observability-shared/src/instrumentation/graphql.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from 'vitest'
+import { parseGraphQLOperation } from './graphql'
+
+describe('parseGraphQLOperation', () => {
+	it('extracts name and type from a named query', () => {
+		const body = JSON.stringify({
+			query: 'query GetUser($id: ID!) { user(id: $id) { id } }',
+			operationName: 'GetUser',
+		})
+		expect(parseGraphQLOperation(body)).toEqual({
+			name: 'GetUser',
+			type: 'query',
+		})
+	})
+
+	it('extracts name and type from a named mutation', () => {
+		const body = JSON.stringify({
+			query: 'mutation AddItem($name: String!) { addItem(name: $name) { id } }',
+		})
+		expect(parseGraphQLOperation(body)).toEqual({
+			name: 'AddItem',
+			type: 'mutation',
+		})
+	})
+
+	it('extracts name and type from a named subscription', () => {
+		const body = JSON.stringify({
+			query: 'subscription OnComment { commentAdded { id } }',
+		})
+		expect(parseGraphQLOperation(body)).toEqual({
+			name: 'OnComment',
+			type: 'subscription',
+		})
+	})
+
+	it('prefers the explicit operationName over the document name', () => {
+		const body = JSON.stringify({
+			query: 'query A { a }\nquery B { b }',
+			operationName: 'B',
+		})
+		expect(parseGraphQLOperation(body)).toEqual({
+			name: 'B',
+			type: 'query',
+		})
+	})
+
+	it('parses the name from the document when operationName is absent', () => {
+		const body = JSON.stringify({
+			query: 'query GetTeams { teams { id } }',
+		})
+		expect(parseGraphQLOperation(body)).toEqual({
+			name: 'GetTeams',
+			type: 'query',
+		})
+	})
+
+	it('treats anonymous shorthand as a query with no name', () => {
+		const body = JSON.stringify({ query: '{ viewer { id } }' })
+		expect(parseGraphQLOperation(body)).toEqual({
+			name: undefined,
+			type: 'query',
+		})
+	})
+
+	it('handles an anonymous keyword operation with no name', () => {
+		const body = JSON.stringify({ query: 'mutation { logout }' })
+		expect(parseGraphQLOperation(body)).toEqual({
+			name: undefined,
+			type: 'mutation',
+		})
+	})
+
+	it('describes the first operation in a batched request', () => {
+		const body = JSON.stringify([
+			{ query: 'query First { a }', operationName: 'First' },
+			{ query: 'query Second { b }', operationName: 'Second' },
+		])
+		expect(parseGraphQLOperation(body)).toEqual({
+			name: 'First',
+			type: 'query',
+		})
+	})
+
+	it('accepts an already-parsed object body', () => {
+		expect(
+			parseGraphQLOperation({
+				query: 'query Ping { ping }',
+			}),
+		).toEqual({ name: 'Ping', type: 'query' })
+	})
+
+	it('supports a persisted query that only sends operationName', () => {
+		const body = JSON.stringify({
+			operationName: 'GetUser',
+			extensions: { persistedQuery: { sha256Hash: 'abc' } },
+		})
+		expect(parseGraphQLOperation(body)).toEqual({
+			name: 'GetUser',
+			type: undefined,
+		})
+	})
+
+	it('returns null for a non-GraphQL JSON body', () => {
+		expect(parseGraphQLOperation(JSON.stringify({ foo: 'bar' }))).toBeNull()
+	})
+
+	it('returns null for malformed JSON without throwing', () => {
+		expect(parseGraphQLOperation('{ not json')).toBeNull()
+	})
+
+	it('returns null for empty, null, and undefined bodies', () => {
+		expect(parseGraphQLOperation('')).toBeNull()
+		expect(parseGraphQLOperation(null)).toBeNull()
+		expect(parseGraphQLOperation(undefined)).toBeNull()
+	})
+})

--- a/sdk/@launchdarkly/observability-shared/src/instrumentation/graphql.ts
+++ b/sdk/@launchdarkly/observability-shared/src/instrumentation/graphql.ts
@@ -1,0 +1,95 @@
+export type GraphQLOperationType = 'query' | 'mutation' | 'subscription'
+
+/**
+ * The identity of a GraphQL operation extracted from a request body.
+ */
+export interface GraphQLOperation {
+	name?: string
+	type?: GraphQLOperationType
+}
+
+// Matches the leading operation keyword and its optional name in a GraphQL
+// document, e.g. `query GetUser`, `mutation($id: ID!)`, `subscription OnEvent`.
+const OPERATION_RE = /\b(query|mutation|subscription)\b\s*([A-Za-z_]\w*)?/
+
+/**
+ * Best-effort extraction of a GraphQL operation's name and type from an
+ * outgoing HTTP request body. Returns `null` when the body is not a GraphQL
+ * request, so callers can cheaply skip non-GraphQL traffic.
+ *
+ * Handles the transports used by the common clients (Apollo, urql,
+ * graphql-request):
+ *   - a JSON object `{ query, operationName?, variables? }`
+ *   - a batched array of those objects (the first entry is described)
+ *   - an already-parsed object (not just a JSON string)
+ *
+ * Intentionally regex-based with no dependency on the `graphql` package: this
+ * runs inside an OpenTelemetry instrumentation hook, so it must be synchronous,
+ * exception-safe, and small enough to inline into the browser SDK's bundle.
+ */
+export function parseGraphQLOperation(body: unknown): GraphQLOperation | null {
+	const payload = parseBody(body)
+	if (payload === null || typeof payload !== 'object') {
+		return null
+	}
+
+	// Batched requests send an array of operations; describe the first one.
+	const operation = Array.isArray(payload) ? payload[0] : payload
+	if (!operation || typeof operation !== 'object') {
+		return null
+	}
+
+	const record = operation as Record<string, unknown>
+	const query = typeof record.query === 'string' ? record.query : undefined
+	const operationName =
+		typeof record.operationName === 'string'
+			? record.operationName
+			: undefined
+
+	// A GraphQL request carries a document and/or an explicit operation name.
+	// Anything else (e.g. a plain REST JSON body) is not a GraphQL operation.
+	if (query === undefined && operationName === undefined) {
+		return null
+	}
+
+	const match = query ? OPERATION_RE.exec(query) : null
+	const type =
+		(match?.[1] as GraphQLOperationType | undefined) ?? inferType(query)
+	const name = operationName ?? match?.[2]
+
+	if (name === undefined && type === undefined) {
+		return null
+	}
+
+	return { name, type }
+}
+
+// Accepts an already-parsed object/array verbatim, or parses a JSON string.
+// Returns null for anything that isn't parseable JSON.
+function parseBody(body: unknown): unknown {
+	if (body === null || body === undefined) {
+		return null
+	}
+	if (typeof body === 'object') {
+		return body
+	}
+	if (typeof body !== 'string') {
+		return null
+	}
+	try {
+		return JSON.parse(body)
+	} catch {
+		return null
+	}
+}
+
+// Anonymous shorthand (`{ ... }`) has no operation keyword but is a query per
+// the GraphQL spec.
+function inferType(
+	query: string | undefined,
+): GraphQLOperationType | undefined {
+	if (query !== undefined && /^\s*\{/.test(query)) {
+		return 'query'
+	}
+	return undefined
+}

--- a/sdk/@launchdarkly/observability-shared/src/instrumentation/graphql.ts
+++ b/sdk/@launchdarkly/observability-shared/src/instrumentation/graphql.ts
@@ -1,39 +1,23 @@
 export type GraphQLOperationType = 'query' | 'mutation' | 'subscription'
 
-/**
- * The identity of a GraphQL operation extracted from a request body.
- */
 export interface GraphQLOperation {
 	name?: string
 	type?: GraphQLOperationType
 }
 
-// Matches the leading operation keyword and its optional name in a GraphQL
-// document, e.g. `query GetUser`, `mutation($id: ID!)`, `subscription OnEvent`.
+// Leading operation keyword + optional name, e.g. `query GetUser`.
 const OPERATION_RE = /\b(query|mutation|subscription)\b\s*([A-Za-z_]\w*)?/
 
-/**
- * Best-effort extraction of a GraphQL operation's name and type from an
- * outgoing HTTP request body. Returns `null` when the body is not a GraphQL
- * request, so callers can cheaply skip non-GraphQL traffic.
- *
- * Handles the transports used by the common clients (Apollo, urql,
- * graphql-request):
- *   - a JSON object `{ query, operationName?, variables? }`
- *   - a batched array of those objects (the first entry is described)
- *   - an already-parsed object (not just a JSON string)
- *
- * Intentionally regex-based with no dependency on the `graphql` package: this
- * runs inside an OpenTelemetry instrumentation hook, so it must be synchronous,
- * exception-safe, and small enough to inline into the browser SDK's bundle.
- */
+// Best-effort extraction of a GraphQL operation from a request body (Apollo,
+// urql, graphql-request shapes). Returns null for non-GraphQL bodies. Regex
+// based, no `graphql` dep, so it stays cheap and bundle-friendly.
 export function parseGraphQLOperation(body: unknown): GraphQLOperation | null {
 	const payload = parseBody(body)
 	if (payload === null || typeof payload !== 'object') {
 		return null
 	}
 
-	// Batched requests send an array of operations; describe the first one.
+	// Batched requests send an array; describe the first operation.
 	const operation = Array.isArray(payload) ? payload[0] : payload
 	if (!operation || typeof operation !== 'object') {
 		return null
@@ -46,8 +30,6 @@ export function parseGraphQLOperation(body: unknown): GraphQLOperation | null {
 			? record.operationName
 			: undefined
 
-	// A GraphQL request carries a document and/or an explicit operation name.
-	// Anything else (e.g. a plain REST JSON body) is not a GraphQL operation.
 	if (query === undefined && operationName === undefined) {
 		return null
 	}
@@ -64,8 +46,7 @@ export function parseGraphQLOperation(body: unknown): GraphQLOperation | null {
 	return { name, type }
 }
 
-// Accepts an already-parsed object/array verbatim, or parses a JSON string.
-// Returns null for anything that isn't parseable JSON.
+// Parses a JSON string, or passes an already-parsed object/array through.
 function parseBody(body: unknown): unknown {
 	if (body === null || body === undefined) {
 		return null
@@ -83,8 +64,7 @@ function parseBody(body: unknown): unknown {
 	}
 }
 
-// Anonymous shorthand (`{ ... }`) has no operation keyword but is a query per
-// the GraphQL spec.
+// Anonymous shorthand (`{ ... }`) is a query.
 function inferType(
 	query: string | undefined,
 ): GraphQLOperationType | undefined {

--- a/sdk/@launchdarkly/observability-shared/src/instrumentation/graphql.ts
+++ b/sdk/@launchdarkly/observability-shared/src/instrumentation/graphql.ts
@@ -5,8 +5,9 @@ export interface GraphQLOperation {
 	type?: GraphQLOperationType
 }
 
-// Leading operation keyword + optional name, e.g. `query GetUser`.
-const OPERATION_RE = /\b(query|mutation|subscription)\b\s*([A-Za-z_]\w*)?/
+// Operation keyword + optional name, e.g. `query GetUser`. Global so we can
+// scan every operation in a multi-operation document.
+const OPERATION_RE = /\b(query|mutation|subscription)\b\s*([A-Za-z_]\w*)?/g
 
 // Best-effort extraction of a GraphQL operation from a request body (Apollo,
 // urql, graphql-request shapes). Returns null for non-GraphQL bodies. Regex
@@ -34,7 +35,7 @@ export function parseGraphQLOperation(body: unknown): GraphQLOperation | null {
 		return null
 	}
 
-	const match = query ? OPERATION_RE.exec(query) : null
+	const match = query ? matchOperation(query, operationName) : null
 	const type =
 		(match?.[1] as GraphQLOperationType | undefined) ?? inferType(query)
 	const name = operationName ?? match?.[2]
@@ -44,6 +45,31 @@ export function parseGraphQLOperation(body: unknown): GraphQLOperation | null {
 	}
 
 	return { name, type }
+}
+
+// Finds the relevant operation in the document. When operationName is given,
+// returns that specific operation so the type reflects the named operation in a
+// multi-operation document (which may mix queries and mutations); otherwise, or
+// when the named operation isn't found, returns the first operation.
+function matchOperation(
+	query: string,
+	operationName: string | undefined,
+): RegExpExecArray | null {
+	OPERATION_RE.lastIndex = 0
+	let first: RegExpExecArray | null = null
+	for (
+		let match = OPERATION_RE.exec(query);
+		match !== null;
+		match = OPERATION_RE.exec(query)
+	) {
+		if (operationName === undefined || match[2] === operationName) {
+			return match
+		}
+		if (first === null) {
+			first = match
+		}
+	}
+	return first
 }
 
 // Parses a JSON string, or passes an already-parsed object/array through.

--- a/sdk/@launchdarkly/observability-shared/src/instrumentation/utils.ts
+++ b/sdk/@launchdarkly/observability-shared/src/instrumentation/utils.ts
@@ -1,4 +1,3 @@
-import { parse } from 'graphql'
 import { isLDContextUrl } from '../launchdarkly/urlFilters'
 import { TracingOrigins } from './types'
 

--- a/sdk/highlight-node/package.json
+++ b/sdk/highlight-node/package.json
@@ -40,6 +40,7 @@
 		"@opentelemetry/exporter-metrics-otlp-http": "^0.203.0",
 		"@opentelemetry/exporter-trace-otlp-http": "^0.203.0",
 		"@opentelemetry/instrumentation": "^0.203.0",
+		"@opentelemetry/instrumentation-pg": "^0.69.0",
 		"@opentelemetry/otlp-exporter-base": "^0.203.0",
 		"@opentelemetry/otlp-transformer": "^0.203.0",
 		"@opentelemetry/resources": "^2.0.1",

--- a/sdk/highlight-run/package.json
+++ b/sdk/highlight-run/package.json
@@ -93,6 +93,7 @@
 		"@highlight-run/rrweb": "workspace:*",
 		"@highlight-run/rrweb-rrweb-plugin-sequential-id-record": "workspace:*",
 		"@highlight-run/rrweb-types": "workspace:*",
+		"@launchdarkly/observability-shared": "workspace:*",
 		"@opentelemetry/api": "^1.9.0",
 		"@opentelemetry/exporter-metrics-otlp-http": ">=0.57.1 < 0.200.0",
 		"@opentelemetry/exporter-trace-otlp-http": ">=0.57.1 < 0.200.0",

--- a/sdk/highlight-run/src/client/otel/index.ts
+++ b/sdk/highlight-run/src/client/otel/index.ts
@@ -707,9 +707,8 @@ export const enhanceSpanWithHttpRequestAttributes = (
 	const sanitizedUrl = sanitizeUrl(url)
 	const sanitizedUrlObject = safeParseUrl(sanitizedUrl)
 
-	// Tag GraphQL requests with their operation as OTel semconv attributes so
-	// the UI can show which operation ran. The span name is left as-is to keep
-	// it low-cardinality, per the HTTP/GraphQL semantic conventions.
+	// Tag GraphQL requests with operation attributes; the span name is left as
+	// the low-cardinality OTel default and the UI formats the display name.
 	const gql = parseGraphQLOperation(body)
 	if (gql) {
 		if (gql.name) {

--- a/sdk/highlight-run/src/client/otel/index.ts
+++ b/sdk/highlight-run/src/client/otel/index.ts
@@ -707,9 +707,9 @@ export const enhanceSpanWithHttpRequestAttributes = (
 	const sanitizedUrl = sanitizeUrl(url)
 	const sanitizedUrlObject = safeParseUrl(sanitizedUrl)
 
-	// Give GraphQL requests a useful span name derived from the operation in
-	// the request body. Every GraphQL call hits the same endpoint, so the
-	// default OTel name carries no signal in the trace list.
+	// Tag GraphQL requests with their operation as OTel semconv attributes so
+	// the UI can show which operation ran. The span name is left as-is to keep
+	// it low-cardinality, per the HTTP/GraphQL semantic conventions.
 	const gql = parseGraphQLOperation(body)
 	if (gql) {
 		if (gql.name) {
@@ -718,11 +718,6 @@ export const enhanceSpanWithHttpRequestAttributes = (
 		if (gql.type) {
 			span.setAttribute('graphql.operation.type', gql.type)
 		}
-		span.updateName(
-			gql.name
-				? `${gql.type ?? 'query'} ${gql.name}`
-				: (gql.type ?? 'graphql'),
-		)
 	}
 
 	span.setAttributes({

--- a/sdk/highlight-run/src/client/otel/index.ts
+++ b/sdk/highlight-run/src/client/otel/index.ts
@@ -24,6 +24,7 @@ import {
 	WebTracerProvider,
 } from '@opentelemetry/sdk-trace-web'
 import * as SemanticAttributes from '@opentelemetry/semantic-conventions'
+import { parseGraphQLOperation } from '@launchdarkly/observability-shared'
 import { getResponseBody } from '../listeners/network-listener/utils/fetch-listener'
 import {
 	DEFAULT_URL_BLOCKLIST,
@@ -689,7 +690,7 @@ export const shutdown = async () => {
 	])
 }
 
-const enhanceSpanWithHttpRequestAttributes = (
+export const enhanceSpanWithHttpRequestAttributes = (
 	span: api.Span,
 	body: Request['body'] | RequestInit['body'] | BrowserXHR['_body'],
 	headers:
@@ -706,17 +707,22 @@ const enhanceSpanWithHttpRequestAttributes = (
 	const sanitizedUrl = sanitizeUrl(url)
 	const sanitizedUrlObject = safeParseUrl(sanitizedUrl)
 
-	const stringBody = typeof body === 'string' ? body : String(body)
-	try {
-		const parsedBody = body ? JSON.parse(stringBody) : undefined
-		if (parsedBody?.operationName) {
-			span.setAttribute(
-				'graphql.operation.name',
-				parsedBody.operationName,
-			)
+	// Give GraphQL requests a useful span name derived from the operation in
+	// the request body. Every GraphQL call hits the same endpoint, so the
+	// default OTel name carries no signal in the trace list.
+	const gql = parseGraphQLOperation(body)
+	if (gql) {
+		if (gql.name) {
+			span.setAttribute('graphql.operation.name', gql.name)
 		}
-	} catch {
-		// Ignore parsing errors
+		if (gql.type) {
+			span.setAttribute('graphql.operation.type', gql.type)
+		}
+		span.updateName(
+			gql.name
+				? `${gql.type ?? 'query'} ${gql.name}`
+				: (gql.type ?? 'graphql'),
+		)
 	}
 
 	span.setAttributes({

--- a/sdk/highlight-run/src/client/otel/instrumentation.test.ts
+++ b/sdk/highlight-run/src/client/otel/instrumentation.test.ts
@@ -1259,7 +1259,7 @@ describe('Network Instrumentation Custom Attributes', () => {
 			})
 		})
 
-		describe('graphql operation naming', () => {
+		describe('graphql operation attributes', () => {
 			const createMockSpan = (url: string) => {
 				const attributes: Record<string, unknown> = {
 					'url.full': url,
@@ -1280,7 +1280,7 @@ describe('Network Instrumentation Custom Attributes', () => {
 				return { span: span as unknown as Span, attributes, updateName }
 			}
 
-			it('names a GraphQL request and sets semconv attributes', () => {
+			it('sets semconv attributes without renaming the span', () => {
 				const { span, attributes, updateName } = createMockSpan(
 					'https://api.example.com/graphql',
 				)
@@ -1293,10 +1293,11 @@ describe('Network Instrumentation Custom Attributes', () => {
 
 				expect(attributes['graphql.operation.name']).toBe('GetUser')
 				expect(attributes['graphql.operation.type']).toBe('query')
-				expect(updateName).toHaveBeenCalledWith('query GetUser')
+				// Span name is left as-is (low cardinality) per OTel conventions.
+				expect(updateName).not.toHaveBeenCalled()
 			})
 
-			it('leaves a non-GraphQL request unnamed', () => {
+			it('leaves a non-GraphQL request untouched', () => {
 				const { span, attributes, updateName } = createMockSpan(
 					'https://api.example.com/rest',
 				)

--- a/sdk/highlight-run/src/client/otel/instrumentation.test.ts
+++ b/sdk/highlight-run/src/client/otel/instrumentation.test.ts
@@ -1293,7 +1293,6 @@ describe('Network Instrumentation Custom Attributes', () => {
 
 				expect(attributes['graphql.operation.name']).toBe('GetUser')
 				expect(attributes['graphql.operation.type']).toBe('query')
-				// Span name is left as-is (low cardinality) per OTel conventions.
 				expect(updateName).not.toHaveBeenCalled()
 			})
 

--- a/sdk/highlight-run/src/client/otel/instrumentation.test.ts
+++ b/sdk/highlight-run/src/client/otel/instrumentation.test.ts
@@ -1,15 +1,17 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import {
 	safeParseUrl,
 	sanitizeHeaders,
 	sanitizeUrl,
 } from '../listeners/network-listener/utils/network-sanitizer'
 import {
+	enhanceSpanWithHttpRequestAttributes,
 	parseXhrResponseHeaders,
 	splitHeaderValue,
 	convertHeadersToOtelAttributes,
 	convertSearchParamsToOtelAttributes,
 } from './index'
+import type { Span } from '@opentelemetry/api'
 
 describe('Network Instrumentation Custom Attributes', () => {
 	describe('splitHeaderValue', () => {
@@ -1254,6 +1256,60 @@ describe('Network Instrumentation Custom Attributes', () => {
 				expect(result).toBe(
 					'https://REDACTED:REDACTED@api.example.com/v1/users?AWSAccessKeyId=REDACTED&Signature=REDACTED&filter=active#section',
 				)
+			})
+		})
+
+		describe('graphql operation naming', () => {
+			const createMockSpan = (url: string) => {
+				const attributes: Record<string, unknown> = {
+					'url.full': url,
+				}
+				const updateName = vi.fn()
+				const span = {
+					attributes,
+					setAttribute: (key: string, value: unknown) => {
+						attributes[key] = value
+						return span
+					},
+					setAttributes: (attrs: Record<string, unknown>) => {
+						Object.assign(attributes, attrs)
+						return span
+					},
+					updateName,
+				}
+				return { span: span as unknown as Span, attributes, updateName }
+			}
+
+			it('names a GraphQL request and sets semconv attributes', () => {
+				const { span, attributes, updateName } = createMockSpan(
+					'https://api.example.com/graphql',
+				)
+				const body = JSON.stringify({
+					query: 'query GetUser($id: ID!) { user(id: $id) { id } }',
+					operationName: 'GetUser',
+				})
+
+				enhanceSpanWithHttpRequestAttributes(span, body, {}, undefined)
+
+				expect(attributes['graphql.operation.name']).toBe('GetUser')
+				expect(attributes['graphql.operation.type']).toBe('query')
+				expect(updateName).toHaveBeenCalledWith('query GetUser')
+			})
+
+			it('leaves a non-GraphQL request unnamed', () => {
+				const { span, attributes, updateName } = createMockSpan(
+					'https://api.example.com/rest',
+				)
+
+				enhanceSpanWithHttpRequestAttributes(
+					span,
+					JSON.stringify({ hello: 'world' }),
+					{},
+					undefined,
+				)
+
+				expect(attributes['graphql.operation.name']).toBeUndefined()
+				expect(updateName).not.toHaveBeenCalled()
 			})
 		})
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7408,6 +7408,7 @@ __metadata:
     "@opentelemetry/exporter-metrics-otlp-http": "npm:^0.203.0"
     "@opentelemetry/exporter-trace-otlp-http": "npm:^0.203.0"
     "@opentelemetry/instrumentation": "npm:^0.203.0"
+    "@opentelemetry/instrumentation-pg": "npm:^0.69.0"
     "@opentelemetry/otlp-exporter-base": "npm:^0.203.0"
     "@opentelemetry/otlp-transformer": "npm:^0.203.0"
     "@opentelemetry/resources": "npm:^2.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9249,6 +9249,7 @@ __metadata:
     "@opentelemetry/exporter-metrics-otlp-http": "npm:^0.203.0"
     "@opentelemetry/exporter-trace-otlp-http": "npm:^0.203.0"
     "@opentelemetry/instrumentation": "npm:^0.203.0"
+    "@opentelemetry/instrumentation-pg": "npm:^0.69.0"
     "@opentelemetry/otlp-exporter-base": "npm:^0.203.0"
     "@opentelemetry/otlp-transformer": "npm:^0.203.0"
     "@opentelemetry/resources": "npm:^2.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -28975,6 +28975,7 @@ __metadata:
     "@highlight-run/rrweb-rrweb-plugin-sequential-id-record": "workspace:*"
     "@highlight-run/rrweb-types": "workspace:*"
     "@launchdarkly/js-client-sdk": "npm:^4.0.0"
+    "@launchdarkly/observability-shared": "workspace:*"
     "@opentelemetry/api": "npm:^1.9.0"
     "@opentelemetry/exporter-metrics-otlp-http": "npm:>=0.57.1 < 0.200.0"
     "@opentelemetry/exporter-trace-otlp-http": "npm:>=0.57.1 < 0.200.0"


### PR DESCRIPTION
## Summary

Auto-instrumented GraphQL requests all hit the same endpoint, so their spans show up as a generic `POST /graphql` / `HTTP POST` in the trace list with no indication of which operation ran. This was raised as feedback on the React Native SDK's auto-instrumentation.

This adds a shared, dependency-free `parseGraphQLOperation` helper in `observability-shared` and uses it in both client SDKs to tag GraphQL request spans with the OTel semconv attributes `graphql.operation.name` and `graphql.operation.type`:

- **React Native** (`observability-react-native`): the fetch hook parses the request body and sets the attributes.
- **Browser** (`highlight.run`): `enhanceSpanWithHttpRequestAttributes` (which already runs for both fetch and XHR) now also sets `graphql.operation.type` alongside the existing `graphql.operation.name`. `@launchdarkly/observability` re-exports `highlight.run`, so it's covered too.

**Span names are deliberately left as the low-cardinality, OTel-generated names** (method-based, e.g. `HTTP POST`). Per the OTel [HTTP](https://opentelemetry.io/docs/specs/semconv/http/http-spans/) and [GraphQL](https://opentelemetry.io/docs/specs/semconv/graphql/graphql-spans/) semantic conventions, the high-cardinality operation name belongs in an attribute, not the span name. The friendly display name is formatted in the gonfalon trace UI from these attributes (companion PR: launchdarkly/gonfalon#65434), where it renders as `POST /graphql - query GetUser`.

The parser is intentionally regex-based (no `graphql` dependency) so it tree-shakes into the browser bundle; a stale unused `graphql` import was removed from `observability-shared` to keep it out.

**Known limitation (follow-up):** React Native **XHR** request bodies aren't captured, so XHR-based GraphQL clients won't be tagged yet; the fetch path covers Apollo / urql / graphql-request.

## How did you test this change?

Unit tests (vitest):

- `observability-shared` `parseGraphQLOperation` — 13/13 (named query/mutation/subscription, `operationName`-only, name-from-document, anonymous shorthand, batched array, persisted query, non-GraphQL, malformed JSON)
- `observability-react-native` `network-listener` — 3/3 (attributes set; span name left unchanged)
- `highlight.run` `instrumentation` — 129/129 (incl. GraphQL attribute cases)

`tsc --noEmit` and Prettier are clean on the changed files. Full build / `enforce-size` (256 KB brotli budget) / ESLint run in CI — the change adds only ~40 lines of pure code to the browser bundle, so no size impact is expected.

## Are there any deployment considerations?

No migrations or backfills. Pure client-SDK change; `release-please` will version-bump `observability-react-native` and `highlight.run` on merge. The new `graphql.operation.*` attributes are purely additive and span names are unchanged, so existing saved views / alerts / aggregations keyed on span name are unaffected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive client-side span attributes only; span names and existing alerts keyed on names stay the same, with no server or auth changes.
> 
> **Overview**
> GraphQL HTTP spans can now be distinguished in traces via OTel semconv **`graphql.operation.name`** and **`graphql.operation.type`**, without changing low-cardinality span names.
> 
> A shared, regex-based **`parseGraphQLOperation`** helper is added in **`observability-shared`** (exported from the package) and wired into **React Native** fetch instrumentation and **`highlight.run`**’s **`enhanceSpanWithHttpRequestAttributes`** (fetch and XHR). Tagging runs even when request body recording is off on React Native; only operation metadata is read, not stored as body content.
> 
> The browser path replaces ad-hoc JSON parsing of **`operationName`** with the shared parser (also sets operation type). An unused **`graphql`** import is removed from **`observability-shared`** **`utils.ts`**. **`highlight.run`** takes a workspace dev dependency on **`observability-shared`**. Node SDK **`package.json`** / lockfile also pick up **`@opentelemetry/instrumentation-pg`** as a dev dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 633ee26042e06fbaadef5600d0ad6df8ccc05a28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->