### PR TITLE
fix: MAUI - drop OTel activity instrumentation dependency

### DIFF
--- a/sdk/@launchdarkly/mobile-dotnet/android/native/LDObserve/build.gradle.kts
+++ b/sdk/@launchdarkly/mobile-dotnet/android/native/LDObserve/build.gradle.kts
@@ -89,9 +89,6 @@ dependencies {
     implementation("io.opentelemetry.android.instrumentation:crash:0.11.0-alpha")
     "copyDependencies"("io.opentelemetry.android.instrumentation:crash:0.11.0-alpha")
 
-    implementation("io.opentelemetry.android.instrumentation:activity:0.11.0-alpha")
-    "copyDependencies"("io.opentelemetry.android.instrumentation:activity:0.11.0-alpha")
-
     implementation("io.opentelemetry.android:android-agent:0.11.0-alpha")
     "copyDependencies"("io.opentelemetry.android:android-agent:0.11.0-alpha")
 }

--- a/sdk/@launchdarkly/mobile-dotnet/android/native/LDObserve/src/main/java/com/example/LDObserve/ObservabilityBridge.kt
+++ b/sdk/@launchdarkly/mobile-dotnet/android/native/LDObserve/src/main/java/com/example/LDObserve/ObservabilityBridge.kt
@@ -81,8 +81,10 @@ public class ObservabilityBridge(
                 backendUrl = observability.backendUrl,
                 tracesApi = com.launchdarkly.observability.api.ObservabilityOptions.TracesApi(includeErrors = true, includeSpans = true),
                 metricsApi = com.launchdarkly.observability.api.ObservabilityOptions.MetricsApi.enabled(),
+                // Page views rely on the OTel `activity` instrumentation AAR, which MAUI no longer ships.
+                analytics = com.launchdarkly.observability.api.ObservabilityOptions.Analytics(pageViews = false),
                 instrumentations = com.launchdarkly.observability.api.ObservabilityOptions.Instrumentations(
-                    crashReporting = false, launchTime = observability.launchTime, activityLifecycle = true
+                    crashReporting = false, launchTime = observability.launchTime
                 ),
             )
         } catch (t: Throwable) {


### PR DESCRIPTION
## Summary
- Remove `io.opentelemetry.android.instrumentation:activity:0.11.0-alpha` (both `implementation` and `copyDependencies`) from the MAUI native Android module (`LDObserve/build.gradle.kts`), so the activity instrumentation AAR is no longer copied into the shipped NuGet deps.
- Fix `ObservabilityBridge`, which still passed `activityLifecycle = true` to `Instrumentations(...)` — a parameter removed in #577 (renamed to `analytics.pageViews`). This was a stale reference that no longer compiles against the current `observability-android` lib.
- Since page views rely on the activity instrumentation AAR we no longer ship, explicitly set `analytics.pageViews = false` so the SDK calls `suppressInstrumentation("activity")` instead of relying on the instrumentation just being silently absent.

## Notes
- `instrumentations.screens` / `userTaps` are left at their defaults (`true`): screen detection and Session Replay navigation use Android's own `registerActivityLifecycleCallbacks`, not the OTel `activity` AAR, so they keep working.
- `observability-android/lib` still declares the activity dependency (shared with Flutter); at runtime on MAUI the AAR simply won't be on the classpath and the suppressed instrumentation stays off.

## Test plan
- [ ] MAUI native Android Gradle module compiles (`ObservabilityBridge` no longer references the removed `activityLifecycle` param).
- [ ] Verify the activity instrumentation AAR is absent from `outputs/deps` / the produced NuGet.
- [ ] Smoke test a MAUI sample app: crash reporting + launch time + session replay navigation still function; no page-view spans emitted.

Made with [Cursor](https://cursor.com)