### PR TITLE
feat(observability-android): support external session id

### DIFF
--- a/sdk/@launchdarkly/observability-android/lib/build.gradle.kts
+++ b/sdk/@launchdarkly/observability-android/lib/build.gradle.kts
@@ -92,7 +92,9 @@ dependencies {
 
     // OTEL Android Instrumentations
     implementation("io.opentelemetry.android.instrumentation:crash:0.11.0-alpha")
-    implementation("io.opentelemetry.android.instrumentation:activity:0.11.0-alpha")
+    // NOTE: the `activity` instrumentation is intentionally NOT depended on. It is superseded by
+    // LaunchDarkly's own app/screen lifecycle spans and would otherwise double-report; we also
+    // defensively suppress it by name (see ObservabilityService.createOtelRumConfig).
 
     // Use JUnit Jupiter for testing.
     // Testing exporters for telemetry inspection

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/client/LDSessionManager.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/client/LDSessionManager.kt
@@ -1,0 +1,136 @@
+package com.launchdarkly.observability.client
+
+import io.opentelemetry.android.session.Session
+import io.opentelemetry.android.session.SessionIdGenerator
+import io.opentelemetry.android.session.SessionManager
+import io.opentelemetry.android.session.SessionObserver
+import io.opentelemetry.sdk.common.Clock
+import java.util.Collections.synchronizedList
+import kotlin.time.Duration
+
+/**
+ * LaunchDarkly's own [SessionManager], used in place of OpenTelemetry Android's default so we can
+ * **seed the initial session id** ([initialSessionId]). This lets the native observability instance
+ * adopt a session id created elsewhere (e.g. by the JavaScript SDK on the same device), so that
+ * spans, logs, metrics, and Session Replay all report the same `session.id`.
+ *
+ * Injected into [io.opentelemetry.android.OpenTelemetryRumBuilder] via
+ * [io.opentelemetry.android.LDRumSessionManagerAccessor] so it backs OpenTelemetry Android's own
+ * `session.id` span/log appenders as well — making it the single source of session identity.
+ *
+ * Rotation behavior mirrors OpenTelemetry Android's default `SessionManagerImpl` /
+ * `SessionIdTimeoutHandler`:
+ *  - a foreground session never times out;
+ *  - a background gap of at least [backgroundInactivityTimeout] rotates the session on next use;
+ *  - a session older than [maxLifetime] rotates regardless of foreground/background.
+ *
+ * Foreground/background transitions are fed in via [onApplicationForegrounded] /
+ * [onApplicationBackgrounded] (wired from the service's app-lifecycle tracker).
+ *
+ * @param initialSessionId Optional session id to start with. When null or blank, an id is generated
+ *   lazily on first use (matching the default manager).
+ * @param backgroundInactivityTimeout Background inactivity after which the session rotates.
+ * @param maxLifetime Absolute maximum session lifetime before rotation.
+ * @param clock Time source; defaults to the OpenTelemetry default clock.
+ * @param idGenerator Generator for new session ids; defaults to OpenTelemetry's.
+ */
+internal class LDSessionManager(
+    initialSessionId: String? = null,
+    private val backgroundInactivityTimeout: Duration,
+    private val maxLifetime: Duration,
+    private val clock: Clock = Clock.getDefault(),
+    private val idGenerator: SessionIdGenerator = SessionIdGenerator.DEFAULT,
+) : SessionManager {
+
+    private val lock = Any()
+    private val observers = synchronizedList(ArrayList<SessionObserver>())
+
+    // Guarded by [lock].
+    private var session: Session =
+        if (!initialSessionId.isNullOrBlank()) {
+            Session.DefaultSession(initialSessionId, clock.now())
+        } else {
+            // Empty id + (-1) timestamp forces generation on first getSessionId(), exactly like
+            // the default manager's initial Session.NONE.
+            Session.NONE
+        }
+
+    // Timeout bookkeeping, mirroring SessionIdTimeoutHandler.
+    @Volatile
+    private var timeoutStartNanos: Long = clock.nanoTime()
+
+    @Volatile
+    private var state: State = State.FOREGROUND
+
+    override fun addObserver(observer: SessionObserver) {
+        observers.add(observer)
+    }
+
+    override fun getSessionId(): String {
+        val newSession: Session
+        val previousSession: Session
+        val rotated: Boolean
+
+        synchronized(lock) {
+            var candidate = session
+            if (sessionHasExpired() || hasTimedOut()) {
+                candidate = Session.DefaultSession(idGenerator.generateSessionId(), clock.now())
+            }
+            // Bump the inactivity timer after deciding, before notifying (a new span may be created).
+            bump()
+            rotated = candidate !== session
+            previousSession = session
+            if (rotated) {
+                session = candidate
+            }
+            newSession = session
+        }
+
+        if (rotated) {
+            // Notify outside the lock; observers may create spans which call back into getSessionId().
+            observers.forEach { observer ->
+                observer.onSessionEnded(previousSession)
+                observer.onSessionStarted(newSession, previousSession)
+            }
+        }
+        return newSession.getId()
+    }
+
+    /** Marks the app as transitioning to the foreground; the next event settles it to foreground. */
+    fun onApplicationForegrounded() {
+        state = State.TRANSITIONING_TO_FOREGROUND
+    }
+
+    /** Marks the app as backgrounded, after which the inactivity timeout can rotate the session. */
+    fun onApplicationBackgrounded() {
+        state = State.BACKGROUND
+    }
+
+    private fun sessionHasExpired(): Boolean {
+        val elapsed = clock.now() - session.getStartTimestamp()
+        return elapsed >= maxLifetime.inWholeNanoseconds
+    }
+
+    private fun hasTimedOut(): Boolean {
+        // The session never times out while the app is in the foreground.
+        if (state == State.FOREGROUND) return false
+        val elapsed = clock.nanoTime() - timeoutStartNanos
+        return elapsed >= backgroundInactivityTimeout.inWholeNanoseconds
+    }
+
+    private fun bump() {
+        timeoutStartNanos = clock.nanoTime()
+        // The first event after returning to the foreground settles the transitional state.
+        if (state == State.TRANSITIONING_TO_FOREGROUND) {
+            state = State.FOREGROUND
+        }
+    }
+
+    private enum class State {
+        FOREGROUND,
+        BACKGROUND,
+
+        /** Temporary state for the first event after the app is brought back to the foreground. */
+        TRANSITIONING_TO_FOREGROUND,
+    }
+}

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/client/LDSessionManager.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/client/LDSessionManager.kt
@@ -18,7 +18,11 @@ import kotlin.time.Duration
  * [io.opentelemetry.android.LDRumSessionManagerAccessor] so it backs OpenTelemetry Android's own
  * `session.id` span/log appenders as well — making it the single source of session identity.
  *
- * Rotation behavior mirrors OpenTelemetry Android's default `SessionManagerImpl` /
+ * When [initialSessionId] is supplied the session is treated as *custom*: the caller owns the
+ * session lifecycle, so automatic rotation is disabled and the seeded id is used for the lifetime
+ * of this manager (mirrors iOS's `isCustomSession`).
+ *
+ * Otherwise rotation mirrors OpenTelemetry Android's default `SessionManagerImpl` /
  * `SessionIdTimeoutHandler`:
  *  - a foreground session never times out;
  *  - a background gap of at least [backgroundInactivityTimeout] rotates the session on next use;
@@ -27,8 +31,9 @@ import kotlin.time.Duration
  * Foreground/background transitions are fed in via [onApplicationForegrounded] /
  * [onApplicationBackgrounded] (wired from the service's app-lifecycle tracker).
  *
- * @param initialSessionId Optional session id to start with. When null or blank, an id is generated
- *   lazily on first use (matching the default manager).
+ * @param initialSessionId Optional session id to start with. When non-blank the session is custom
+ *   (never auto-rotated). When null or blank, an id is generated lazily on first use and rotated
+ *   automatically (matching the default manager).
  * @param backgroundInactivityTimeout Background inactivity after which the session rotates.
  * @param maxLifetime Absolute maximum session lifetime before rotation.
  * @param clock Time source; defaults to the OpenTelemetry default clock.
@@ -45,10 +50,17 @@ internal class LDSessionManager(
     private val lock = Any()
     private val observers = synchronizedList(ArrayList<SessionObserver>())
 
+    /**
+     * Whether a session id was supplied externally. When true, the caller owns the session
+     * lifecycle, so automatic rotation (background-inactivity timeout and max-lifetime) is disabled
+     * and the seeded id is used for the lifetime of this manager. Mirrors iOS's `isCustomSession`.
+     */
+    private val isCustomSession: Boolean = !initialSessionId.isNullOrBlank()
+
     // Guarded by [lock].
     private var session: Session =
-        if (!initialSessionId.isNullOrBlank()) {
-            Session.DefaultSession(initialSessionId, clock.now())
+        if (isCustomSession) {
+            Session.DefaultSession(initialSessionId!!, clock.now())
         } else {
             // Empty id + (-1) timestamp forces generation on first getSessionId(), exactly like
             // the default manager's initial Session.NONE.
@@ -73,7 +85,8 @@ internal class LDSessionManager(
 
         synchronized(lock) {
             var candidate = session
-            if (sessionHasExpired() || hasTimedOut()) {
+            // An externally supplied session id is never rotated; the caller owns its lifecycle.
+            if (!isCustomSession && (sessionHasExpired() || hasTimedOut())) {
                 candidate = Session.DefaultSession(idGenerator.generateSessionId(), clock.now())
             }
             // Bump the inactivity timer after deciding, before notifying (a new span may be created).

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/client/ObservabilityService.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/client/ObservabilityService.kt
@@ -33,13 +33,11 @@ import com.launchdarkly.observability.sampling.SamplingLogProcessor
 import com.launchdarkly.observability.traces.EventSpanProcessor
 import com.launchdarkly.observability.traces.OtlpTraceExporter
 import com.launchdarkly.observability.util.requireMainThread
+import io.opentelemetry.android.LDRumSessionManagerAccessor
 import io.opentelemetry.android.OpenTelemetryRum
 import io.opentelemetry.android.OpenTelemetryRumBuilder
 import io.opentelemetry.android.config.OtelRumConfig
-import io.opentelemetry.android.instrumentation.AndroidInstrumentation
-import io.opentelemetry.android.instrumentation.InstallationContext
 import io.opentelemetry.android.session.Session
-import io.opentelemetry.android.session.SessionConfig
 import io.opentelemetry.android.session.SessionManager
 import io.opentelemetry.android.session.SessionObserver
 import io.opentelemetry.api.common.AttributeKey
@@ -73,6 +71,7 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.launch
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeUnit
+import kotlin.time.Duration.Companion.hours
 
 /**
  * The [ObservabilityService] can be used for recording observability data such as
@@ -98,9 +97,22 @@ class ObservabilityService(
     private val resources: Resource,
     private val logger: ObserveLogger,
     private val observabilityOptions: ObservabilityOptions,
+    // Optional session id to adopt (e.g. forwarded from another LaunchDarkly SDK on the device) so
+    // all signals share one `session.id`. Null lets the manager generate its own.
+    private val customSessionId: String? = null,
 ) : Observe, TrackEmitting {
     private val otelRUM: OpenTelemetryRum
-    var sessionManager: SessionManager? = null
+
+    // LaunchDarkly's own session manager. Owns session identity for all signals (it also backs the
+    // RUM SDK's `session.id` appenders via LDRumSessionManagerAccessor) and can be seeded with
+    // [customSessionId]. Exposed through [sessionManager] for Session Replay.
+    private val ldSessionManager = LDSessionManager(
+        initialSessionId = customSessionId,
+        backgroundInactivityTimeout = observabilityOptions.sessionBackgroundTimeout,
+        maxLifetime = 4.hours,
+    )
+
+    var sessionManager: SessionManager? = ldSessionManager
         private set
     private var otelMeter: Meter
     private var otelLogger: Logger
@@ -209,8 +221,6 @@ class ObservabilityService(
         registerOtlpExporters()
         val otelRumConfig = createOtelRumConfig()
 
-        var capturedSessionManager: SessionManager? = null
-
         val rumBuilder = OpenTelemetryRum.builder(application, otelRumConfig)
             .addLoggerProviderCustomizer { sdkLoggerProviderBuilder, _ ->
                 return@addLoggerProviderCustomizer configureLoggerProvider(sdkLoggerProviderBuilder)
@@ -222,22 +232,15 @@ class ObservabilityService(
                 return@addMeterProviderCustomizer configureMeterProvider(sdkMeterProviderBuilder)
             }
 
-        rumBuilder.addInstrumentation(object : AndroidInstrumentation {
-            override val name = "ld-session-manager-bridge"
-            override fun install(ctx: InstallationContext) {
-                capturedSessionManager = ctx.sessionManager
-            }
-        })
+        // Use our own session manager (instead of the RUM SDK's default) so we can seed the session
+        // id and keep a single source of session identity across spans, logs, metrics, and replay.
+        LDRumSessionManagerAccessor.setSessionManager(rumBuilder, ldSessionManager)
 
         if (observabilityOptions.instrumentations.launchTime) {
             addLaunchTimeInstrumentation(rumBuilder)
         }
 
         otelRUM = rumBuilder.build()
-        sessionManager = capturedSessionManager
-        if (sessionManager == null) {
-            logger.warn("SessionManager was not captured during OpenTelemetryRum.build(); session-dependent features will be unavailable.")
-        }
 
         // A new session (e.g. after a background timeout) must start with a fresh navigation
         // history, otherwise the first screen_view/Navigate of the new session would resolve
@@ -410,8 +413,9 @@ class ObservabilityService(
     }
 
     private fun createOtelRumConfig(): OtelRumConfig {
+        // Session lifetime/rotation is owned by [ldSessionManager] (injected via
+        // [LDRumSessionManagerAccessor]), so no SessionConfig is applied here.
         val config = OtelRumConfig()
-            .setSessionConfig(SessionConfig(backgroundInactivityTimeout = observabilityOptions.sessionBackgroundTimeout))
 
         if (!observabilityOptions.instrumentations.crashReporting) {
             // Disables [io.opentelemetry.android.instrumentation.crash.CrashReporterInstrumentation.java]
@@ -772,6 +776,12 @@ class ObservabilityService(
      * navigation/track emitters.
      */
     private fun handleAppLifecycleSignal(signal: AppLifecycleSignal) {
+        // Drive the session manager's background-inactivity timeout from the same lifecycle source.
+        when (signal.kind) {
+            AppLifecycleSignal.Kind.FOREGROUND -> ldSessionManager.onApplicationForegrounded()
+            AppLifecycleSignal.Kind.BACKGROUND -> ldSessionManager.onApplicationBackgrounded()
+        }
+
         // Broadcast so Session Replay can emit a breadcrumb independent of the span flags below.
         _appLifecycleFlow.tryEmit(signal)
 
@@ -912,7 +922,7 @@ class ObservabilityService(
         }
     }
 
-    private fun Attributes.addSessionId() = this.toBuilder().put(SESSION_ID_ATTRIBUTE, otelRUM.rumSessionId).build()
+    private fun Attributes.addSessionId() = this.toBuilder().put(SESSION_ID_ATTRIBUTE, ldSessionManager.getSessionId()).build()
 
     companion object {
         private const val METRICS_PATH = "/v1/metrics"

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/client/ObservabilityService.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/client/ObservabilityService.kt
@@ -422,12 +422,13 @@ class ObservabilityService(
             config.suppressInstrumentation("crash")
         }
 
-        // Always disable the OpenTelemetry Android activity instrumentation
+        // Defensively disable the OpenTelemetry Android activity instrumentation
         // ([io.opentelemetry.android.instrumentation.activity.ActivityLifecycleInstrumentation]).
-        // It emits an `AppStart` span plus per-activity lifecycle spans (`Created`, `Resumed`,
-        // `Paused`, `Stopped`, `Destroyed`, `Restarted`). These are now superseded by LaunchDarkly's
-        // own `app_launch`, `app_foreground`/`app_background`, and `screen_view` spans, so leaving
-        // it on would double-report the same app/screen lifecycle.
+        // We no longer depend on that artifact (see lib/build.gradle.kts), so it is normally not on
+        // the classpath; this suppression guards against it being reintroduced transitively by a
+        // host. It emits an `AppStart` span plus per-activity lifecycle spans, which are superseded
+        // by LaunchDarkly's own `app_launch`, `app_foreground`/`app_background`, and `screen_view`
+        // spans, so leaving it on would double-report the same app/screen lifecycle.
         config.suppressInstrumentation("activity")
 
         return config

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/client/ObservabilityService.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/client/ObservabilityService.kt
@@ -3,6 +3,8 @@ package com.launchdarkly.observability.client
 import android.app.Application
 import android.view.MotionEvent
 import android.view.ViewConfiguration
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.ProcessLifecycleOwner
 import com.launchdarkly.observability.context.ObserveLogger
 import com.launchdarkly.observability.api.ObservabilityOptions
 import com.launchdarkly.observability.bridge.emitLog
@@ -313,6 +315,16 @@ class ObservabilityService(
         // App-lifecycle detection runs unconditionally so Session Replay breadcrumbs are always
         // available; the span itself is gated by analytics.appLifecycle inside the handler.
         appLifecycleTracker.start()
+
+        // Prime the session manager with the actual process state. [appLifecycleTracker] only
+        // reports genuine foreground/background transitions (it suppresses the initial replay and
+        // never emits a catch-up background), so if the SDK initializes while the app is already
+        // backgrounded the manager would otherwise stay FOREGROUND and skip background-inactivity
+        // rotation until the next foreground/background cycle. A genuine onStart will later settle
+        // it back to foreground if the app comes forward.
+        if (!ProcessLifecycleOwner.get().lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)) {
+            ldSessionManager.onApplicationBackgrounded()
+        }
 
         // App-launch detection runs unconditionally so the Session Replay `Launch` breadcrumb is
         // always available; the `app_launch` span is gated by analytics.appLaunch inside the handler.

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/plugin/Observability.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/plugin/Observability.kt
@@ -47,11 +47,15 @@ import java.util.Collections
  * @param application The application instance.
  * @param options The options for the plugin.
  * @param mobileKey The primary mobile key used in LDConfig.
+ * @param customSessionId Optional session id to adopt instead of generating one. Lets the native
+ *   instance share a single `session.id` with another LaunchDarkly SDK on the device (e.g. the
+ *   JavaScript SDK in a React Native app). When null, a session id is generated automatically.
  */
 class Observability(
     private val application: Application,
     private val mobileKey: String,
-    private val options: ObservabilityOptions = ObservabilityOptions() // new instance has reasonable defaults
+    private val options: ObservabilityOptions = ObservabilityOptions(), // new instance has reasonable defaults
+    private val customSessionId: String? = null,
 ) : Plugin() {
     var distroAttributes: Map<String, String> = DEFAULT_DISTRO_ATTRIBUTES
     private val logger: ObserveLogger
@@ -112,7 +116,7 @@ class Observability(
         LDObserve.context?.resourceAttributes = resource.attributes
 
         val observabilityService = ObservabilityService(
-            application, sdkKey, resource, logger, options,
+            application, sdkKey, resource, logger, options, customSessionId,
         )
         observabilityClient = observabilityService
         LDObserve.context?.sessionManager = observabilityService.sessionManager

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/sdk/LDObserve.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/sdk/LDObserve.kt
@@ -136,6 +136,9 @@ class LDObserve(private val client: Observe) : Observe {
          * @param replay Optional configuration for session replay. Pass `null` (the default)
          *                      to skip session replay initialization.
          * @param imageCaptureService Optional capture implementation for session replay.
+         * @param customSessionId Optional session id to adopt instead of generating one, so this
+         *                      instance can share a single `session.id` with another LaunchDarkly
+         *                      SDK on the device. When null, a session id is generated automatically.
          */
         fun init(
             application: Application,
@@ -144,6 +147,7 @@ class LDObserve(private val client: Observe) : Observe {
             observability: ObservabilityOptions = ObservabilityOptions(),
             replay: ReplayOptions? = null,
             imageCaptureService: ImageCaptureServicing? = null,
+            customSessionId: String? = null,
         ) {
             val logger = ObserveLogger.build(observability.logAdapter, observability.loggerName, observability.debug)
 
@@ -164,7 +168,7 @@ class LDObserve(private val client: Observe) : Observe {
             // NOTE: the calling thread must not hold any lock the main thread is waiting on, or
             // this will deadlock — see runOnMainThread KDoc.
             runOnMainThread {
-                installObservability(application, mobileKey, resource, logger, observability, obsContext)
+                installObservability(application, mobileKey, resource, logger, observability, obsContext, customSessionId)
                 if (replay != null) {
                     installSessionReplay(
                         replay,
@@ -189,9 +193,10 @@ class LDObserve(private val client: Observe) : Observe {
             logger: ObserveLogger,
             options: ObservabilityOptions,
             obsContext: ObservabilityContext,
+            customSessionId: String? = null,
         ) {
             val service = ObservabilityService(
-                application, mobileKey, resource, logger, options,
+                application, mobileKey, resource, logger, options, customSessionId,
             )
             obsContext.sessionManager = service.sessionManager
             obsContext.userInteractionManager = service.userInteractionManager

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/io/opentelemetry/android/LDRumSessionManagerAccessor.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/io/opentelemetry/android/LDRumSessionManagerAccessor.kt
@@ -1,0 +1,17 @@
+package io.opentelemetry.android
+
+import io.opentelemetry.android.session.SessionManager
+
+/**
+ * Bridges to [OpenTelemetryRumBuilder.setSessionManager], which is package-private in
+ * OpenTelemetry Android. Declaring this object in the same `io.opentelemetry.android` package lets
+ * the LaunchDarkly SDK supply its own [SessionManager] (see
+ * [com.launchdarkly.observability.client.LDSessionManager]) so it backs the RUM SDK's `session.id`
+ * span/log appenders, rather than relying on the default manager captured via an instrumentation.
+ */
+internal object LDRumSessionManagerAccessor {
+    fun setSessionManager(
+        builder: OpenTelemetryRumBuilder,
+        sessionManager: SessionManager,
+    ): OpenTelemetryRumBuilder = builder.setSessionManager(sessionManager)
+}


### PR DESCRIPTION
## Summary

Adds external session id support to the Android observability SDK so a native instance can adopt a session id created elsewhere (e.g. the JavaScript SDK in a React Native app) and report a single shared `session.id` across spans, logs, metrics, and Session Replay. This mirrors the existing iOS capability and unblocks the React Native integration, which will consume a published Android version.

- **`LDSessionManager`** — a LaunchDarkly-owned `io.opentelemetry.android.session.SessionManager` that can be seeded with an external session id (`initialSessionId`). It otherwise replicates OpenTelemetry Android's default rotation semantics: foreground sessions never time out, a background-inactivity gap rotates on next use, and a session older than the max lifetime rotates regardless. It notifies `SessionObserver`s on rotation.
- **`LDRumSessionManagerAccessor`** — a tiny shim declared in the `io.opentelemetry.android` package so it can call the package-private `OpenTelemetryRumBuilder.setSessionManager(...)`. This makes our manager back the RUM SDK's own `session.id` span/log appenders, so it is the single source of session identity.
- **`ObservabilityService`** — injects the custom manager, removes the old `ld-session-manager-bridge` instrumentation + `capturedSessionManager` workaround, drops `SessionConfig` from `OtelRumConfig` (lifetime is now owned by the manager), feeds foreground/background transitions from the app-lifecycle tracker into the manager, and reads `session.id` from it.
- Threads an optional `customSessionId` through the `Observability` plugin constructor and the standalone `LDObserve.init(...)` (both default to `null`).

## Notes

- Stacked on top of `fix/android-service-name`; please merge that first (base of this PR is `fix/android-service-name`).
- React Native wiring (forwarding the JS `session.id` into the Android adapter) is intentionally out of scope here and will follow once this is published.

## Test plan

- [x] `./gradlew :lib:compileDebugKotlin` passes
- [ ] Verify a seeded `customSessionId` is reported on spans, logs, metrics, and Session Replay
- [ ] Verify rotation still occurs after background-inactivity timeout and max lifetime
- [ ] Verify navigation/screen state resets on session rotation

Made with [Cursor](https://cursor.com)