### PR TITLE
feat(session-replay-react-native): configurable otlp/backend endpoints (native passthrough)

### DIFF
--- a/sdk/@launchdarkly/react-native-ld-session-replay/README.md
+++ b/sdk/@launchdarkly/react-native-ld-session-replay/README.md
@@ -50,6 +50,26 @@ await startSessionReplay();
 // later: await stopSessionReplay();
 ```
 
+## Custom endpoints
+
+By default the native session replay and observability instances report to
+LaunchDarkly's production endpoints. To target a different environment (for
+example staging or a proxy), set `otlpEndpoint` and/or `backendUrl`:
+
+```js
+const plugin = createSessionReplayPlugin({
+  isEnabled: true,
+  otlpEndpoint: 'https://otel.observability.app.launchdarkly.com:4318',
+  backendUrl: 'https://pub.observability.app.launchdarkly.com',
+});
+```
+
+`backendUrl` drives the session replay upload endpoint as well: the native
+session replay plugin derives its upload URL from the shared observability
+options, so setting `backendUrl` routes both observability and session replay to
+the same environment. Either option falls back to its production default when
+unset. Both are applied on iOS and Android.
+
 ## Masking sensitive content
 
 ### How the SDK decides what to mask

--- a/sdk/@launchdarkly/react-native-ld-session-replay/android/src/main/java/com/sessionreplayreactnative/SessionReplayClientAdapter.kt
+++ b/sdk/@launchdarkly/react-native-ld-session-replay/android/src/main/java/com/sessionreplayreactnative/SessionReplayClientAdapter.kt
@@ -27,6 +27,11 @@ internal class SessionReplayClientAdapter private constructor() {
     private var serviceName: String = DEFAULT_SERVICE_NAME
     // Optional `service.version` forwarded from JS. null keeps the SDK default.
     private var serviceVersion: String? = null
+    // Optional OTLP endpoint / backend URL forwarded from JS. null keeps the SDK
+    // default. backendUrl also drives the session replay upload endpoint (the
+    // SessionReplay plugin reads it from the shared observability options).
+    private var otlpEndpoint: String? = null
+    private var backendUrl: String? = null
     // Optional session id forwarded from the JS observability SDK so the native observability
     // instance (which emits e.g. `click` spans) seeds its session manager with the same
     // `session.id`. null means the native SDK generates and owns its own session.
@@ -52,6 +57,12 @@ internal class SessionReplayClientAdapter private constructor() {
             this.customSessionId = options?.takeIf { it.hasKey("sessionId") }
                 ?.getString("sessionId")
                 ?.takeIf { it.isNotBlank() }
+            this.otlpEndpoint = options?.takeIf { it.hasKey("otlpEndpoint") }
+                ?.getString("otlpEndpoint")
+                ?.takeIf { it.isNotBlank() }
+            this.backendUrl = options?.takeIf { it.hasKey("backendUrl") }
+                ?.getString("backendUrl")
+                ?.takeIf { it.isNotBlank() }
             this.replayOptions = replayOptionsFrom(options)
         }
     }
@@ -62,6 +73,8 @@ internal class SessionReplayClientAdapter private constructor() {
         val localServiceVersion: String?
         val localCustomSessionId: String?
         val localReplayOptions: ReplayOptions?
+        val localOtlpEndpoint: String?
+        val localBackendUrl: String?
 
         // Capture configuration under the lock, then release it before posting to the main thread.
         synchronized(lock) {
@@ -70,6 +83,8 @@ internal class SessionReplayClientAdapter private constructor() {
             localServiceName = serviceName
             localServiceVersion = serviceVersion
             localCustomSessionId = customSessionId
+            localOtlpEndpoint = otlpEndpoint
+            localBackendUrl = backendUrl
         }
         if (localMobileKey == null || localReplayOptions == null) {
             val msg = "start: configure() was not called — mobile key or options are missing"
@@ -84,7 +99,7 @@ internal class SessionReplayClientAdapter private constructor() {
         Handler(Looper.getMainLooper()).post {
             if (!initialized) {
                 try {
-                    initLDClient(application, localMobileKey, localServiceName, localServiceVersion, localCustomSessionId, localReplayOptions)
+                    initLDClient(application, localMobileKey, localServiceName, localServiceVersion, localCustomSessionId, localReplayOptions, localOtlpEndpoint, localBackendUrl)
                 } catch (e: Exception) {
                     logger.error("start: LDClient.init() threw {0}: {1}", e::class.simpleName, e.message)
                     completion(false, "Session replay failed to initialize.")
@@ -148,7 +163,9 @@ internal class SessionReplayClientAdapter private constructor() {
         serviceName: String,
         serviceVersion: String?,
         customSessionId: String?,
-        replayOptions: ReplayOptions
+        replayOptions: ReplayOptions,
+        otlpEndpoint: String?,
+        backendUrl: String?
     ) {
         logger.debug("initLDClient: calling LDClient.init()")
         // Apply the forwarded service.version only when provided; otherwise keep the SDK default.
@@ -163,14 +180,21 @@ internal class SessionReplayClientAdapter private constructor() {
         if (serviceVersion != null) {
             observabilityOptions = observabilityOptions.copy(serviceVersion = serviceVersion)
         }
+        // Forwarded endpoints (when provided) override the SDK defaults. backendUrl also
+        // drives the session replay upload endpoint, since the SessionReplay plugin reads it
+        // from the shared observability options.
+        if (otlpEndpoint != null) {
+            observabilityOptions = observabilityOptions.copy(otlpEndpoint = otlpEndpoint)
+        }
+        if (backendUrl != null) {
+            observabilityOptions = observabilityOptions.copy(backendUrl = backendUrl)
+        }
         val config = LDConfig.Builder(LDConfig.Builder.AutoEnvAttributes.Enabled)
             .mobileKey(mobileKey)
             .offline(true)
             .plugins(
                 Components.plugins().setPlugins(
                     listOf(
-                        // TODO: Pass JS ObservabilityOptions such as backendUrl,
-                        //  resourceAttributes, and sessionBackgroundTimeout through to here.
                         // Forward the JS observability session id (when provided) so the native
                         // observability instance seeds its session manager with the same
                         // `session.id`, matching iOS. null lets the native SDK own its session.

--- a/sdk/@launchdarkly/react-native-ld-session-replay/example-legacy/src/App.tsx
+++ b/sdk/@launchdarkly/react-native-ld-session-replay/example-legacy/src/App.tsx
@@ -24,6 +24,14 @@ import MaskingScreen from './MaskingScreen';
 import TracingScreen from './TracingScreen';
 import ApiScreen from './ApiScreen';
 
+// Optional endpoint overrides from .env. When unset, the SDK falls back to its
+// production defaults. Passed to both the JS observability plugin (traces, logs,
+// metrics, errors) and the native session replay plugin (which forwards them to
+// the native observability instance, so on-device replay uploads to the same
+// environment), e.g. staging.
+const OTLP_ENDPOINT = LAUNCHDARKLY_OTLP_ENDPOINT || undefined;
+const BACKEND_URL = LAUNCHDARKLY_BACKEND_URL || undefined;
+
 const plugin = createSessionReplayPlugin({
   isEnabled: true,
   serviceName: 'session-replay-rn-legacy-example',
@@ -35,13 +43,9 @@ const plugin = createSessionReplayPlugin({
   maskTestIDs: ['password', 'ssn'],
   unmaskTestIDs: ['safe'],
   minimumAlpha: 0.05,
+  ...(OTLP_ENDPOINT ? {otlpEndpoint: OTLP_ENDPOINT} : {}),
+  ...(BACKEND_URL ? {backendUrl: BACKEND_URL} : {}),
 });
-
-// Optional endpoint overrides from .env. When unset, the SDK falls back to its
-// production defaults. These route the JS observability telemetry (traces, logs,
-// metrics, errors) to the configured environment, e.g. staging.
-const OTLP_ENDPOINT = LAUNCHDARKLY_OTLP_ENDPOINT || undefined;
-const BACKEND_URL = LAUNCHDARKLY_BACKEND_URL || undefined;
 
 const observability = new Observability({
   serviceName: 'session-replay-rn-legacy-example',

--- a/sdk/@launchdarkly/react-native-ld-session-replay/ios/SessionReplayClientAdapter.swift
+++ b/sdk/@launchdarkly/react-native-ld-session-replay/ios/SessionReplayClientAdapter.swift
@@ -19,6 +19,11 @@ public class SessionReplayClientAdapter: NSObject {
   // plugin only (the session replay options have no version). nil keeps the
   // SDK default.
   private var serviceVersion: String?
+  // Optional OTLP endpoint / backend URL forwarded from JS. nil keeps the SDK
+  // default. backendUrl also drives the session replay upload endpoint (the
+  // SessionReplay plugin reads it from the shared observability options).
+  private var otlpEndpoint: String?
+  private var backendUrl: String?
   // Each start()/stop() appends a new Task that awaits the previous one, serializing all work.
   private var lastTask: Task<Void, Never> = Task {}
 
@@ -52,6 +57,18 @@ public class SessionReplayClientAdapter: NSObject {
     } else {
       self.serviceVersion = nil
     }
+    if let otlpEndpoint = (options?["otlpEndpoint"] as? String)?
+      .trimmingCharacters(in: .whitespacesAndNewlines), !otlpEndpoint.isEmpty {
+      self.otlpEndpoint = otlpEndpoint
+    } else {
+      self.otlpEndpoint = nil
+    }
+    if let backendUrl = (options?["backendUrl"] as? String)?
+      .trimmingCharacters(in: .whitespacesAndNewlines), !backendUrl.isEmpty {
+      self.backendUrl = backendUrl
+    } else {
+      self.backendUrl = nil
+    }
   }
 
   private func makeConfig(mobileKey: String, options: SessionReplayOptions) -> LDConfig {
@@ -66,6 +83,11 @@ public class SessionReplayClientAdapter: NSObject {
       // first start — which the auto-start would consume.
       isEnabled: false,
       serviceName: options.serviceName,
+      // Forwarded endpoints (when provided) override the SDK defaults; nil/empty
+      // falls back to the production defaults. backendUrl also drives the session
+      // replay upload endpoint via the shared observability options.
+      otlpEndpoint: self.otlpEndpoint,
+      backendUrl: self.backendUrl,
       sessionBackgroundTimeout: 10,
       /// Disable the underlying KSCrash-based crash reporter that
       crashReporting: .init(source: .none)

--- a/sdk/@launchdarkly/react-native-ld-session-replay/src/NativeSessionReplayReactNative.ts
+++ b/sdk/@launchdarkly/react-native-ld-session-replay/src/NativeSessionReplayReactNative.ts
@@ -15,6 +15,22 @@ export type SessionReplayOptions = {
    * observability-emitted signals.
    */
   serviceVersion?: string;
+
+  /**
+   * Override the OTLP exporter endpoint used by the native observability instance.
+   * When unset, the native SDK uses its production default. Applied to the
+   * observability plugin on iOS and Android.
+   */
+  otlpEndpoint?: string;
+
+  /**
+   * Override the backend URL used by the native observability instance. The native
+   * session replay plugin derives its upload endpoint from this value, so setting
+   * it routes both observability and session replay to the same environment. When
+   * unset, the native SDK uses its production default. Applied on iOS and Android.
+   */
+  backendUrl?: string;
+
   maskTextInputs?: boolean;
   maskWebViews?: boolean;
   maskLabels?: boolean;

--- a/sdk/@launchdarkly/react-native-ld-session-replay/tsconfig.build.json
+++ b/sdk/@launchdarkly/react-native-ld-session-replay/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig",
-  "exclude": ["example", "lib"]
+  "exclude": ["example", "example-legacy", "lib"]
 }


### PR DESCRIPTION
## Summary

Adds `otlpEndpoint` and `backendUrl` to `SessionReplayOptions` and forwards them from JS into the **native** `ObservabilityOptions` on both iOS and Android. Because the native session replay plugin derives its upload endpoint from the shared observability options (`SessionReplayExporter(backendUrl = observabilityContext.options.backendUrl)` on Android; `URL(string: observabilityContext.options.backendUrl)` on iOS), setting `backendUrl` routes **both** observability and on-device session replay to the same environment (e.g. staging). Either option falls back to its production default when unset.

This resolves the existing `TODO` in `SessionReplayClientAdapter.kt` and the gap noted in PR (base branch): previously these endpoints could only be set on the JS observability plugin, so native replay always uploaded to production.

### Changes
- **TS spec** (`NativeSessionReplayReactNative.ts`): add optional `otlpEndpoint` / `backendUrl` to `SessionReplayOptions`.
- **Android** (`SessionReplayClientAdapter.kt`): read both from the options map, thread them through `start()` into `initLDClient`, and apply via `ObservabilityOptions.copy(...)` (only when provided).
- **iOS** (`SessionReplayClientAdapter.swift`): read both from the options dictionary and pass into `ObservabilityOptions(otlpEndpoint:backendUrl:)` (nil/empty falls back to defaults).
- **Example** (`example-legacy/src/App.tsx`): pass the `.env` endpoints to the session replay plugin too (not just the JS observability plugin).
- **README**: new "Custom endpoints" section.

## Test plan
- [x] `yarn jest` (session-replay-react-native): 15/15 pass.
- [ ] iOS legacy build + runtime: replay uploads to the configured (staging) backend.
- [ ] Android legacy build + runtime: replay uploads to the configured (staging) backend.

> Based on branch `andrey/rn75legacy` (legacy-arch support PR #653); retarget to `main` once that merges.

Made with [Cursor](https://cursor.com)