### PR TITLE
chore: Skip yarn test for Android and MAUI, Flutter PRs

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -100,7 +100,12 @@ jobs:
             # built package into a clean consumer and type-check it with
             # skipLibCheck:false. Runs before publish so a broken .d.ts blocks
             # the release. See scripts/check-published-types.mjs.
+            #
+            # Skipped on native-only changes for the same reason as `yarn test`:
+            # the script requires sdk/highlight-run/dist/index.d.ts, which is
+            # produced by the turbo build that only runs as part of `yarn test`.
             - name: Verify published types resolve in a clean consumer
+              if: steps.changes.outputs.yarn-test == 'true' || github.event_name == 'workflow_dispatch'
               run: node scripts/check-published-types.mjs
 
             - name: Configure yarn npm registry credentials

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -63,6 +63,19 @@ jobs:
             - name: Install js dependencies
               run: yarn install
 
+            - name: Detect JS monorepo changes
+              uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2
+              id: changes
+              with:
+                  filters: |
+                      yarn-test:
+                        - '**'
+                        - '!sdk/@launchdarkly/observability-android/**'
+                        - '!sdk/@launchdarkly/mobile-dotnet/**'
+                        - '!e2e/android/**'
+                        - '!.github/workflows/android-observability.yml'
+                        - '!.github/workflows/android-e2e.yml'
+
             - name: Check yarn for duplicate deps
               run: yarn dedupe --check
 
@@ -70,10 +83,15 @@ jobs:
               run: yarn format-check
 
             - name: Build & test (in a fork without doppler)
+              if: steps.changes.outputs.yarn-test == 'true' || github.event_name == 'workflow_dispatch'
               run: yarn test
               env:
                   NEXT_PUBLIC_HIGHLIGHT_PROJECT_ID: 1jdkoe52
                   REACT_APP_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+
+            - name: Skipped yarn test (Android/MAUI-only change)
+              if: steps.changes.outputs.yarn-test != 'true' && github.event_name != 'workflow_dispatch'
+              run: echo "Skipping yarn test — only Android observability and/or MAUI (.NET) paths changed."
 
             # Guard against shipping unresolvable types: install the freshly
             # built package into a clean consumer and type-check it with

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -72,9 +72,12 @@ jobs:
                         - '**'
                         - '!sdk/@launchdarkly/observability-android/**'
                         - '!sdk/@launchdarkly/mobile-dotnet/**'
+                        - '!sdk/@launchdarkly/flutter/**'
                         - '!e2e/android/**'
                         - '!.github/workflows/android-observability.yml'
                         - '!.github/workflows/android-e2e.yml'
+                        - '!.github/workflows/flutter-observability.yml'
+                        - '!.github/workflows/flutter-observability-publish.yml'
 
             - name: Check yarn for duplicate deps
               run: yarn dedupe --check
@@ -89,9 +92,9 @@ jobs:
                   NEXT_PUBLIC_HIGHLIGHT_PROJECT_ID: 1jdkoe52
                   REACT_APP_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
 
-            - name: Skipped yarn test (Android/MAUI-only change)
+            - name: Skipped yarn test (native-only change)
               if: steps.changes.outputs.yarn-test != 'true' && github.event_name != 'workflow_dispatch'
-              run: echo "Skipping yarn test — only Android observability and/or MAUI (.NET) paths changed."
+              run: echo "Skipping yarn test — only Android, MAUI (.NET), and/or Flutter paths changed."
 
             # Guard against shipping unresolvable types: install the freshly
             # built package into a clean consumer and type-check it with


### PR DESCRIPTION
## Summary
- Add a `dorny/paths-filter` step to the Monorepo workflow so `yarn test` is skipped when a PR or push only touches native Android/MAUI paths.
- Excluded paths: `observability-android`, `mobile-dotnet`, `e2e/android`, and the dedicated Android workflow files.
- Manual `workflow_dispatch` runs still execute the full test suite.

## Why
Android and MAUI changes are validated by their own workflows (`android-observability`, etc.). Running the full JS turborepo test suite on those PRs is slow and can fail on unrelated packages (e.g. `@highlight-run/next` timeouts).

## Test plan
- [ ] Merge this PR first so subsequent Android/MAUI-only PRs skip `yarn test`
- [ ] Confirm an Android-only PR skips the turbo test step after this lands
- [ ] Confirm a JS/RN PR still runs `yarn test`


Made with [Cursor](https://cursor.com)