### PR TITLE
ci: skip yarn test for .NET/Python/Ruby plugin-only changes

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -100,7 +100,12 @@ jobs:
             # built package into a clean consumer and type-check it with
             # skipLibCheck:false. Runs before publish so a broken .d.ts blocks
             # the release. See scripts/check-published-types.mjs.
+            #
+            # Skipped on native-only changes for the same reason as `yarn test`:
+            # the script requires sdk/highlight-run/dist/index.d.ts, which is
+            # produced by the turbo build that only runs as part of `yarn test`.
             - name: Verify published types resolve in a clean consumer
+              if: steps.changes.outputs.yarn-test == 'true' || github.event_name == 'workflow_dispatch'
               run: node scripts/check-published-types.mjs
 
             - name: Configure yarn npm registry credentials

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -73,11 +73,18 @@ jobs:
                         - '!sdk/@launchdarkly/observability-android/**'
                         - '!sdk/@launchdarkly/mobile-dotnet/**'
                         - '!sdk/@launchdarkly/flutter/**'
+                        - '!sdk/@launchdarkly/launchdarkly_flutter_observability/**'
+                        - '!sdk/@launchdarkly/observability-dotnet/**'
+                        - '!sdk/@launchdarkly/observability-python/**'
+                        - '!sdk/@launchdarkly/observability-ruby/**'
                         - '!e2e/android/**'
                         - '!.github/workflows/android-observability.yml'
                         - '!.github/workflows/android-e2e.yml'
                         - '!.github/workflows/flutter-observability.yml'
                         - '!.github/workflows/flutter-observability-publish.yml'
+                        - '!.github/workflows/dotnet-plugin.yml'
+                        - '!.github/workflows/python-plugin.yml'
+                        - '!.github/workflows/ruby-plugin.yml'
 
             - name: Check yarn for duplicate deps
               run: yarn dedupe --check
@@ -94,7 +101,7 @@ jobs:
 
             - name: Skipped yarn test (native-only change)
               if: steps.changes.outputs.yarn-test != 'true' && github.event_name != 'workflow_dispatch'
-              run: echo "Skipping yarn test — only Android, MAUI (.NET), and/or Flutter paths changed."
+              run: echo "Skipping yarn test — only non-yarn SDK paths changed (Android, MAUI/.NET, Flutter, and the .NET/Python/Ruby plugins)."
 
             # Guard against shipping unresolvable types: install the freshly
             # built package into a clean consumer and type-check it with

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -63,6 +63,19 @@ jobs:
             - name: Install js dependencies
               run: yarn install
 
+            - name: Detect JS monorepo changes
+              uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2
+              id: changes
+              with:
+                  filters: |
+                      yarn-test:
+                        - '**'
+                        - '!sdk/@launchdarkly/observability-android/**'
+                        - '!sdk/@launchdarkly/mobile-dotnet/**'
+                        - '!e2e/android/**'
+                        - '!.github/workflows/android-observability.yml'
+                        - '!.github/workflows/android-e2e.yml'
+
             - name: Check yarn for duplicate deps
               run: yarn dedupe --check
 
@@ -70,10 +83,15 @@ jobs:
               run: yarn format-check
 
             - name: Build & test (in a fork without doppler)
+              if: steps.changes.outputs.yarn-test == 'true' || github.event_name == 'workflow_dispatch'
               run: yarn test
               env:
                   NEXT_PUBLIC_HIGHLIGHT_PROJECT_ID: 1jdkoe52
                   REACT_APP_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+
+            - name: Skipped yarn test (Android/MAUI-only change)
+              if: steps.changes.outputs.yarn-test != 'true' && github.event_name != 'workflow_dispatch'
+              run: echo "Skipping yarn test — only Android observability and/or MAUI (.NET) paths changed."
 
             # Guard against shipping unresolvable types: install the freshly
             # built package into a clean consumer and type-check it with

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -72,9 +72,12 @@ jobs:
                         - '**'
                         - '!sdk/@launchdarkly/observability-android/**'
                         - '!sdk/@launchdarkly/mobile-dotnet/**'
+                        - '!sdk/@launchdarkly/flutter/**'
                         - '!e2e/android/**'
                         - '!.github/workflows/android-observability.yml'
                         - '!.github/workflows/android-e2e.yml'
+                        - '!.github/workflows/flutter-observability.yml'
+                        - '!.github/workflows/flutter-observability-publish.yml'
 
             - name: Check yarn for duplicate deps
               run: yarn dedupe --check
@@ -89,9 +92,9 @@ jobs:
                   NEXT_PUBLIC_HIGHLIGHT_PROJECT_ID: 1jdkoe52
                   REACT_APP_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
 
-            - name: Skipped yarn test (Android/MAUI-only change)
+            - name: Skipped yarn test (native-only change)
               if: steps.changes.outputs.yarn-test != 'true' && github.event_name != 'workflow_dispatch'
-              run: echo "Skipping yarn test — only Android observability and/or MAUI (.NET) paths changed."
+              run: echo "Skipping yarn test — only Android, MAUI (.NET), and/or Flutter paths changed."
 
             # Guard against shipping unresolvable types: install the freshly
             # built package into a clean consumer and type-check it with


### PR DESCRIPTION
## Summary
- Extends the `yarn-test` path filter in the Monorepo CI so that changes isolated to additional non-yarn SDKs skip `yarn test` and the published-types check.
- Newly excluded paths: `observability-dotnet`, `observability-python`, `observability-ruby`, and `launchdarkly_flutter_observability`, plus their dedicated workflows (`dotnet-plugin.yml`, `python-plugin.yml`, `ruby-plugin.yml`).
- These SDKs have no `package.json` and aren't part of the turbo build/test graph — they run their own dedicated workflows — so running the yarn turborepo for them is wasted CI time.

## Test plan
- [ ] PR touching only `sdk/@launchdarkly/observability-python/**` shows the "Skipped yarn test" step and does not run `yarn test`.
- [ ] PR touching any JS/TS package still runs `yarn test` and the published-types check.


Made with [Cursor](https://cursor.com)