### PR TITLE
fix(observability-android): report service.name and service.version as resource attributes

### DIFF
--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/client/ObservabilityResource.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/client/ObservabilityResource.kt
@@ -34,7 +34,9 @@ internal val DEFAULT_DISTRO_ATTRIBUTES: Map<String, String> = mapOf(
  *  2. `highlight.project_id` = [sdkKey].
  *  3. [distroAttributes] (defaults to [DEFAULT_DISTRO_ATTRIBUTES] — `telemetry.distro.{name,version}`).
  *  4. Caller-supplied [ObservabilityOptions.resourceAttributes].
- *  5. `launchdarkly.application.id`, `launchdarkly.application.version`, `launchdarkly.sdk.version`
+ *  5. `service.name` = [ObservabilityOptions.serviceName] and `service.version` =
+ *     [ObservabilityOptions.serviceVersion], so the configured service identity always wins.
+ *  6. `launchdarkly.application.id`, `launchdarkly.application.version`, `launchdarkly.sdk.version`
  *     when provided (LDClient plugin path only).
  *
  * The metadata-derived attributes (5) come *after* the user's [ObservabilityOptions.resourceAttributes]
@@ -75,6 +77,9 @@ internal fun buildObservabilityResource(
     }
 
     builder.putAll(options.resourceAttributes)
+
+    builder.put("service.name", options.serviceName)
+    builder.put("service.version", options.serviceVersion)
 
     applicationId?.let { builder.put("launchdarkly.application.id", it) }
     applicationVersion?.let { builder.put("launchdarkly.application.version", it) }

--- a/sdk/@launchdarkly/observability-android/lib/src/test/kotlin/com/launchdarkly/observability/client/ObservabilityResourceTest.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/test/kotlin/com/launchdarkly/observability/client/ObservabilityResourceTest.kt
@@ -1,0 +1,43 @@
+package com.launchdarkly.observability.client
+
+import com.launchdarkly.observability.api.ObservabilityOptions
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.api.common.Attributes
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+/**
+ * Unit tests for [buildObservabilityResource], covering the `service.name` / `service.version`
+ * resource attributes that backends use to identify the emitting service.
+ */
+class ObservabilityResourceTest {
+    private val serviceName = AttributeKey.stringKey("service.name")
+    private val serviceVersion = AttributeKey.stringKey("service.version")
+
+    @Test
+    fun `service name and version from options are written to the resource`() {
+        val resource = buildObservabilityResource(
+            sdkKey = "test-key",
+            options = ObservabilityOptions(
+                serviceName = "my-service",
+                serviceVersion = "1.2.3",
+            ),
+        )
+
+        assertEquals("my-service", resource.attributes.get(serviceName))
+        assertEquals("1.2.3", resource.attributes.get(serviceVersion))
+    }
+
+    @Test
+    fun `options service name overrides one supplied via resourceAttributes`() {
+        val resource = buildObservabilityResource(
+            sdkKey = "test-key",
+            options = ObservabilityOptions(
+                serviceName = "configured-service",
+                resourceAttributes = Attributes.of(serviceName, "attr-service"),
+            ),
+        )
+
+        assertEquals("configured-service", resource.attributes.get(serviceName))
+    }
+}


### PR DESCRIPTION
## Summary
- `service.name` (and `service.version`) were missing from exported Android spans/logs/metrics. `buildObservabilityResource()` explicitly strips the OTel default `service.name`, but nothing re-adds it from `ObservabilityOptions.serviceName` — so the resource had no `service.name` and backends couldn't identify the service. The configured `serviceName` only reached Session Replay payloads.
- This mirrors the iOS regression fixed in launchdarkly/swift-launchdarkly-observability#236.
- Fix populates `service.name` / `service.version` from `options.serviceName` / `options.serviceVersion` in the shared resource builder, so both init paths (LDClient plugin `Observability.onPluginsReady` and standalone `LDObserve.init`) get a populated service identity across traces, logs, and metrics.

## Changes
- `ObservabilityResource.buildObservabilityResource()`: add `service.name` / `service.version` resource attributes from options (placed after user `resourceAttributes` so the configured service identity wins, matching iOS).
- Update the attribute-precedence KDoc.
- Add `ObservabilityResourceTest` asserting `service.name` / `service.version` are present and that the option overrides a value supplied via `resourceAttributes`.

## Test plan
- [ ] `./gradlew :lib:test` (runs `ObservabilityResourceTest`).
- [ ] Run an app emitting a span and confirm exported OTLP `resource.attributes` includes `service.name` reflecting `ObservabilityOptions.serviceName`.

Made with [Cursor](https://cursor.com)