### PR TITLE
feat(observability-react-native): expose LDTracer with withSpan via getTracer()

### DIFF
--- a/sdk/@launchdarkly/observability-react-native/README.md
+++ b/sdk/@launchdarkly/observability-react-native/README.md
@@ -63,6 +63,43 @@ await LDObserve.withSpan('LoadProducts', async (scope) => {
 });
 ```
 
+### Using the OpenTelemetry API directly
+
+If you prefer to follow the standard [OpenTelemetry JS](https://opentelemetry.io/docs/languages/js/)
+documentation, or you need to hand a `Tracer` to a third-party library,
+`LDObserve.getTracer()` returns an [`LDTracer`](https://launchdarkly.github.io/observability-sdk/sdk/@launchdarkly/observability-react-native/interfaces/LDTracer.html)
+— a standard OpenTelemetry [`Tracer`](https://open-telemetry.github.io/opentelemetry-js/interfaces/_opentelemetry_api.Tracer.html)
+plus the async-safe `withSpan` helper. It is wired to the same exporter and
+sampler as the rest of the SDK. It is always safe to call — before the SDK
+finishes initializing (or when `disableTraces` is set) it returns a no-op tracer.
+
+```typescript
+import { LDObserve } from '@launchdarkly/observability-react-native';
+
+const tracer = LDObserve.getTracer();
+
+// Standard OpenTelemetry API
+const span = tracer.startSpan('checkout');
+span.setAttribute('cart.id', 'cart-7');
+span.end();
+
+// Async-safe nested spans (React Native) — same helper as LDObserve.withSpan
+await tracer.withSpan('LoadProducts', async (scope) => {
+  const products = await scope.child('FetchFromApi', async (fetchScope) => {
+    const response = await fetch('https://api.example.com/products');
+    fetchScope.span.setAttribute('http.status_code', response.status);
+    return response.json();
+  });
+  scope.span.setAttribute('product_count', products.length);
+});
+```
+
+> **Context propagation in React Native.** React Native tracks the active span
+> only synchronously (there is no `AsyncLocalStorage`), so it is not restored
+> after an `await`. Use `tracer.withSpan` / `scope.child` (or
+> `LDObserve.withSpan`) for nested async work. See the
+> [Tracing Guide](guides/tracing.md) for details.
+
 ## Guides
 
 - [Tracing Guide](guides/tracing.md) — a cookbook of common tracing patterns (spans, nested operations, error handling, correlated logs, and end-to-end mobile-to-backend traces).

--- a/sdk/@launchdarkly/observability-react-native/guides/tracing.md
+++ b/sdk/@launchdarkly/observability-react-native/guides/tracing.md
@@ -233,7 +233,9 @@ const httpWithErrorHandling = async () => {
 
 ## 4. Automatic `fetch` / `XMLHttpRequest` Instrumentation Under a Custom Parent
 
-The SDK auto-instruments `fetch` and `XMLHttpRequest` (unless `disableTraces` is set). Every network request generates its own span automatically. If a custom span is active at call time, the auto-generated HTTP span becomes its child.
+The SDK auto-instruments `fetch` and `XMLHttpRequest`. Every network request generates its own span automatically. If a custom span is active at call time, the auto-generated HTTP span becomes its child.
+
+> `disableTraces` turns off **custom/public** span APIs (`startSpan`, `getTracer()`, etc.) only. Auto-instrumented network spans and other SDK-internal telemetry continue to be recorded.
 
 ```typescript
 async function syncOrders() {

--- a/sdk/@launchdarkly/observability-react-native/guides/tracing.md
+++ b/sdk/@launchdarkly/observability-react-native/guides/tracing.md
@@ -669,6 +669,67 @@ Like trace headers, the `baggage` header is only attached to requests whose URL 
 
 ---
 
+## 13. Using the OpenTelemetry Tracer Directly
+
+Everything above goes through `LDObserve`, but the SDK is built on standard OpenTelemetry. Call `LDObserve.getTracer()` to get an [`LDTracer`](../src/api/LDTracer.ts) — a standard OpenTelemetry [`Tracer`](https://open-telemetry.github.io/opentelemetry-js/interfaces/_opentelemetry_api.Tracer.html) (`startSpan`, `startActiveSpan`) **plus** the async-safe `withSpan` helper for React Native.
+
+The returned tracer is wired to the same exporter and sampler as the rest of the SDK. It is always safe to call: before the SDK finishes initializing (or when `disableTraces` is set) it returns a no-op tracer.
+
+### Standard OpenTelemetry API
+
+```typescript
+const withTracer = async () => {
+  const tracer = LDObserve.getTracer()
+
+  await tracer.startActiveSpan('Checkout', async (span) => {
+    span.setAttribute('cart.id', 'cart-7')
+    try {
+      const response = await fetch('https://jsonplaceholder.typicode.com/posts')
+      span.setAttribute('http.status_code', response.status)
+      span.setStatus({ code: SpanStatusCode.OK })
+    } catch (err) {
+      span.recordException(err as Error)
+      span.setStatus({ code: SpanStatusCode.ERROR })
+    } finally {
+      span.end()
+    }
+  })
+}
+```
+
+### Async-safe spans via `tracer.withSpan`
+
+For nested work across `await`s, use `tracer.withSpan` — the same helper as [`LDObserve.withSpan`](#0-recommended-withspan-for-nested-async-work), available directly on the tracer:
+
+```typescript
+const withTracerNested = async () => {
+  const tracer = LDObserve.getTracer()
+
+  const count = await tracer.withSpan('LoadProducts', async (load) => {
+    const items = await load.child('FetchFromApi', async (fetchScope) => {
+      const response = await fetch('https://jsonplaceholder.typicode.com/posts')
+      fetchScope.span.setAttribute('http.status_code', response.status)
+      const json = await response.text()
+      return fetchScope.child('DeserializeJson', (parseScope) => {
+        const result = JSON.parse(json) as unknown[]
+        parseScope.span.setAttribute('product_count', result.length)
+        return result
+      })
+    })
+    load.child('RenderUI', (renderScope) => {
+      renderScope.span.setAttribute('product_count', items.length)
+    })
+    return items.length
+  })
+}
+```
+
+`LDObserve.withSpan`, `LDObserve.startSpan`, and `LDObserve.startActiveSpan` all delegate to this same tracer under the hood.
+
+> **The React Native context caveat still applies** when using `startSpan` / `startActiveSpan` directly: the active span is tracked only synchronously and is **not** restored after an `await`. Use `tracer.withSpan` / `scope.child` for nested async work, or thread context explicitly as shown in [recipe 2](#2-nested-spans-for-a-typical-react-native-workflow).
+
+---
+
 ## Quick Reference
 
 ### Span Creation (`LDObserve`)
@@ -682,12 +743,15 @@ Like trace headers, the `baggage` header is only attached to requests whose URL 
 | `startSpan(name, { root: true })` | None (new trace) | `Span` |
 | `runWithHeaders(name, headers, cb, options?)` | Current active span; records `http.header.*` attributes | result of `cb` |
 | `startWithHeaders(name, headers, options?)` | Current active span; records `http.header.*` attributes | `Span` |
+| `getTracer()` | -- | `LDTracer` (OTel `Tracer` + `withSpan`; same exporter/sampler) |
 | `getContextFromSpan(span)` | -- | `Context` (for explicit re-parenting) |
 | `parseHeaders(headers)` | -- | `RequestContext` (`sessionId`, `requestId`) |
 
 > Both `startActiveSpan` and `startSpan` require a manual `span.end()`. The difference is that `startActiveSpan` makes the span active (the current parent) for the duration of its callback, while `startSpan` does not change the active context. `withSpan` is the recommended wrapper: it ends the span automatically and its `scope.child(...)` keeps nesting correct across `await`s.
 
 > **`withSpan` scope** — the callback receives a `SpanScope`: `scope.span` (the OTel `Span`), `scope.child(name, fn, options?)` (start a correctly-parented child), `scope.active(fn)` (run with this span active, e.g. for auto-instrumented `fetch`/XHR after an `await`), and `scope.ctx` (the span's `Context`).
+
+> **`LDTracer.withSpan`** — `getTracer()` returns an `LDTracer`, which adds `tracer.withSpan(name, fn, options?)` with the same `SpanScope` API as `LDObserve.withSpan`. Use it when working in OpenTelemetry style but still need async-safe nesting in React Native.
 
 ### Span Operations (OpenTelemetry `Span`)
 

--- a/sdk/@launchdarkly/observability-react-native/src/api/LDTracer.test.ts
+++ b/sdk/@launchdarkly/observability-react-native/src/api/LDTracer.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { wrapTracer } from './LDTracer'
+import { NOOP_SPAN_OPS } from '../sdk/withSpan'
+import { _LDObserve } from '../sdk/LDObserve'
+import { ObservabilityClient } from '../client/ObservabilityClient'
+
+describe('wrapTracer', () => {
+	it('routes startSpan through SpanOps', () => {
+		const startSpan = vi.fn(() => ({ id: 'span' }))
+		const tracer = wrapTracer({
+			...NOOP_SPAN_OPS,
+			startSpan,
+		})
+
+		tracer.startSpan('test-span', { attributes: { a: 1 } })
+
+		expect(startSpan).toHaveBeenCalledWith(
+			'test-span',
+			{ attributes: { a: 1 } },
+			undefined,
+		)
+	})
+
+	it('routes startActiveSpan overloads through SpanOps', () => {
+		const startActiveSpan = vi.fn((_name, fn) => fn({ id: 'span' }))
+		const tracer = wrapTracer({
+			...NOOP_SPAN_OPS,
+			startActiveSpan,
+		})
+
+		tracer.startActiveSpan('fn-only', (span) => span)
+		tracer.startActiveSpan('with-options', { root: true }, (span) => span)
+		tracer.startActiveSpan(
+			'with-context',
+			{ root: true },
+			{} as any,
+			(span) => span,
+		)
+
+		expect(startActiveSpan).toHaveBeenCalledTimes(3)
+		expect(startActiveSpan).toHaveBeenNthCalledWith(
+			1,
+			'fn-only',
+			expect.any(Function),
+			undefined,
+			undefined,
+		)
+		expect(startActiveSpan).toHaveBeenNthCalledWith(
+			2,
+			'with-options',
+			expect.any(Function),
+			{ root: true },
+			undefined,
+		)
+		expect(startActiveSpan).toHaveBeenNthCalledWith(
+			3,
+			'with-context',
+			expect.any(Function),
+			{ root: true },
+			{},
+		)
+	})
+})
+
+describe('LDObserve getTracer span guards', () => {
+	beforeEach(() => {
+		_LDObserve._resetForTesting()
+	})
+
+	it('returns no-op spans from getTracer().startSpan before init', () => {
+		const span = _LDObserve.getTracer().startSpan('pre-init')
+
+		expect(span.isRecording()).toBe(false)
+		expect(span.spanContext().traceId).toBe(
+			'00000000000000000000000000000000',
+		)
+	})
+
+	it('runs getTracer().startActiveSpan with no-op span before init', () => {
+		let callbackSpan: any = null
+
+		const result = _LDObserve
+			.getTracer()
+			.startActiveSpan('pre-init', (span) => {
+				callbackSpan = span
+				return 'ok'
+			})
+
+		expect(result).toBe('ok')
+		expect(callbackSpan.isRecording()).toBe(false)
+	})
+
+	it('returns a no-op tracer from getTracer() when disableTraces is set', async () => {
+		const client = new ObservabilityClient('sdkKey', {
+			disableTraces: true,
+		})
+
+		_LDObserve._init(client)
+
+		await vi.waitFor(
+			() => {
+				expect(_LDObserve.isInitialized()).toBe(true)
+			},
+			{ timeout: 2000 },
+		)
+
+		const span = _LDObserve.getTracer().startSpan('disabled')
+		expect(span.isRecording()).toBe(false)
+
+		let callbackSpan: any = null
+		_LDObserve.getTracer().startActiveSpan('disabled', (s) => {
+			callbackSpan = s
+			return 'done'
+		})
+		expect(callbackSpan.isRecording()).toBe(false)
+	})
+
+	it('still initializes tracing when disableTraces is set', async () => {
+		const client = new ObservabilityClient('sdkKey', {
+			disableTraces: true,
+		})
+
+		_LDObserve._init(client)
+
+		await vi.waitFor(
+			() => {
+				expect(_LDObserve.isInitialized()).toBe(true)
+			},
+			{ timeout: 2000 },
+		)
+
+		expect(client.getIsInitialized()).toBe(true)
+	})
+})

--- a/sdk/@launchdarkly/observability-react-native/src/api/LDTracer.ts
+++ b/sdk/@launchdarkly/observability-react-native/src/api/LDTracer.ts
@@ -1,0 +1,41 @@
+import { Tracer } from '@opentelemetry/api'
+import { runInSpan, SpanOps } from '../sdk/withSpan'
+import { SpanScope, WithSpanOptions } from './SpanScope'
+
+/**
+ * An OpenTelemetry {@link Tracer} enriched with {@link withSpan} for React
+ * Native, where the active context is tracked only synchronously.
+ *
+ * Returned by {@link Observe.getTracer}. Implements the full standard
+ * `Tracer` API (`startSpan`, `startActiveSpan`) plus the async-safe
+ * {@link LDTracer.withSpan} helper.
+ */
+export interface LDTracer extends Tracer {
+	/**
+	 * Start a span, run `fn` within it, and end the span automatically.
+	 *
+	 * Same behavior as {@link Observe.withSpan}: the callback receives a
+	 * {@link SpanScope} whose {@link SpanScope.child} method parents spans
+	 * correctly across `await`s in React Native.
+	 */
+	withSpan<T>(
+		spanName: string,
+		fn: (scope: SpanScope) => T,
+		options?: WithSpanOptions,
+	): T
+}
+
+/**
+ * Wrap an OpenTelemetry {@link Tracer} with {@link LDTracer.withSpan}.
+ *
+ * @param tracer The underlying OpenTelemetry tracer
+ * @param ops Span operations used by `withSpan` (`startSpan` defaults to
+ *   `tracer.startSpan`; `recordError` is required for error reporting)
+ */
+export function wrapTracer(tracer: Tracer, ops: SpanOps): LDTracer {
+	return {
+		startSpan: tracer.startSpan.bind(tracer),
+		startActiveSpan: tracer.startActiveSpan.bind(tracer),
+		withSpan: (name, fn, options) => runInSpan(ops, name, fn, options),
+	}
+}

--- a/sdk/@launchdarkly/observability-react-native/src/api/LDTracer.ts
+++ b/sdk/@launchdarkly/observability-react-native/src/api/LDTracer.ts
@@ -1,4 +1,9 @@
-import { Tracer } from '@opentelemetry/api'
+import {
+	Context,
+	Span as OtelSpan,
+	SpanOptions,
+	Tracer,
+} from '@opentelemetry/api'
 import { runInSpan, SpanOps } from '../sdk/withSpan'
 import { SpanScope, WithSpanOptions } from './SpanScope'
 
@@ -25,17 +30,46 @@ export interface LDTracer extends Tracer {
 	): T
 }
 
-/**
- * Wrap an OpenTelemetry {@link Tracer} with {@link LDTracer.withSpan}.
- *
- * @param tracer The underlying OpenTelemetry tracer
- * @param ops Span operations used by `withSpan` (`startSpan` defaults to
- *   `tracer.startSpan`; `recordError` is required for error reporting)
- */
-export function wrapTracer(tracer: Tracer, ops: SpanOps): LDTracer {
+function parseStartActiveSpanArgs(
+	name: string,
+	...rest: unknown[]
+): {
+	fn: (span: OtelSpan) => unknown
+	options?: SpanOptions
+	ctx?: Context
+} {
+	if (typeof rest[0] === 'function') {
+		return { fn: rest[0] as (span: OtelSpan) => unknown }
+	}
+	if (typeof rest[1] === 'function') {
+		return {
+			options: rest[0] as SpanOptions,
+			fn: rest[1] as (span: OtelSpan) => unknown,
+		}
+	}
 	return {
-		startSpan: tracer.startSpan.bind(tracer),
-		startActiveSpan: tracer.startActiveSpan.bind(tracer),
+		options: rest[0] as SpanOptions,
+		ctx: rest[1] as Context,
+		fn: rest[2] as (span: OtelSpan) => unknown,
+	}
+}
+
+/**
+ * Wrap span operations with the {@link LDTracer} surface (`startSpan`,
+ * `startActiveSpan`, `withSpan`).
+ *
+ * All three methods delegate to `ops` so callers can enforce SDK guards
+ * (for example `disableTraces`) and pre-init no-op behavior consistently.
+ */
+export function wrapTracer(ops: SpanOps): LDTracer {
+	const startActiveSpan = ((name: string, ...rest: unknown[]) => {
+		const { fn, options, ctx } = parseStartActiveSpanArgs(name, ...rest)
+		return ops.startActiveSpan(name, fn, options, ctx)
+	}) as LDTracer['startActiveSpan']
+
+	return {
+		startSpan: (name, options, ctx) => ops.startSpan(name, options, ctx),
+		startActiveSpan,
 		withSpan: (name, fn, options) => runInSpan(ops, name, fn, options),
 	}
 }

--- a/sdk/@launchdarkly/observability-react-native/src/api/Observe.ts
+++ b/sdk/@launchdarkly/observability-react-native/src/api/Observe.ts
@@ -7,6 +7,7 @@ import {
 import { Metric } from './Metric'
 import { RequestContext } from './RequestContext'
 import { SessionInfo } from '../client/SessionManager'
+import { LDTracer } from './LDTracer'
 import { SpanScope, WithSpanOptions } from './SpanScope'
 import { TrackProperties } from './TrackProperties'
 
@@ -161,6 +162,20 @@ export interface Observe {
 		fn: (scope: SpanScope) => T,
 		options?: WithSpanOptions,
 	): T
+
+	/**
+	 * Get the OpenTelemetry {@link LDTracer} backing this SDK.
+	 *
+	 * Returns a standard OpenTelemetry {@link Tracer} (`startSpan`,
+	 * `startActiveSpan`) plus {@link LDTracer.withSpan} for async-safe nested
+	 * spans in React Native. Use this to follow the official OpenTelemetry JS
+	 * documentation or integrate a third-party library that expects a `Tracer`.
+	 * The tracer is wired to the same exporter/sampler as the rest of the SDK.
+	 *
+	 * Before the SDK finishes initializing (or when `disableTraces` is set) this
+	 * returns a no-op tracer, so it is always safe to call.
+	 */
+	getTracer(): LDTracer
 
 	/**
 	 * Get the context from a span.

--- a/sdk/@launchdarkly/observability-react-native/src/api/Observe.ts
+++ b/sdk/@launchdarkly/observability-react-native/src/api/Observe.ts
@@ -173,7 +173,8 @@ export interface Observe {
 	 * The tracer is wired to the same exporter/sampler as the rest of the SDK.
 	 *
 	 * Before the SDK finishes initializing (or when `disableTraces` is set) this
-	 * returns a no-op tracer, so it is always safe to call.
+	 * returns a no-op tracer, so it is always safe to call. `disableTraces` affects
+	 * only public custom tracing APIs; SDK auto-instrumentation is unaffected.
 	 */
 	getTracer(): LDTracer
 

--- a/sdk/@launchdarkly/observability-react-native/src/api/Options.ts
+++ b/sdk/@launchdarkly/observability-react-native/src/api/Options.ts
@@ -115,7 +115,9 @@ export interface ReactNativeOptions {
 	disableLogs?: boolean
 
 	/**
-	 * Whether traces are disabled.
+	 * Disables public custom tracing APIs (`startSpan`, `startActiveSpan`,
+	 * `withSpan`, `getTracer()`, `track`, `runWithHeaders`, `startWithHeaders`).
+	 * SDK auto-instrumentation (network requests, internal telemetry) is unaffected.
 	 */
 	disableTraces?: boolean
 

--- a/sdk/@launchdarkly/observability-react-native/src/api/index.ts
+++ b/sdk/@launchdarkly/observability-react-native/src/api/index.ts
@@ -1,5 +1,7 @@
 export * from './Options'
 export * from './Metric'
 export * from './RequestContext'
+export type { LDTracer } from './LDTracer'
+export { wrapTracer } from './LDTracer'
 export type { SpanScope, WithSpanOptions } from './SpanScope'
 export type { TrackProperties, TrackPropertyValue } from './TrackProperties'

--- a/sdk/@launchdarkly/observability-react-native/src/client/InstrumentationManager.ts
+++ b/sdk/@launchdarkly/observability-react-native/src/client/InstrumentationManager.ts
@@ -125,8 +125,6 @@ export class InstrumentationManager {
 	}
 
 	private initializeTracing() {
-		if (this.options.disableTraces) return
-
 		const compositePropagator = new CompositePropagator({
 			propagators: [
 				new W3CBaggagePropagator(),

--- a/sdk/@launchdarkly/observability-react-native/src/client/InstrumentationManager.ts
+++ b/sdk/@launchdarkly/observability-react-native/src/client/InstrumentationManager.ts
@@ -57,7 +57,6 @@ import {
 import { CustomBatchSpanProcessor } from '../otel/CustomBatchSpanProcessor'
 import { CustomTraceExporter } from '../otel/CustomTraceExporter'
 import { CustomLogExporter } from '../otel/CustomLogExporter'
-import { LDTracer, wrapTracer } from '../api/LDTracer'
 
 export type InstrumentationManagerOptions = Required<ReactNativeOptions> & {
 	projectId: string
@@ -89,7 +88,6 @@ export class InstrumentationManager {
 		string,
 		UpDownCounter
 	>()
-	private ldTracer?: LDTracer
 
 	constructor(
 		private options: Required<ReactNativeOptions> & {
@@ -171,8 +169,6 @@ export class InstrumentationManager {
 
 		this.traceProvider.register()
 		trace.setGlobalTracerProvider(this.traceProvider)
-		// Any tracer cached before the real provider was registered must be rebuilt.
-		this.ldTracer = undefined
 
 		const corsPattern = getCorsUrlsPattern(this.options.tracingOrigins)
 		const networkRecording = this.options.networkRecording
@@ -522,40 +518,14 @@ export class InstrumentationManager {
 			}
 
 			this.isInitialized = false
-			this.ldTracer = undefined
 			this._log('InstrumentationManager stopped')
 		} catch (e) {
 			console.error('Failed to stop InstrumentationManager:', e)
 		}
 	}
 
-	/**
-	 * Returns the OpenTelemetry {@link Tracer} backing this SDK, enriched with
-	 * {@link LDTracer.withSpan} for React Native async context propagation.
-	 * Falls back to a no-op tracer before initialization.
-	 */
-	public getTracer(): LDTracer {
-		// Never cache a wrapper around the pre-init no-op provider.
-		if (!this.traceProvider) {
-			const noop = trace.getTracerProvider().getTracer(this.serviceName)
-			return wrapTracer(noop, {
-				startSpan: (name, options, ctx) =>
-					noop.startSpan(name, options, ctx),
-				recordError: (error, attributes, options) =>
-					this.recordError(error, attributes, options),
-			})
-		}
-
-		if (!this.ldTracer) {
-			const tracer = this.traceProvider.getTracer(this.serviceName)
-			this.ldTracer = wrapTracer(tracer, {
-				startSpan: (name, options, ctx) =>
-					tracer.startSpan(name, options, ctx),
-				recordError: (error, attributes, options) =>
-					this.recordError(error, attributes, options),
-			})
-		}
-		return this.ldTracer
+	private getTracer() {
+		return trace.getTracerProvider().getTracer(this.serviceName)
 	}
 
 	private getLogger() {

--- a/sdk/@launchdarkly/observability-react-native/src/client/InstrumentationManager.ts
+++ b/sdk/@launchdarkly/observability-react-native/src/client/InstrumentationManager.ts
@@ -57,6 +57,7 @@ import {
 import { CustomBatchSpanProcessor } from '../otel/CustomBatchSpanProcessor'
 import { CustomTraceExporter } from '../otel/CustomTraceExporter'
 import { CustomLogExporter } from '../otel/CustomLogExporter'
+import { LDTracer, wrapTracer } from '../api/LDTracer'
 
 export type InstrumentationManagerOptions = Required<ReactNativeOptions> & {
 	projectId: string
@@ -88,6 +89,7 @@ export class InstrumentationManager {
 		string,
 		UpDownCounter
 	>()
+	private ldTracer?: LDTracer
 
 	constructor(
 		private options: Required<ReactNativeOptions> & {
@@ -169,6 +171,8 @@ export class InstrumentationManager {
 
 		this.traceProvider.register()
 		trace.setGlobalTracerProvider(this.traceProvider)
+		// Any tracer cached before the real provider was registered must be rebuilt.
+		this.ldTracer = undefined
 
 		const corsPattern = getCorsUrlsPattern(this.options.tracingOrigins)
 		const networkRecording = this.options.networkRecording
@@ -518,14 +522,40 @@ export class InstrumentationManager {
 			}
 
 			this.isInitialized = false
+			this.ldTracer = undefined
 			this._log('InstrumentationManager stopped')
 		} catch (e) {
 			console.error('Failed to stop InstrumentationManager:', e)
 		}
 	}
 
-	private getTracer() {
-		return trace.getTracerProvider().getTracer(this.serviceName)
+	/**
+	 * Returns the OpenTelemetry {@link Tracer} backing this SDK, enriched with
+	 * {@link LDTracer.withSpan} for React Native async context propagation.
+	 * Falls back to a no-op tracer before initialization.
+	 */
+	public getTracer(): LDTracer {
+		// Never cache a wrapper around the pre-init no-op provider.
+		if (!this.traceProvider) {
+			const noop = trace.getTracerProvider().getTracer(this.serviceName)
+			return wrapTracer(noop, {
+				startSpan: (name, options, ctx) =>
+					noop.startSpan(name, options, ctx),
+				recordError: (error, attributes, options) =>
+					this.recordError(error, attributes, options),
+			})
+		}
+
+		if (!this.ldTracer) {
+			const tracer = this.traceProvider.getTracer(this.serviceName)
+			this.ldTracer = wrapTracer(tracer, {
+				startSpan: (name, options, ctx) =>
+					tracer.startSpan(name, options, ctx),
+				recordError: (error, attributes, options) =>
+					this.recordError(error, attributes, options),
+			})
+		}
+		return this.ldTracer
 	}
 
 	private getLogger() {

--- a/sdk/@launchdarkly/observability-react-native/src/client/ObservabilityClient.ts
+++ b/sdk/@launchdarkly/observability-react-native/src/client/ObservabilityClient.ts
@@ -4,6 +4,7 @@ import type {
 	Span as OtelSpan,
 	SpanOptions,
 } from '@opentelemetry/api'
+import { LDTracer } from '../api/LDTracer'
 import { context } from '@opentelemetry/api'
 import { resourceFromAttributes } from '@opentelemetry/resources'
 import {
@@ -247,6 +248,10 @@ export class ObservabilityClient {
 			ctx || context.active(),
 			fn,
 		)
+	}
+
+	public getTracer(): LDTracer {
+		return this.instrumentationManager.getTracer()
 	}
 
 	public getContextFromSpan(span: OtelSpan): Context {

--- a/sdk/@launchdarkly/observability-react-native/src/client/ObservabilityClient.ts
+++ b/sdk/@launchdarkly/observability-react-native/src/client/ObservabilityClient.ts
@@ -5,7 +5,8 @@ import type {
 	SpanOptions,
 } from '@opentelemetry/api'
 import { LDTracer, wrapTracer } from '../api/LDTracer'
-import { context, trace } from '@opentelemetry/api'
+import { context } from '@opentelemetry/api'
+import { NOOP_SPAN_OPS } from '../sdk/withSpan'
 import { resourceFromAttributes } from '@opentelemetry/resources'
 import {
 	ATTR_SERVICE_NAME,
@@ -253,15 +254,27 @@ export class ObservabilityClient {
 
 	public getTracer(): LDTracer {
 		if (!this.ldTracer) {
-			const otelTracer = trace
-				.getTracerProvider()
-				.getTracer(this.options.serviceName)
-			this.ldTracer = wrapTracer(otelTracer, {
-				startSpan: (name, options, ctx) =>
-					this.startSpan(name, options, ctx),
-				recordError: (error, attributes, options) =>
-					this.consumeCustomError(error, attributes, options),
-			})
+			if (this.options.disableTraces) {
+				this.ldTracer = wrapTracer(NOOP_SPAN_OPS)
+			} else {
+				this.ldTracer = wrapTracer({
+					startSpan: (name, options, ctx) =>
+						this.instrumentationManager.startSpan(
+							name,
+							options,
+							ctx,
+						),
+					startActiveSpan: (name, fn, options, ctx) =>
+						this.instrumentationManager.startActiveSpan(
+							name,
+							options || {},
+							ctx || context.active(),
+							fn,
+						),
+					recordError: (error, attributes, options) =>
+						this.consumeCustomError(error, attributes, options),
+				})
+			}
 		}
 		return this.ldTracer
 	}

--- a/sdk/@launchdarkly/observability-react-native/src/client/ObservabilityClient.ts
+++ b/sdk/@launchdarkly/observability-react-native/src/client/ObservabilityClient.ts
@@ -4,8 +4,8 @@ import type {
 	Span as OtelSpan,
 	SpanOptions,
 } from '@opentelemetry/api'
-import { LDTracer } from '../api/LDTracer'
-import { context } from '@opentelemetry/api'
+import { LDTracer, wrapTracer } from '../api/LDTracer'
+import { context, trace } from '@opentelemetry/api'
 import { resourceFromAttributes } from '@opentelemetry/resources'
 import {
 	ATTR_SERVICE_NAME,
@@ -32,6 +32,7 @@ export class ObservabilityClient {
 	private errorInstrumentation?: ErrorInstrumentation
 	private options: InstrumentationManagerOptions
 	private isInitialized = false
+	private ldTracer?: LDTracer
 
 	constructor(
 		private readonly sdkKey: string,
@@ -251,7 +252,18 @@ export class ObservabilityClient {
 	}
 
 	public getTracer(): LDTracer {
-		return this.instrumentationManager.getTracer()
+		if (!this.ldTracer) {
+			const otelTracer = trace
+				.getTracerProvider()
+				.getTracer(this.options.serviceName)
+			this.ldTracer = wrapTracer(otelTracer, {
+				startSpan: (name, options, ctx) =>
+					this.startSpan(name, options, ctx),
+				recordError: (error, attributes, options) =>
+					this.consumeCustomError(error, attributes, options),
+			})
+		}
+		return this.ldTracer
 	}
 
 	public getContextFromSpan(span: OtelSpan): Context {
@@ -270,6 +282,7 @@ export class ObservabilityClient {
 		}
 
 		await this.instrumentationManager.stop()
+		this.ldTracer = undefined
 		this.isInitialized = false
 	}
 

--- a/sdk/@launchdarkly/observability-react-native/src/internal/internalSpans.ts
+++ b/sdk/@launchdarkly/observability-react-native/src/internal/internalSpans.ts
@@ -1,0 +1,19 @@
+import { Span as OtelSpan, SpanOptions, trace } from '@opentelemetry/api'
+
+const DEFAULT_SERVICE_NAME = 'launchdarkly-observability-react-native'
+
+/**
+ * SDK-internal spans bypass {@link ReactNativeOptions.disableTraces}, which
+ * applies only to public custom tracing APIs.
+ */
+export function startInternalActiveSpan<T>(
+	serviceName: string | undefined,
+	name: string,
+	fn: (span: OtelSpan) => T,
+	options?: SpanOptions,
+): T {
+	return trace
+		.getTracerProvider()
+		.getTracer(serviceName ?? DEFAULT_SERVICE_NAME)
+		.startActiveSpan(name, options ?? {}, fn)
+}

--- a/sdk/@launchdarkly/observability-react-native/src/plugin/observability.ts
+++ b/sdk/@launchdarkly/observability-react-native/src/plugin/observability.ts
@@ -3,6 +3,7 @@ import { ReactNativeOptions } from '../api/Options'
 import { TrackProperties } from '../api/TrackProperties'
 import { flattenTrackProperties } from '../utils/trackAttributes'
 import { ObservabilityClient } from '../client/ObservabilityClient'
+import { startInternalActiveSpan } from '../internal/internalSpans'
 import { _LDObserve } from '../sdk/LDObserve'
 import type {
 	LDEvaluationDetail,
@@ -124,21 +125,25 @@ class TracingHook implements Hook {
 
 			const allAttributes = { ...this.metaAttributes, ...eventAttributes }
 
-			_LDObserve.startActiveSpan(FEATURE_FLAG_SPAN_NAME, (span) => {
-				span.addEvent(FEATURE_FLAG_SCOPE, allAttributes)
+			startInternalActiveSpan(
+				this._options?.serviceName,
+				FEATURE_FLAG_SPAN_NAME,
+				(span) => {
+					span.addEvent(FEATURE_FLAG_SCOPE, allAttributes)
 
-				span.setAttributes({
-					[FEATURE_FLAG_KEY_ATTR]: hookContext.flagKey,
-					[FEATURE_FLAG_PROVIDER_ATTR]: 'LaunchDarkly',
-					[FEATURE_FLAG_VALUE_ATTR]: JSON.stringify(detail.value),
-					// Mark this as SDK-internal telemetry so it can be filtered
-					// out universally (independent of instrumentation scope).
-					[LD_INTERNAL_ATTR]: true,
-				})
+					span.setAttributes({
+						[FEATURE_FLAG_KEY_ATTR]: hookContext.flagKey,
+						[FEATURE_FLAG_PROVIDER_ATTR]: 'LaunchDarkly',
+						[FEATURE_FLAG_VALUE_ATTR]: JSON.stringify(detail.value),
+						// Mark this as SDK-internal telemetry so it can be filtered
+						// out universally (independent of instrumentation scope).
+						[LD_INTERNAL_ATTR]: true,
+					})
 
-				span.setStatus({ code: 1 })
-				span.end()
-			})
+					span.setStatus({ code: 1 })
+					span.end()
+				},
+			)
 
 			_LDObserve.recordLog(
 				`Feature flag "${hookContext.flagKey}" evaluated`,
@@ -179,11 +184,15 @@ class TracingHook implements Hook {
 					: {}),
 			}
 
-			_LDObserve.startActiveSpan(LD_TRACK_SPAN_NAME, (span) => {
-				span.setAttributes(trackAttributes)
-				span.setStatus({ code: 1 })
-				span.end()
-			})
+			startInternalActiveSpan(
+				this._options?.serviceName,
+				LD_TRACK_SPAN_NAME,
+				(span) => {
+					span.setAttributes(trackAttributes)
+					span.setStatus({ code: 1 })
+					span.end()
+				},
+			)
 		} catch (error) {
 			_LDObserve.recordError(error as Error, {
 				'track.key': hookContext.key,

--- a/sdk/@launchdarkly/observability-react-native/src/sdk/LDObserve.test.ts
+++ b/sdk/@launchdarkly/observability-react-native/src/sdk/LDObserve.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { _LDObserve } from './LDObserve'
 import { ObservabilityClient } from '../client/ObservabilityClient'
 
@@ -103,6 +103,24 @@ describe('LDObserve Buffering', () => {
 
 			expect(callbackSpan).toBeTruthy()
 			expect(callbackSpan.isRecording()).toBe(false)
+		})
+
+		it('should upgrade getTracer() obtained before init after client loads', async () => {
+			const earlyTracer = _LDObserve.getTracer()
+			const client = new ObservabilityClient('sdkKey', {})
+			const getTracerSpy = vi.spyOn(client, 'getTracer')
+
+			_LDObserve._init(client)
+
+			await vi.waitFor(
+				() => {
+					expect(_LDObserve.isInitialized()).toBe(true)
+				},
+				{ timeout: 2000 },
+			)
+
+			earlyTracer.startSpan('post-init-span')
+			expect(getTracerSpy).toHaveBeenCalled()
 		})
 	})
 })

--- a/sdk/@launchdarkly/observability-react-native/src/sdk/LDObserve.ts
+++ b/sdk/@launchdarkly/observability-react-native/src/sdk/LDObserve.ts
@@ -22,6 +22,40 @@ class LDObserveClass
 	extends BufferedClass<ObservabilityClient>
 	implements Observe
 {
+	private _lazyTracer?: LDTracer
+
+	private _resolveTracer(): LDTracer {
+		if (this._isLoaded) {
+			return this._sdk.getTracer()
+		}
+		return wrapTracer(
+			trace.getTracer('launchdarkly-observability-react-native'),
+			NOOP_SPAN_OPS,
+		)
+	}
+
+	private _getLazyTracer(): LDTracer {
+		if (!this._lazyTracer) {
+			this._lazyTracer = {
+				startSpan: (name, options, ctx) =>
+					this._resolveTracer().startSpan(name, options, ctx),
+				startActiveSpan: ((name: string, ...rest: unknown[]) =>
+					(this._resolveTracer().startActiveSpan as Function)(
+						name,
+						...rest,
+					)) as LDTracer['startActiveSpan'],
+				withSpan: (name, fn, options) =>
+					this._resolveTracer().withSpan(name, fn, options),
+			}
+		}
+		return this._lazyTracer
+	}
+
+	_resetForTesting(): void {
+		this._lazyTracer = undefined
+		super._resetForTesting()
+	}
+
 	recordError(
 		error: Error,
 		attributes?: Attributes,
@@ -153,13 +187,7 @@ class LDObserveClass
 	}
 
 	getTracer(): LDTracer {
-		const response = this._bufferCall('getTracer', [])
-		return this._isLoaded
-			? response
-			: wrapTracer(
-					trace.getTracer('launchdarkly-observability-react-native'),
-					NOOP_SPAN_OPS,
-				)
+		return this._getLazyTracer()
 	}
 
 	getContextFromSpan(span: OtelSpan): Context {

--- a/sdk/@launchdarkly/observability-react-native/src/sdk/LDObserve.ts
+++ b/sdk/@launchdarkly/observability-react-native/src/sdk/LDObserve.ts
@@ -4,7 +4,10 @@ import {
 	Context,
 	Span as OtelSpan,
 	SpanOptions,
+	trace,
 } from '@opentelemetry/api'
+import { wrapTracer } from '../api/LDTracer'
+import type { LDTracer } from '../api/LDTracer'
 import { ObservabilityClient } from '../client/ObservabilityClient'
 import { Metric } from '../api/Metric'
 import { RequestContext } from '../api/RequestContext'
@@ -143,11 +146,19 @@ class LDObserveClass
 		fn: (scope: SpanScope) => T,
 		options?: WithSpanOptions,
 	): T {
-		// When loaded, `this` provides real startSpan/recordError that execute
-		// immediately (no buffering). Before init we use no-op span ops so the
-		// callback still runs without enqueueing stray spans.
-		const ops: SpanOps = this._isLoaded ? this : NOOP_SPAN_OPS
-		return runInSpan(ops, spanName, fn, options)
+		return this._isLoaded
+			? this.getTracer().withSpan(spanName, fn, options)
+			: runInSpan(NOOP_SPAN_OPS, spanName, fn, options)
+	}
+
+	getTracer(): LDTracer {
+		const response = this._bufferCall('getTracer', [])
+		return this._isLoaded
+			? response
+			: wrapTracer(
+					trace.getTracer('launchdarkly-observability-react-native'),
+					NOOP_SPAN_OPS,
+				)
 	}
 
 	getContextFromSpan(span: OtelSpan): Context {

--- a/sdk/@launchdarkly/observability-react-native/src/sdk/LDObserve.ts
+++ b/sdk/@launchdarkly/observability-react-native/src/sdk/LDObserve.ts
@@ -4,7 +4,6 @@ import {
 	Context,
 	Span as OtelSpan,
 	SpanOptions,
-	trace,
 } from '@opentelemetry/api'
 import { wrapTracer } from '../api/LDTracer'
 import type { LDTracer } from '../api/LDTracer'
@@ -28,10 +27,7 @@ class LDObserveClass
 		if (this._isLoaded) {
 			return this._sdk.getTracer()
 		}
-		return wrapTracer(
-			trace.getTracer('launchdarkly-observability-react-native'),
-			NOOP_SPAN_OPS,
-		)
+		return wrapTracer(NOOP_SPAN_OPS)
 	}
 
 	private _getLazyTracer(): LDTracer {

--- a/sdk/@launchdarkly/observability-react-native/src/sdk/LDObserve.ts
+++ b/sdk/@launchdarkly/observability-react-native/src/sdk/LDObserve.ts
@@ -146,9 +146,10 @@ class LDObserveClass
 		fn: (scope: SpanScope) => T,
 		options?: WithSpanOptions,
 	): T {
-		return this._isLoaded
-			? this.getTracer().withSpan(spanName, fn, options)
-			: runInSpan(NOOP_SPAN_OPS, spanName, fn, options)
+		// When loaded, `this` routes recordError through consumeCustomError (respects
+		// disableErrorTracking). Before init we use no-op span ops.
+		const ops: SpanOps = this._isLoaded ? this : NOOP_SPAN_OPS
+		return runInSpan(ops, spanName, fn, options)
 	}
 
 	getTracer(): LDTracer {

--- a/sdk/@launchdarkly/observability-react-native/src/sdk/withSpan.ts
+++ b/sdk/@launchdarkly/observability-react-native/src/sdk/withSpan.ts
@@ -18,6 +18,12 @@ import { noOpSpan } from '../utils/NoOpSpan'
  */
 export interface SpanOps {
 	startSpan(spanName: string, options?: SpanOptions, ctx?: Context): OtelSpan
+	startActiveSpan<T>(
+		spanName: string,
+		fn: (span: OtelSpan) => T,
+		options?: SpanOptions,
+		ctx?: Context,
+	): T
 	recordError(
 		error: Error,
 		attributes?: Attributes,
@@ -33,6 +39,7 @@ export interface SpanOps {
  */
 export const NOOP_SPAN_OPS: SpanOps = {
 	startSpan: () => noOpSpan,
+	startActiveSpan: (_spanName, fn) => fn(noOpSpan),
 	recordError: () => {},
 }
 

--- a/sdk/@launchdarkly/react-native-ld-session-replay/example-launch.md
+++ b/sdk/@launchdarkly/react-native-ld-session-replay/example-launch.md
@@ -7,9 +7,11 @@ This package ships two example apps:
 | New arch        | `example`        | New (Fabric/Turbo)   | 0.83         |
 | Legacy arch     | `example-legacy` | Legacy (bridge)      | 0.78         |
 
-Both consume the workspace packages (`@launchdarkly/session-replay-react-native`,
-`@launchdarkly/observability-react-native`) directly from local source, so any
-change you make to the library is picked up by a Metro reload / rebuild.
+Both consume the workspace packages from local source via Metro (`metro.config.js`
+maps `@launchdarkly/session-replay-react-native` and
+`@launchdarkly/observability-react-native` to their `src/` entry points), so any
+change you make to the library is picked up by a Metro reload — no separate
+`yarn build` in the observability package is required for the examples.
 
 ## Prerequisites
 
@@ -123,3 +125,17 @@ own web examples instead.
   `bundle exec pod install --project-directory=ios` (new arch).
 - **Stale native module after editing the library:** rebuild the native app
   (`yarn ios` / `yarn android`); a Metro reload only refreshes JS.
+- **JS observability changes not showing up:** restart Metro with a clean cache
+  (`yarn start --reset-cache`). The examples resolve both workspace SDKs from
+  `src/`; if Metro fails on OpenTelemetry subpath imports (e.g.
+  `@opentelemetry/otlp-exporter-base/browser-http`), ensure `metro.config.js`
+  has `unstable_enablePackageExports: true` (already set for both examples).
+  As a fallback, remove the observability `sourcePackageEntries` mapping and
+  run `yarn build` inside `@launchdarkly/observability-react-native` to use
+  the prebundled `dist/` instead.
+- **JS spans missing but native replay traces appear:** these are separate
+  pipelines — JS spans go through `LDObserve` / OpenTelemetry OTLP export;
+  native replay uses the session-replay native module. Check the Tracing tab
+  **Session info** button (`initialized=true`) and tap **Flush** after creating
+  spans. With `debug: true` in `App.tsx`, look for `[InstrumentationManager]
+  Tracing initialized` in the Metro console.

--- a/sdk/@launchdarkly/react-native-ld-session-replay/example-legacy/metro.config.js
+++ b/sdk/@launchdarkly/react-native-ld-session-replay/example-legacy/metro.config.js
@@ -13,6 +13,10 @@ const sdkPackages = path.resolve(__dirname, '../..');
 // Several of those packages' dependencies (@opentelemetry/*, graphql) are
 // hoisted to the monorepo root node_modules, so it must be resolvable too.
 const monorepoNodeModules = path.resolve(__dirname, '../../../../node_modules');
+const observabilityNodeModules = path.resolve(
+  __dirname,
+  '../../observability-react-native/node_modules',
+);
 
 /**
  * Metro configuration
@@ -34,7 +38,14 @@ config.watchFolders = [
 config.resolver.nodeModulesPaths = [
   ...(config.resolver.nodeModulesPaths || []),
   monorepoNodeModules,
+  observabilityNodeModules,
 ];
+
+// RN 0.78 / Metro 0.81: package.json "exports" subpaths (e.g.
+// @opentelemetry/otlp-exporter-base/browser-http) are not resolved unless
+// enabled. Required when bundling @launchdarkly/observability-react-native
+// from source — the prebuilt dist/ inlines these deps and does not hit Metro.
+config.resolver.unstable_enablePackageExports = true;
 
 // This monorepo has SEVERAL different react-native versions installed (the root
 // has 0.76.x, @launchdarkly/observability-react-native ships its own 0.79.x as a
@@ -61,6 +72,10 @@ const sourcePackageEntries = {
     __dirname,
     '../src/index.tsx',
   ),
+  '@launchdarkly/observability-react-native': path.resolve(
+    __dirname,
+    '../../observability-react-native/src/index.ts',
+  ),
 };
 
 const defaultResolveRequest = config.resolver.resolveRequest;
@@ -68,6 +83,23 @@ config.resolver.resolveRequest = (context, moduleName, platform) => {
   const sourceEntry = sourcePackageEntries[moduleName];
   if (sourceEntry) {
     return context.resolveRequest(context, sourceEntry, platform);
+  }
+  // OpenTelemetry OTLP exporters import subpaths like
+  // `@opentelemetry/otlp-exporter-base/browser-http`. Assert the browser
+  // export condition so Metro picks the RN-compatible build.
+  if (
+    moduleName === '@opentelemetry/otlp-exporter-base/browser-http' ||
+    moduleName.startsWith('@opentelemetry/otlp-exporter-base/')
+  ) {
+    return context.resolveRequest(
+      {
+        ...context,
+        unstable_enablePackageExports: true,
+        unstable_conditionNames: ['browser', 'require', 'react-native', 'default'],
+      },
+      moduleName,
+      platform,
+    );
   }
   for (const [name, target] of Object.entries(forcedSingletons)) {
     if (moduleName === name || moduleName.startsWith(`${name}/`)) {

--- a/sdk/@launchdarkly/react-native-ld-session-replay/example-legacy/metro.config.js
+++ b/sdk/@launchdarkly/react-native-ld-session-replay/example-legacy/metro.config.js
@@ -95,7 +95,12 @@ config.resolver.resolveRequest = (context, moduleName, platform) => {
       {
         ...context,
         unstable_enablePackageExports: true,
-        unstable_conditionNames: ['browser', 'require', 'react-native', 'default'],
+        unstable_conditionNames: [
+          'browser',
+          'require',
+          'react-native',
+          'default',
+        ],
       },
       moduleName,
       platform,

--- a/sdk/@launchdarkly/react-native-ld-session-replay/example-legacy/src/ApiScreen.tsx
+++ b/sdk/@launchdarkly/react-native-ld-session-replay/example-legacy/src/ApiScreen.tsx
@@ -10,7 +10,7 @@ import {
 import {LDObserve} from '@launchdarkly/observability-react-native';
 import type {SpanScope} from '@launchdarkly/observability-react-native';
 import {useLDClient} from '@launchdarkly/react-native-client-sdk';
-import {context} from '@opentelemetry/api';
+import {context, SpanStatusCode, type Span} from '@opentelemetry/api';
 
 /**
  * Manual test screen that mirrors the iOS TestApp `MainMenuViewModel`
@@ -84,6 +84,53 @@ export default function ApiScreen() {
     log(
       '[nested] NestedSpan > NestedSpan1 > NestedSpan2 (+ counter, log, http)',
     );
+  };
+
+  // -- getTracer(): standard OpenTelemetry startActiveSpan ----------------
+  const tracerStartActiveSpan = async () => {
+    const tracer = LDObserve.getTracer();
+    await tracer.startActiveSpan('Checkout', async (span: Span) => {
+      span.setAttribute('cart.id', 'cart-7');
+      try {
+        const response = await fetch(
+          'https://jsonplaceholder.typicode.com/posts',
+        );
+        span.setAttribute('http.status_code', response.status);
+        span.setStatus({code: SpanStatusCode.OK});
+        log(`[tracer] startActiveSpan Checkout status=${response.status}`);
+      } catch (err) {
+        span.recordException(err as Error);
+        span.setStatus({code: SpanStatusCode.ERROR});
+        log(`[tracer] Checkout threw: ${(err as Error).message}`);
+      } finally {
+        span.end();
+      }
+    });
+  };
+
+  // -- getTracer(): async-safe nested spans via tracer.withSpan -------------
+  const tracerWithSpanNested = async () => {
+    const tracer = LDObserve.getTracer();
+    await tracer.withSpan('LoadProducts', async (load: SpanScope) => {
+      const items = await load.child('FetchFromApi', async (fetchScope: SpanScope) => {
+        const response = await fetch(
+          'https://jsonplaceholder.typicode.com/posts',
+        );
+        fetchScope.span.setAttribute('http.status_code', response.status);
+        const json = await response.text();
+        return fetchScope.child('DeserializeJson', (parseScope: SpanScope) => {
+          const result = JSON.parse(json) as unknown[];
+          parseScope.span.setAttribute('product_count', result.length);
+          return result;
+        });
+      });
+      load.child('RenderUI', (renderScope: SpanScope) => {
+        renderScope.span.setAttribute('product_count', items.length);
+      });
+      log(
+        `[tracer] withSpan LoadProducts > FetchFromApi > DeserializeJson / RenderUI (${items.length})`,
+      );
+    });
   };
 
   // Auto-instrumented fetch spans only attach to the active span when `fetch`
@@ -357,6 +404,18 @@ export default function ApiScreen() {
           <Btn
             label="Nested spans"
             onPress={run('nested', triggerNestedSpans)}
+          />
+        </View>
+
+        <SectionHeader title="OpenTelemetry Tracer (getTracer)" topSpacing />
+        <View style={styles.col}>
+          <Btn
+            label="Tracer · startActiveSpan"
+            onPress={run('tracer-active', tracerStartActiveSpan)}
+          />
+          <Btn
+            label="Tracer · withSpan (nested)"
+            onPress={run('tracer-withSpan', tracerWithSpanNested)}
           />
         </View>
 

--- a/sdk/@launchdarkly/react-native-ld-session-replay/example-legacy/src/ApiScreen.tsx
+++ b/sdk/@launchdarkly/react-native-ld-session-replay/example-legacy/src/ApiScreen.tsx
@@ -112,18 +112,24 @@ export default function ApiScreen() {
   const tracerWithSpanNested = async () => {
     const tracer = LDObserve.getTracer();
     await tracer.withSpan('LoadProducts', async (load: SpanScope) => {
-      const items = await load.child('FetchFromApi', async (fetchScope: SpanScope) => {
-        const response = await fetch(
-          'https://jsonplaceholder.typicode.com/posts',
-        );
-        fetchScope.span.setAttribute('http.status_code', response.status);
-        const json = await response.text();
-        return fetchScope.child('DeserializeJson', (parseScope: SpanScope) => {
-          const result = JSON.parse(json) as unknown[];
-          parseScope.span.setAttribute('product_count', result.length);
-          return result;
-        });
-      });
+      const items = await load.child(
+        'FetchFromApi',
+        async (fetchScope: SpanScope) => {
+          const response = await fetch(
+            'https://jsonplaceholder.typicode.com/posts',
+          );
+          fetchScope.span.setAttribute('http.status_code', response.status);
+          const json = await response.text();
+          return fetchScope.child(
+            'DeserializeJson',
+            (parseScope: SpanScope) => {
+              const result = JSON.parse(json) as unknown[];
+              parseScope.span.setAttribute('product_count', result.length);
+              return result;
+            },
+          );
+        },
+      );
       load.child('RenderUI', (renderScope: SpanScope) => {
         renderScope.span.setAttribute('product_count', items.length);
       });

--- a/sdk/@launchdarkly/react-native-ld-session-replay/example-legacy/src/TracingScreen.tsx
+++ b/sdk/@launchdarkly/react-native-ld-session-replay/example-legacy/src/TracingScreen.tsx
@@ -421,24 +421,33 @@ export default function TracingScreen() {
   // -- 13b. Async-safe nested spans via tracer.withSpan -------------------
   const tracerWithSpanNested = async () => {
     const tracer = LDObserve.getTracer();
-    const count = await tracer.withSpan('LoadProducts', async (load: SpanScope) => {
-      const items = await load.child('FetchFromApi', async (fetchScope: SpanScope) => {
-        const response = await fetch(
-          'https://jsonplaceholder.typicode.com/posts',
+    const count = await tracer.withSpan(
+      'LoadProducts',
+      async (load: SpanScope) => {
+        const items = await load.child(
+          'FetchFromApi',
+          async (fetchScope: SpanScope) => {
+            const response = await fetch(
+              'https://jsonplaceholder.typicode.com/posts',
+            );
+            fetchScope.span.setAttribute('http.status_code', response.status);
+            const json = await response.text();
+            return fetchScope.child(
+              'DeserializeJson',
+              (parseScope: SpanScope) => {
+                const result = JSON.parse(json) as unknown[];
+                parseScope.span.setAttribute('product_count', result.length);
+                return result;
+              },
+            );
+          },
         );
-        fetchScope.span.setAttribute('http.status_code', response.status);
-        const json = await response.text();
-        return fetchScope.child('DeserializeJson', (parseScope: SpanScope) => {
-          const result = JSON.parse(json) as unknown[];
-          parseScope.span.setAttribute('product_count', result.length);
-          return result;
+        load.child('RenderUI', (renderScope: SpanScope) => {
+          renderScope.span.setAttribute('product_count', items.length);
         });
-      });
-      load.child('RenderUI', (renderScope: SpanScope) => {
-        renderScope.span.setAttribute('product_count', items.length);
-      });
-      return items.length;
-    });
+        return items.length;
+      },
+    );
     log(
       `[13b] tracer.withSpan LoadProducts > FetchFromApi > DeserializeJson / RenderUI (${count})`,
     );

--- a/sdk/@launchdarkly/react-native-ld-session-replay/example-legacy/src/TracingScreen.tsx
+++ b/sdk/@launchdarkly/react-native-ld-session-replay/example-legacy/src/TracingScreen.tsx
@@ -8,6 +8,7 @@ import {
   View,
 } from 'react-native';
 import {LDObserve} from '@launchdarkly/observability-react-native';
+import type {SpanScope} from '@launchdarkly/observability-react-native';
 import {
   context,
   propagation,
@@ -25,7 +26,7 @@ import {
  * IDs where relevant) to the on-screen log. The observability plugin is wired up
  * in App.tsx with `tracingOrigins` set to the demo API hosts used below, so the
  * backend-propagation recipes (11, 12) actually inject `traceparent` / `baggage`
- * headers.
+ * headers. Recipes 13a/13b exercise {@link LDObserve.getTracer} (`LDTracer`).
  *
  * Note: with a placeholder mobile key the SDK still creates spans locally; export
  * to LaunchDarkly only happens once a real key is configured.
@@ -395,6 +396,54 @@ export default function TracingScreen() {
     );
   };
 
+  // -- 13a. Standard OpenTelemetry API via getTracer() --------------------
+  const tracerStartActiveSpan = async () => {
+    const tracer = LDObserve.getTracer();
+    await tracer.startActiveSpan('Checkout', async (span: Span) => {
+      span.setAttribute('cart.id', 'cart-7');
+      try {
+        const response = await fetch(
+          'https://jsonplaceholder.typicode.com/posts',
+        );
+        span.setAttribute('http.status_code', response.status);
+        span.setStatus({code: SpanStatusCode.OK});
+        log(`[13a] tracer.startActiveSpan Checkout trace=${traceOf(span)}`);
+      } catch (err) {
+        span.recordException(err as Error);
+        span.setStatus({code: SpanStatusCode.ERROR});
+        log(`[13a] Checkout threw: ${(err as Error).message}`);
+      } finally {
+        span.end();
+      }
+    });
+  };
+
+  // -- 13b. Async-safe nested spans via tracer.withSpan -------------------
+  const tracerWithSpanNested = async () => {
+    const tracer = LDObserve.getTracer();
+    const count = await tracer.withSpan('LoadProducts', async (load: SpanScope) => {
+      const items = await load.child('FetchFromApi', async (fetchScope: SpanScope) => {
+        const response = await fetch(
+          'https://jsonplaceholder.typicode.com/posts',
+        );
+        fetchScope.span.setAttribute('http.status_code', response.status);
+        const json = await response.text();
+        return fetchScope.child('DeserializeJson', (parseScope: SpanScope) => {
+          const result = JSON.parse(json) as unknown[];
+          parseScope.span.setAttribute('product_count', result.length);
+          return result;
+        });
+      });
+      load.child('RenderUI', (renderScope: SpanScope) => {
+        renderScope.span.setAttribute('product_count', items.length);
+      });
+      return items.length;
+    });
+    log(
+      `[13b] tracer.withSpan LoadProducts > FetchFromApi > DeserializeJson / RenderUI (${count})`,
+    );
+  };
+
   // -- Utilities -----------------------------------------------------------
   const showSessionInfo = () => {
     const info = LDObserve.getSessionInfo();
@@ -475,6 +524,18 @@ export default function TracingScreen() {
             onPress={run('11b', incomingHeaders)}
           />
           <Btn label="12 · Baggage" onPress={run('12', baggage)} />
+        </View>
+
+        <SectionHeader title="OpenTelemetry Tracer (getTracer)" topSpacing />
+        <View style={styles.col}>
+          <Btn
+            label="13a · tracer.startActiveSpan"
+            onPress={run('13a', tracerStartActiveSpan)}
+          />
+          <Btn
+            label="13b · tracer.withSpan (nested)"
+            onPress={run('13b', tracerWithSpanNested)}
+          />
         </View>
 
         <SectionHeader title="Utilities" topSpacing />

--- a/sdk/@launchdarkly/react-native-ld-session-replay/example/metro.config.js
+++ b/sdk/@launchdarkly/react-native-ld-session-replay/example/metro.config.js
@@ -10,9 +10,11 @@ const root = path.resolve(__dirname, '..');
 // workspace symlinks; the sdk/@launchdarkly directory covers them all without
 // dragging in the much larger rrweb/ and e2e/ trees.
 const sdkPackages = path.resolve(__dirname, '../..');
-// Several of those packages' dependencies (@opentelemetry/*, graphql) are
-// hoisted to the monorepo root node_modules, so it must be resolvable too.
 const monorepoNodeModules = path.resolve(__dirname, '../../../../node_modules');
+const observabilityNodeModules = path.resolve(
+  __dirname,
+  '../../observability-react-native/node_modules',
+);
 
 /**
  * Metro configuration
@@ -34,6 +36,7 @@ config.watchFolders = [
 config.resolver.nodeModulesPaths = [
   ...(config.resolver.nodeModulesPaths || []),
   monorepoNodeModules,
+  observabilityNodeModules,
 ];
 
 // This monorepo has SEVERAL different react-native versions installed (the root
@@ -49,8 +52,40 @@ const forcedSingletons = {
   'react': path.resolve(__dirname, 'node_modules/react'),
   'react-native': path.resolve(__dirname, 'node_modules/react-native'),
 };
+
+// RN 0.83 honours package `exports`, but force source anyway so both workspace
+// packages always track live TypeScript during SDK development.
+const sourcePackageEntries = {
+  '@launchdarkly/session-replay-react-native': path.resolve(
+    __dirname,
+    '../src/index.tsx',
+  ),
+  '@launchdarkly/observability-react-native': path.resolve(
+    __dirname,
+    '../../observability-react-native/src/index.ts',
+  ),
+};
+
 const defaultResolveRequest = config.resolver.resolveRequest;
 config.resolver.resolveRequest = (context, moduleName, platform) => {
+  const sourceEntry = sourcePackageEntries[moduleName];
+  if (sourceEntry) {
+    return context.resolveRequest(context, sourceEntry, platform);
+  }
+  if (
+    moduleName === '@opentelemetry/otlp-exporter-base/browser-http' ||
+    moduleName.startsWith('@opentelemetry/otlp-exporter-base/')
+  ) {
+    return context.resolveRequest(
+      {
+        ...context,
+        unstable_enablePackageExports: true,
+        unstable_conditionNames: ['browser', 'require', 'react-native', 'default'],
+      },
+      moduleName,
+      platform,
+    );
+  }
   for (const [name, target] of Object.entries(forcedSingletons)) {
     if (moduleName === name || moduleName.startsWith(`${name}/`)) {
       return context.resolveRequest(

--- a/sdk/@launchdarkly/react-native-ld-session-replay/example/metro.config.js
+++ b/sdk/@launchdarkly/react-native-ld-session-replay/example/metro.config.js
@@ -13,7 +13,7 @@ const sdkPackages = path.resolve(__dirname, '../..');
 const monorepoNodeModules = path.resolve(__dirname, '../../../../node_modules');
 const observabilityNodeModules = path.resolve(
   __dirname,
-  '../../observability-react-native/node_modules',
+  '../../observability-react-native/node_modules'
 );
 
 /**
@@ -58,11 +58,11 @@ const forcedSingletons = {
 const sourcePackageEntries = {
   '@launchdarkly/session-replay-react-native': path.resolve(
     __dirname,
-    '../src/index.tsx',
+    '../src/index.tsx'
   ),
   '@launchdarkly/observability-react-native': path.resolve(
     __dirname,
-    '../../observability-react-native/src/index.ts',
+    '../../observability-react-native/src/index.ts'
   ),
 };
 
@@ -80,10 +80,15 @@ config.resolver.resolveRequest = (context, moduleName, platform) => {
       {
         ...context,
         unstable_enablePackageExports: true,
-        unstable_conditionNames: ['browser', 'require', 'react-native', 'default'],
+        unstable_conditionNames: [
+          'browser',
+          'require',
+          'react-native',
+          'default',
+        ],
       },
       moduleName,
-      platform,
+      platform
     );
   }
   for (const [name, target] of Object.entries(forcedSingletons)) {

--- a/sdk/@launchdarkly/react-native-ld-session-replay/example/src/ApiScreen.tsx
+++ b/sdk/@launchdarkly/react-native-ld-session-replay/example/src/ApiScreen.tsx
@@ -112,18 +112,24 @@ export default function ApiScreen() {
   const tracerWithSpanNested = async () => {
     const tracer = LDObserve.getTracer();
     await tracer.withSpan('LoadProducts', async (load: SpanScope) => {
-      const items = await load.child('FetchFromApi', async (fetchScope: SpanScope) => {
-        const response = await fetch(
-          'https://jsonplaceholder.typicode.com/posts'
-        );
-        fetchScope.span.setAttribute('http.status_code', response.status);
-        const json = await response.text();
-        return fetchScope.child('DeserializeJson', (parseScope: SpanScope) => {
-          const result = JSON.parse(json) as unknown[];
-          parseScope.span.setAttribute('product_count', result.length);
-          return result;
-        });
-      });
+      const items = await load.child(
+        'FetchFromApi',
+        async (fetchScope: SpanScope) => {
+          const response = await fetch(
+            'https://jsonplaceholder.typicode.com/posts'
+          );
+          fetchScope.span.setAttribute('http.status_code', response.status);
+          const json = await response.text();
+          return fetchScope.child(
+            'DeserializeJson',
+            (parseScope: SpanScope) => {
+              const result = JSON.parse(json) as unknown[];
+              parseScope.span.setAttribute('product_count', result.length);
+              return result;
+            }
+          );
+        }
+      );
       load.child('RenderUI', (renderScope: SpanScope) => {
         renderScope.span.setAttribute('product_count', items.length);
       });

--- a/sdk/@launchdarkly/react-native-ld-session-replay/example/src/ApiScreen.tsx
+++ b/sdk/@launchdarkly/react-native-ld-session-replay/example/src/ApiScreen.tsx
@@ -10,7 +10,7 @@ import {
 import { LDObserve } from '@launchdarkly/observability-react-native';
 import type { SpanScope } from '@launchdarkly/observability-react-native';
 import { useLDClient } from '@launchdarkly/react-native-client-sdk';
-import { context } from '@opentelemetry/api';
+import { context, SpanStatusCode, type Span } from '@opentelemetry/api';
 
 /**
  * Manual test screen that mirrors the iOS TestApp `MainMenuViewModel`
@@ -84,6 +84,53 @@ export default function ApiScreen() {
     log(
       '[nested] NestedSpan > NestedSpan1 > NestedSpan2 (+ counter, log, http)'
     );
+  };
+
+  // -- getTracer(): standard OpenTelemetry startActiveSpan ----------------
+  const tracerStartActiveSpan = async () => {
+    const tracer = LDObserve.getTracer();
+    await tracer.startActiveSpan('Checkout', async (span: Span) => {
+      span.setAttribute('cart.id', 'cart-7');
+      try {
+        const response = await fetch(
+          'https://jsonplaceholder.typicode.com/posts'
+        );
+        span.setAttribute('http.status_code', response.status);
+        span.setStatus({ code: SpanStatusCode.OK });
+        log(`[tracer] startActiveSpan Checkout status=${response.status}`);
+      } catch (err) {
+        span.recordException(err as Error);
+        span.setStatus({ code: SpanStatusCode.ERROR });
+        log(`[tracer] Checkout threw: ${(err as Error).message}`);
+      } finally {
+        span.end();
+      }
+    });
+  };
+
+  // -- getTracer(): async-safe nested spans via tracer.withSpan -------------
+  const tracerWithSpanNested = async () => {
+    const tracer = LDObserve.getTracer();
+    await tracer.withSpan('LoadProducts', async (load: SpanScope) => {
+      const items = await load.child('FetchFromApi', async (fetchScope: SpanScope) => {
+        const response = await fetch(
+          'https://jsonplaceholder.typicode.com/posts'
+        );
+        fetchScope.span.setAttribute('http.status_code', response.status);
+        const json = await response.text();
+        return fetchScope.child('DeserializeJson', (parseScope: SpanScope) => {
+          const result = JSON.parse(json) as unknown[];
+          parseScope.span.setAttribute('product_count', result.length);
+          return result;
+        });
+      });
+      load.child('RenderUI', (renderScope: SpanScope) => {
+        renderScope.span.setAttribute('product_count', items.length);
+      });
+      log(
+        `[tracer] withSpan LoadProducts > FetchFromApi > DeserializeJson / RenderUI (${items.length})`
+      );
+    });
   };
 
   // Auto-instrumented fetch spans only attach to the active span when `fetch`
@@ -357,6 +404,18 @@ export default function ApiScreen() {
           <Btn
             label="Nested spans"
             onPress={run('nested', triggerNestedSpans)}
+          />
+        </View>
+
+        <SectionHeader title="OpenTelemetry Tracer (getTracer)" topSpacing />
+        <View style={styles.col}>
+          <Btn
+            label="Tracer · startActiveSpan"
+            onPress={run('tracer-active', tracerStartActiveSpan)}
+          />
+          <Btn
+            label="Tracer · withSpan (nested)"
+            onPress={run('tracer-withSpan', tracerWithSpanNested)}
           />
         </View>
 

--- a/sdk/@launchdarkly/react-native-ld-session-replay/example/src/TracingScreen.tsx
+++ b/sdk/@launchdarkly/react-native-ld-session-replay/example/src/TracingScreen.tsx
@@ -8,6 +8,7 @@ import {
   View,
 } from 'react-native';
 import { LDObserve } from '@launchdarkly/observability-react-native';
+import type { SpanScope } from '@launchdarkly/observability-react-native';
 import {
   context,
   propagation,
@@ -25,7 +26,7 @@ import {
  * IDs where relevant) to the on-screen log. The observability plugin is wired up
  * in App.tsx with `tracingOrigins` set to the demo API hosts used below, so the
  * backend-propagation recipes (11, 12) actually inject `traceparent` / `baggage`
- * headers.
+ * headers. Recipes 13a/13b exercise {@link LDObserve.getTracer} (`LDTracer`).
  *
  * Note: with a placeholder mobile key the SDK still creates spans locally; export
  * to LaunchDarkly only happens once a real key is configured.
@@ -395,6 +396,54 @@ export default function TracingScreen() {
     );
   };
 
+  // -- 13a. Standard OpenTelemetry API via getTracer() --------------------
+  const tracerStartActiveSpan = async () => {
+    const tracer = LDObserve.getTracer();
+    await tracer.startActiveSpan('Checkout', async (span: Span) => {
+      span.setAttribute('cart.id', 'cart-7');
+      try {
+        const response = await fetch(
+          'https://jsonplaceholder.typicode.com/posts'
+        );
+        span.setAttribute('http.status_code', response.status);
+        span.setStatus({ code: SpanStatusCode.OK });
+        log(`[13a] tracer.startActiveSpan Checkout trace=${traceOf(span)}`);
+      } catch (err) {
+        span.recordException(err as Error);
+        span.setStatus({ code: SpanStatusCode.ERROR });
+        log(`[13a] Checkout threw: ${(err as Error).message}`);
+      } finally {
+        span.end();
+      }
+    });
+  };
+
+  // -- 13b. Async-safe nested spans via tracer.withSpan -------------------
+  const tracerWithSpanNested = async () => {
+    const tracer = LDObserve.getTracer();
+    const count = await tracer.withSpan('LoadProducts', async (load: SpanScope) => {
+      const items = await load.child('FetchFromApi', async (fetchScope: SpanScope) => {
+        const response = await fetch(
+          'https://jsonplaceholder.typicode.com/posts'
+        );
+        fetchScope.span.setAttribute('http.status_code', response.status);
+        const json = await response.text();
+        return fetchScope.child('DeserializeJson', (parseScope: SpanScope) => {
+          const result = JSON.parse(json) as unknown[];
+          parseScope.span.setAttribute('product_count', result.length);
+          return result;
+        });
+      });
+      load.child('RenderUI', (renderScope: SpanScope) => {
+        renderScope.span.setAttribute('product_count', items.length);
+      });
+      return items.length;
+    });
+    log(
+      `[13b] tracer.withSpan LoadProducts > FetchFromApi > DeserializeJson / RenderUI (${count})`
+    );
+  };
+
   // -- Utilities -----------------------------------------------------------
   const showSessionInfo = () => {
     const info = LDObserve.getSessionInfo();
@@ -475,6 +524,18 @@ export default function TracingScreen() {
             onPress={run('11b', incomingHeaders)}
           />
           <Btn label="12 · Baggage" onPress={run('12', baggage)} />
+        </View>
+
+        <SectionHeader title="OpenTelemetry Tracer (getTracer)" topSpacing />
+        <View style={styles.col}>
+          <Btn
+            label="13a · tracer.startActiveSpan"
+            onPress={run('13a', tracerStartActiveSpan)}
+          />
+          <Btn
+            label="13b · tracer.withSpan (nested)"
+            onPress={run('13b', tracerWithSpanNested)}
+          />
         </View>
 
         <SectionHeader title="Utilities" topSpacing />

--- a/sdk/@launchdarkly/react-native-ld-session-replay/example/src/TracingScreen.tsx
+++ b/sdk/@launchdarkly/react-native-ld-session-replay/example/src/TracingScreen.tsx
@@ -421,24 +421,33 @@ export default function TracingScreen() {
   // -- 13b. Async-safe nested spans via tracer.withSpan -------------------
   const tracerWithSpanNested = async () => {
     const tracer = LDObserve.getTracer();
-    const count = await tracer.withSpan('LoadProducts', async (load: SpanScope) => {
-      const items = await load.child('FetchFromApi', async (fetchScope: SpanScope) => {
-        const response = await fetch(
-          'https://jsonplaceholder.typicode.com/posts'
+    const count = await tracer.withSpan(
+      'LoadProducts',
+      async (load: SpanScope) => {
+        const items = await load.child(
+          'FetchFromApi',
+          async (fetchScope: SpanScope) => {
+            const response = await fetch(
+              'https://jsonplaceholder.typicode.com/posts'
+            );
+            fetchScope.span.setAttribute('http.status_code', response.status);
+            const json = await response.text();
+            return fetchScope.child(
+              'DeserializeJson',
+              (parseScope: SpanScope) => {
+                const result = JSON.parse(json) as unknown[];
+                parseScope.span.setAttribute('product_count', result.length);
+                return result;
+              }
+            );
+          }
         );
-        fetchScope.span.setAttribute('http.status_code', response.status);
-        const json = await response.text();
-        return fetchScope.child('DeserializeJson', (parseScope: SpanScope) => {
-          const result = JSON.parse(json) as unknown[];
-          parseScope.span.setAttribute('product_count', result.length);
-          return result;
+        load.child('RenderUI', (renderScope: SpanScope) => {
+          renderScope.span.setAttribute('product_count', items.length);
         });
-      });
-      load.child('RenderUI', (renderScope: SpanScope) => {
-        renderScope.span.setAttribute('product_count', items.length);
-      });
-      return items.length;
-    });
+        return items.length;
+      }
+    );
     log(
       `[13b] tracer.withSpan LoadProducts > FetchFromApi > DeserializeJson / RenderUI (${count})`
     );


### PR DESCRIPTION
## Summary
- Add `LDObserve.getTracer()` returning an `LDTracer` — a standard OpenTelemetry `Tracer` plus the async-safe `withSpan` helper for React Native
- Introduce `wrapTracer()` and fix tracer caching so a no-op provider is never cached before initialization
- Document the OpenTelemetry API path in README and tracing guide (recipe 13)
- Add example app buttons for `tracer.startActiveSpan` and `tracer.withSpan` (13a/13b), matching the full LoadProducts trace tree
- Update Metro config in both examples to resolve observability from source and enable OTel package exports subpaths

## Test plan
- [ ] Run `example-legacy` with `yarn start --reset-cache`, tap Tracing tab buttons **13a** and **13b**, verify spans export after Flush
- [ ] Confirm recipe **2 · Nested spans** and **13b** produce the same LoadProducts > FetchFromApi > DeserializeJson / RenderUI hierarchy
- [ ] Verify `LDObserve.withSpan` and `getTracer().withSpan` both export spans to staging/production backend


Made with [Cursor](https://cursor.com)