### PR TITLE
fix: stabilize flaky Next.js server instrumentation test

### DIFF
--- a/e2e/mock-otel-server/src/index.ts
+++ b/e2e/mock-otel-server/src/index.ts
@@ -85,11 +85,16 @@ export function startMockOtelServer({
 	return () => server.close()
 }
 
-export function getResourceSpans(port = DEFAULT_PORT, names: string[] = []) {
+export function getResourceSpans(
+	port = DEFAULT_PORT,
+	names: string[] = [],
+	timeoutMs = 30_000,
+) {
 	return new Promise<{
 		details: ReturnType<typeof aggregateAttributes>
 		resourceSpans: IResourceSpans[]
 	}>((resolve, reject) => {
+		const start = Date.now()
 		const interval = setInterval(() => {
 			const resourceSpans = getResourceSpansByPort(port)
 			const details = aggregateAttributes(resourceSpans)
@@ -106,6 +111,25 @@ export function getResourceSpans(port = DEFAULT_PORT, names: string[] = []) {
 				clearInterval(interval)
 
 				resolve({ details, resourceSpans })
+
+				return
+			}
+
+			// Fail fast with diagnostics instead of hanging until the test
+			// runner's global timeout kills the whole run.
+			if (Date.now() - start >= timeoutMs) {
+				clearInterval(interval)
+
+				logDetails(details)
+
+				reject(
+					new Error(
+						`getResourceSpans timed out after ${timeoutMs}ms waiting for a span with a highlight.session_id` +
+							(names.length
+								? ` and event(s): ${names.join(', ')}`
+								: ''),
+					),
+				)
 			}
 		}, 250)
 	})

--- a/sdk/highlight-next/src/server.test.ts
+++ b/sdk/highlight-next/src/server.test.ts
@@ -37,7 +37,13 @@ describe('Next.js server instrumentation', () => {
 	beforeAll(async () => {
 		stopOtel = startMockOtelServer({ port: OTEL_PORT })
 		stopNext = await startNext(OTEL_PORT)
-	}, 60_000)
+
+		// `next dev` compiles routes on demand, so the very first request to a
+		// route is slow and its telemetry races against compilation. Warm up
+		// every endpoint under test up front so the per-test requests hit
+		// already-compiled routes and reliably emit spans.
+		await warmup()
+	}, 120_000)
 
 	afterAll(async () => {
 		try {
@@ -150,6 +156,42 @@ describe('Next.js server instrumentation', () => {
 		}, 60_000)
 	})
 }, 60_000)
+
+async function warmup() {
+	const endpoints = [
+		`${NEXT_URL}/api/page-router-test?success=true`,
+		`${NEXT_URL}/api/page-router-test?success=false`,
+		`${NEXT_URL}/api/app-router-test?success=true&sql=false`,
+		`${NEXT_URL}/api/app-router-test?success=false&sql=false`,
+	]
+
+	for (const endpoint of endpoints) {
+		// Retry the initial hit: on a cold dev server the first request can
+		// arrive before the route is ready to be compiled.
+		for (let attempt = 0; attempt < 5; attempt++) {
+			try {
+				await fetch(endpoint, {
+					method: 'GET',
+					headers: { ...HIGHLIGHT_HEADER },
+				})
+
+				break
+			} catch (err) {
+				console.warn('warmup request failed, retrying', {
+					endpoint,
+					attempt,
+					err,
+				})
+				await new Promise((r) => setTimeout(r, 1_000))
+			}
+		}
+	}
+
+	// Spans are exported on a batch interval (~5s). Wait out one full cycle so
+	// warm-up spans are flushed before the first test's `beforeEach` clears
+	// them, otherwise late arrivals could pollute exact-count assertions.
+	await new Promise((r) => setTimeout(r, 7_000))
+}
 
 async function startNext(port: number) {
 	return new Promise<() => Promise<void>>(async (resolve) => {

--- a/sdk/highlight-next/src/server.test.ts
+++ b/sdk/highlight-next/src/server.test.ts
@@ -165,16 +165,20 @@ async function warmup() {
 		`${NEXT_URL}/api/app-router-test?success=false&sql=false`,
 	]
 
+	const maxAttempts = 5
+
 	for (const endpoint of endpoints) {
 		// Retry the initial hit: on a cold dev server the first request can
 		// arrive before the route is ready to be compiled.
-		for (let attempt = 0; attempt < 5; attempt++) {
+		let succeeded = false
+		for (let attempt = 0; attempt < maxAttempts; attempt++) {
 			try {
 				await fetch(endpoint, {
 					method: 'GET',
 					headers: { ...HIGHLIGHT_HEADER },
 				})
 
+				succeeded = true
 				break
 			} catch (err) {
 				console.warn('warmup request failed, retrying', {
@@ -184,6 +188,15 @@ async function warmup() {
 				})
 				await new Promise((r) => setTimeout(r, 1_000))
 			}
+		}
+
+		// If a route never responds, the dev server isn't usable. Fail setup
+		// loudly instead of continuing as if routes were compiled and letting
+		// later tests hit cold routes or hang in `getResourceSpans`.
+		if (!succeeded) {
+			throw new Error(
+				`warmup failed: ${endpoint} did not respond after ${maxAttempts} attempts`,
+			)
 		}
 	}
 


### PR DESCRIPTION
## Summary

Fixes the flaky `src/server.test.ts > Next.js server instrumentation > App Router > Should report App Router success` test that intermittently times out at the runner's 60s global timeout.

Two root causes:
- **`getResourceSpans` could hang forever.** In `e2e/mock-otel-server`, it polled with `setInterval` but had no timeout and never rejected. A missing span silently blocked until the runner killed the test — producing the observed `Test timed out in 60000ms` with no useful diagnostics.
- **Cold on-demand route compilation.** `next dev` compiles routes lazily, so the first request to `/api/app-router-test` races its telemetry against compilation, occasionally dropping/delaying the span and triggering the hang above.

## Changes
- `e2e/mock-otel-server/src/index.ts`: `getResourceSpans` now accepts an optional `timeoutMs` (default 30s). On timeout it clears the interval, logs collected span/event details, and rejects with a descriptive message instead of hanging.
- `sdk/highlight-next/src/server.test.ts`: added a `warmup()` step in `beforeAll` that hits every endpoint (with retries) before assertions so measured requests hit already-compiled routes. It waits out one ~5s batch-export cycle so warm-up spans are flushed and cleared by `beforeEach`, avoiding leakage into the page-router error test's exact `toEqual(2)` assertion. Bumped the `beforeAll` timeout to 120s to accommodate warm-up compilation.

## Test plan
- [ ] Run `cd sdk/highlight-next && yarn test` several times to confirm the App Router tests pass consistently.
- [ ] Confirm a genuinely missing span now fails fast (~30s) with a descriptive error + span dump rather than a 60s hang.

Made with [Cursor](https://cursor.com)