### PR TITLE
fix(observability): start a fresh session on cold start (React Native)

### DIFF
--- a/sdk/@launchdarkly/observability-react-native/src/api/Options.ts
+++ b/sdk/@launchdarkly/observability-react-native/src/api/Options.ts
@@ -93,15 +93,19 @@ export interface ReactNativeOptions {
 	urlBlocklist?: string[]
 
 	/**
-	 * Maximum inactivity, in milliseconds, before the next app launch / JS reload
-	 * starts a **new** session instead of continuing the previous one. Measured
-	 * from the last recorded activity to the next load.
+	 * Maximum inactivity, in milliseconds, before a **surviving process**
+	 * (soft/OTA reload) starts a **new** session instead of continuing the
+	 * previous one. Measured from the last recorded activity to the next load.
+	 *
+	 * This only governs reloads within a still-running process. A cold start (the
+	 * app was terminated and relaunched) always starts a fresh session regardless
+	 * of this value, so the native session-replay recording never reuses (and
+	 * corrupts) a previous session id — see SessionManager.resolveSession.
 	 *
 	 * The session id is never rotated while the app is running (in-process): it is
 	 * decided once per JS load and held for that load's lifetime, mirroring the
 	 * native session replay / observability instance, which treats an externally
-	 * supplied id as a custom session and never auto-rotates it. Session
-	 * boundaries therefore only occur at a launch/reload, governed by this value.
+	 * supplied id as a custom session and never auto-rotates it.
 	 *
 	 * @default 15 * 60 * 1000 (15 minutes)
 	 */

--- a/sdk/@launchdarkly/observability-react-native/src/client/SessionManager.test.ts
+++ b/sdk/@launchdarkly/observability-react-native/src/client/SessionManager.test.ts
@@ -93,6 +93,51 @@ describe('SessionManager session preservation', () => {
 		expect(store.read().reloadCount).toBe(1)
 	})
 
+	it('starts a fresh session on a cold start even within the resume window', async () => {
+		const store = new MemoryStore()
+		const now = Date.now()
+		store.seed({
+			sessionId: 'prev-session-id',
+			startTime: now - 60_000,
+			lastActivityTime: now - 1_000,
+			reloadCount: 0,
+		})
+
+		// Process started *after* the previous session's last activity → that
+		// activity came from a prior process, i.e. a cold restart.
+		const mgr = new SessionManager(
+			{ getProcessStartTimeMs: () => now - 500 },
+			store,
+		)
+		await mgr.initialize()
+
+		expect(mgr.getSessionInfo().sessionId).not.toBe('prev-session-id')
+		expect(mgr.wasReloaded()).toBe(false)
+		expect(mgr.getResumeInfo().reloadCount).toBe(0)
+	})
+
+	it('resumes on a surviving process (soft reload) within the window', async () => {
+		const store = new MemoryStore()
+		const now = Date.now()
+		store.seed({
+			sessionId: 'prev-session-id',
+			startTime: now - 60_000,
+			lastActivityTime: now - 1_000,
+			reloadCount: 0,
+		})
+
+		// Process started *before* the last activity → the process stayed alive
+		// across the reload, so the session may resume.
+		const mgr = new SessionManager(
+			{ getProcessStartTimeMs: () => now - 5_000 },
+			store,
+		)
+		await mgr.initialize()
+
+		expect(mgr.getSessionInfo().sessionId).toBe('prev-session-id')
+		expect(mgr.wasReloaded()).toBe(true)
+	})
+
 	it('starts a fresh session when the previous one is stale', async () => {
 		const store = new MemoryStore()
 		const now = Date.now()

--- a/sdk/@launchdarkly/observability-react-native/src/client/SessionManager.ts
+++ b/sdk/@launchdarkly/observability-react-native/src/client/SessionManager.ts
@@ -6,6 +6,7 @@ import {
 	SESSION_STORAGE_KEY,
 } from '../constants/sessions'
 import { createSessionStore, SessionStore } from './storage/sessionStore'
+import { getNativeProcessStartTimeMs } from './nativeProcess'
 
 export interface SessionInfo {
 	sessionId: string
@@ -35,11 +36,18 @@ type PersistedSession = {
 type Options = {
 	sessionTimeout?: ReactNativeOptions['sessionTimeout']
 	debug?: ReactNativeOptions['debug']
+	/**
+	 * Resolves the current OS process's start time (ms since epoch), used to
+	 * distinguish a cold start from a surviving process. Injectable for tests;
+	 * defaults to reading the native session-replay module. Returns `undefined`
+	 * when no native signal is available.
+	 */
+	getProcessStartTimeMs?: () => number | undefined
 }
 
 // Minimum spacing between persistence writes triggered by activity, so a burst
-// of spans doesn't hammer AsyncStorage. The resume window is measured in
-// minutes, so a few seconds of write granularity is more than enough.
+// of spans doesn't hammer AsyncStorage. Backgrounding and each JS load persist
+// unconditionally (force=true), so this only throttles mid-run activity writes.
 const PERSIST_THROTTLE_MS = 5 * 1000
 
 export class SessionManager {
@@ -59,6 +67,8 @@ export class SessionManager {
 			sessionTimeout:
 				options?.sessionTimeout ?? SESSION_RESUME_THRESHOLD_MS,
 			debug: !!options?.debug,
+			getProcessStartTimeMs:
+				options?.getProcessStartTimeMs ?? getNativeProcessStartTimeMs,
 		}
 		this.store = store ?? createSessionStore()
 
@@ -111,8 +121,25 @@ export class SessionManager {
 		const previous = await this.readPersisted()
 		const now = Date.now()
 
+		// A cold start (the app was terminated and relaunched) must always begin a
+		// fresh session: the native session-replay recording restarts its payload
+		// sequence at 0 on a new process, so reusing the previous session id would
+		// collide with and corrupt that session's earlier recording on the backend.
+		// We detect it by comparing the previous session's last activity against
+		// this process's start time — if the activity predates the process, it came
+		// from a prior process (a cold restart). A surviving process (soft/OTA
+		// reload) keeps activity newer than its start time, so it may resume within
+		// the window. When no native signal is available we can't tell, so we don't
+		// block resume (purely time-based, matching observability-only behavior).
+		const processStartMs = this.options.getProcessStartTimeMs()
+		const isColdStart =
+			previous !== undefined &&
+			processStartMs !== undefined &&
+			previous.lastActivityTime < processStartMs
+
 		if (
 			previous &&
+			!isColdStart &&
 			now - previous.lastActivityTime < this.options.sessionTimeout
 		) {
 			// Continue the same session across the reload.
@@ -134,6 +161,15 @@ export class SessionManager {
 			// completes.
 			this.reloadCount = 0
 			this.resumeInfo = { reloaded: false, elapsedMs: 0, reloadCount: 0 }
+
+			if (this.options.debug && isColdStart) {
+				console.log(
+					'📱 Cold start detected — starting a fresh session instead of ' +
+						`resuming ${previous?.sessionId} (last activity ` +
+						`${now - (previous?.lastActivityTime ?? now)}ms ago, before ` +
+						'this process started)',
+				)
+			}
 		}
 
 		await this.persist(now, true)

--- a/sdk/@launchdarkly/observability-react-native/src/client/nativeProcess.ts
+++ b/sdk/@launchdarkly/observability-react-native/src/client/nativeProcess.ts
@@ -1,0 +1,46 @@
+import { NativeModules, TurboModuleRegistry } from 'react-native'
+
+/**
+ * Reads the wall-clock time (ms since epoch) at which the current OS process
+ * first touched the native session-replay module, if that module is installed.
+ *
+ * The value is process-global native state: it survives a JS soft/OTA reload
+ * (same process) and is regenerated on a cold start (new process). Comparing a
+ * persisted session's `lastActivityTime` against it lets the session manager
+ * tell a cold restart from a surviving process.
+ *
+ * Returns `undefined` when the native module isn't available — e.g. an
+ * observability-only app (no session replay), React Native for Web, or an older
+ * native module without this seam. Callers then fall back to purely time-based
+ * resume, which is safe because the cold-start payload collision only exists
+ * when native session replay is present.
+ */
+export function getNativeProcessStartTimeMs(): number | undefined {
+	try {
+		const mod =
+			(
+				TurboModuleRegistry as {
+					get?: (name: string) => unknown
+				} | null
+			)?.get?.('SessionReplayReactNative') ??
+			(NativeModules as Record<string, unknown> | null)?.[
+				'SessionReplayReactNative'
+			]
+		const getter = (
+			mod as { getProcessStartTimeMillis?: () => unknown } | undefined
+		)?.getProcessStartTimeMillis
+		if (typeof getter === 'function') {
+			const value = getter()
+			if (
+				typeof value === 'number' &&
+				Number.isFinite(value) &&
+				value > 0
+			) {
+				return value
+			}
+		}
+	} catch {
+		// Native module unavailable or threw — fall back to time-based resume.
+	}
+	return undefined
+}

--- a/sdk/@launchdarkly/observability-react-native/src/constants/sessions.ts
+++ b/sdk/@launchdarkly/observability-react-native/src/constants/sessions.ts
@@ -1,12 +1,20 @@
 /**
- * Maximum time between the last recorded activity of a session and the next JS
- * load for that load to be treated as a *continuation* (reload) of the same
- * session rather than a brand-new session.
+ * Maximum gap between a session's last recorded activity and the next JS load
+ * for that load to *continue* the previous session instead of starting a new
+ * one.
  *
- * Mirrors the web SDK's `SESSION_PUSH_THRESHOLD` (15 minutes) so reload/session
+ * This window only applies to a **surviving process** — a soft/OTA reload where
+ * the native app process stayed alive. A **cold start** (the app was terminated
+ * and relaunched) always begins a fresh session regardless of this window,
+ * because the native session-replay recording restarts its payload sequence at
+ * 0 on a new process and reusing the old session id would corrupt the previous
+ * recording on the backend (see SessionManager.resolveSession, which uses the
+ * native process start time to tell the two apart).
+ *
+ * 15 minutes mirrors the web SDK's `SESSION_PUSH_THRESHOLD` so reload/session
  * continuity behaves consistently across the browser and React Native SDKs.
  */
-export const SESSION_RESUME_THRESHOLD_MS = 15 * 60 * 1000
+export const SESSION_RESUME_THRESHOLD_MS = 15 * 60 * 1000 // 15 minutes
 
 /**
  * Storage key under which the current session is persisted so it can be resumed

--- a/sdk/@launchdarkly/react-native-ld-session-replay/README.md
+++ b/sdk/@launchdarkly/react-native-ld-session-replay/README.md
@@ -118,10 +118,12 @@ required — these spans are emitted alongside your other telemetry:
 | `app_foreground` | The app enters the foreground (including resume from background). | `event.lifecycle_state = foreground`. |
 | `app_background` | The app enters the background. | `event.lifecycle_state = background`. |
 
-In addition, when the JavaScript runtime reloads (a React Native soft reload, an OTA
-bundle reload, or a quick relaunch within the session-resume window) while the same
-session continues, the observability SDK emits an `app_reload` span so the session
-stays stitched together across the reload.
+In addition, when the JavaScript runtime reloads **while the native process stays
+alive** (a React Native soft reload or an OTA bundle reload) and the previous session
+is still within the resume window, the observability SDK emits an `app_reload` span so
+the session stays stitched together across the reload. A full cold start (the process
+was terminated and relaunched, i.e. `app_launch` above) always begins a **new** session
+rather than resuming the previous one.
 
 See the [event taxonomy](../../../analytics-taxonomy.md) for the full `event.*` payload
 of each event.

--- a/sdk/@launchdarkly/react-native-ld-session-replay/android/build.gradle
+++ b/sdk/@launchdarkly/react-native-ld-session-replay/android/build.gradle
@@ -94,7 +94,7 @@ def kotlin_version = getExtOrDefault("kotlinVersion")
 dependencies {
   implementation "com.facebook.react:react-android"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  implementation "com.launchdarkly:launchdarkly-observability-android:0.60.0"
+  implementation "com.launchdarkly:launchdarkly-observability-android:0.61.0"
   implementation "com.launchdarkly:launchdarkly-android-client-sdk:5.13.1"
   // compileOnly: OTel Attributes appears in ObservabilityOptions parameter types; provided at
   // runtime transitively through launchdarkly-observability-android.

--- a/sdk/@launchdarkly/react-native-ld-session-replay/android/src/main/java/com/sessionreplayreactnative/SessionReplayClientAdapter.kt
+++ b/sdk/@launchdarkly/react-native-ld-session-replay/android/src/main/java/com/sessionreplayreactnative/SessionReplayClientAdapter.kt
@@ -64,6 +64,16 @@ internal class SessionReplayClientAdapter private constructor() {
                 ?.getString("backendUrl")
                 ?.takeIf { it.isNotBlank() }
             this.replayOptions = replayOptionsFrom(options)
+            logger.info(
+                "$LOG_PREFIX configure: serviceName=$serviceName, " +
+                    "serviceVersion=${serviceVersion ?: "<sdk-default>"}, " +
+                    "otlpEndpoint=${otlpEndpoint ?: "<sdk-default>"}, " +
+                    "backendUrl=${backendUrl ?: "<sdk-default>"}, " +
+                    // A session id is not a secret; log the value so it can be matched
+                    // against the JS observability session.id and what the backend receives.
+                    "forwardedSessionId=${customSessionId ?: "<none>"}, " +
+                    "enabled=${replayOptions?.enabled}, sampleRate=${replayOptions?.sampleRate}"
+            )
         }
     }
 
@@ -88,7 +98,7 @@ internal class SessionReplayClientAdapter private constructor() {
         }
         if (localMobileKey == null || localReplayOptions == null) {
             val msg = "start: configure() was not called — mobile key or options are missing"
-            logger.error(msg)
+            logger.error("$LOG_PREFIX $msg")
             completion(false, msg)
             return
         }
@@ -98,24 +108,33 @@ internal class SessionReplayClientAdapter private constructor() {
         //  2. Consecutive start()/stop() calls are naturally serialized without locks.
         Handler(Looper.getMainLooper()).post {
             if (!initialized) {
+                logger.info("$LOG_PREFIX start: first start — initializing LDClient")
                 try {
                     initLDClient(application, localMobileKey, localServiceName, localServiceVersion, localCustomSessionId, localReplayOptions, localOtlpEndpoint, localBackendUrl)
                 } catch (e: Exception) {
-                    logger.error("start: LDClient.init() threw {0}: {1}", e::class.simpleName, e.message)
+                    logger.error("$LOG_PREFIX start: LDClient.init() threw {0}: {1}", e::class.simpleName, e.message)
                     completion(false, "Session replay failed to initialize.")
                     return@post
                 }
                 initialized = true
                 // React Native is often initialized after the main activity has already been
                 // created, so we miss its lifecycle events. Manually register it, just in case.
-                activity?.let { LDReplay.registerActivity(it) }
+                if (activity != null) {
+                    logger.info("$LOG_PREFIX start: registering current activity for lifecycle capture")
+                    LDReplay.registerActivity(activity)
+                } else {
+                    logger.warn(
+                        "$LOG_PREFIX start: no current activity at init — lifecycle registration " +
+                            "skipped; recording may not attach until the next foreground event"
+                    )
+                }
             } else {
-                logger.debug("start: already initialized, re-applying isEnabled={0}", localReplayOptions.enabled)
+                logger.info("$LOG_PREFIX start: already initialized, re-applying enabled=${localReplayOptions.enabled}")
             }
             try {
                 applyEnabled(localReplayOptions.enabled)
             } catch (e: Exception) {
-                logger.error("start: applyEnabled threw {0}: {1}", e::class.simpleName, e.message)
+                logger.error("$LOG_PREFIX start: applyEnabled threw {0}: {1}", e::class.simpleName, e.message)
                 completion(false, "Session replay failed to start.")
                 return@post
             }
@@ -139,19 +158,19 @@ internal class SessionReplayClientAdapter private constructor() {
                     LDReplay.hookProxy?.afterIdentify(keys, canonicalKey, completed)
                 }
             } catch (e: Exception) {
-                logger.error("afterIdentify: threw {0}: {1}", e::class.simpleName, e.message)
+                logger.error("$LOG_PREFIX afterIdentify: threw {0}: {1}", e::class.simpleName, e.message)
             }
         }
     }
 
     fun stop(completion: () -> Unit) {
-        logger.debug("stop")
+        logger.info("$LOG_PREFIX stop: requested")
         // Post to the main thread so that stop() queues behind any in-progress start().
         Handler(Looper.getMainLooper()).post {
             try {
                 LDReplay.stop()
             } catch (e: Exception) {
-                logger.error("stop: threw {0}: {1}", e::class.simpleName, e.message)
+                logger.error("$LOG_PREFIX stop: threw {0}: {1}", e::class.simpleName, e.message)
             }
             completion()
         }
@@ -167,7 +186,7 @@ internal class SessionReplayClientAdapter private constructor() {
         otlpEndpoint: String?,
         backendUrl: String?
     ) {
-        logger.debug("initLDClient: calling LDClient.init()")
+        logger.info("$LOG_PREFIX initLDClient: building LDConfig and calling LDClient.init(offline=true, startWait=0)")
         // Apply the forwarded service.version only when provided; otherwise keep the SDK default.
         var observabilityOptions = ObservabilityOptions(
             serviceName = serviceName,
@@ -210,6 +229,9 @@ internal class SessionReplayClientAdapter private constructor() {
             )
             .build()
 
+        logger.info(
+            "$LOG_PREFIX initLDClient: observability session.id=${customSessionId ?: "<native-generated>"}"
+        )
         // timeout=0: return immediately without blocking the main thread waiting for flags.
         // onPluginsReady() fires synchronously during init() before it returns.
         LDClient.init(application, config, cachedContext, 0)
@@ -312,5 +334,16 @@ internal class SessionReplayClientAdapter private constructor() {
         val shared = SessionReplayClientAdapter()
         private const val TAG = "LDSessionReplay"
         private const val DEFAULT_SERVICE_NAME = "sessionreplay-react-native"
+        // Shared marker so the whole native init sequence can be filtered from logcat
+        // with a single grep (`adb logcat | grep 'SR init'`).
+        private const val LOG_PREFIX = "[SR init]"
+
+        // Wall-clock time (ms since epoch) captured once per OS process, when this
+        // companion is first loaded. Static state lives for the process lifetime, so
+        // it survives a JS soft/OTA reload (same process) but is regenerated on a
+        // cold start (new process). The JS observability session uses it to tell a
+        // cold restart from a surviving process when deciding whether to resume a
+        // persisted session.
+        val processStartTimeMillis: Double = System.currentTimeMillis().toDouble()
     }
 }

--- a/sdk/@launchdarkly/react-native-ld-session-replay/android/src/main/java/com/sessionreplayreactnative/SessionReplayReactNativeModule.kt
+++ b/sdk/@launchdarkly/react-native-ld-session-replay/android/src/main/java/com/sessionreplayreactnative/SessionReplayReactNativeModule.kt
@@ -69,6 +69,9 @@ class SessionReplayReactNativeModule(reactContext: ReactApplicationContext) :
     }
   }
 
+  override fun getProcessStartTimeMillis(): Double =
+    SessionReplayClientAdapter.processStartTimeMillis
+
   companion object {
     const val NAME = "SessionReplayReactNative"
   }

--- a/sdk/@launchdarkly/react-native-ld-session-replay/example/src/ApiScreen.tsx
+++ b/sdk/@launchdarkly/react-native-ld-session-replay/example/src/ApiScreen.tsx
@@ -419,6 +419,7 @@ export default function ApiScreen() {
         <SectionHeader title="Track (via Observability API)" topSpacing />
         <View style={styles.col}>
           <Btn
+            test-id="track-observe"
             label="Track via LDObserve"
             onPress={run('track-observe', trackViaLDObserve)}
           />
@@ -435,6 +436,7 @@ export default function ApiScreen() {
         <SectionHeader title="Track (via LD client)" topSpacing />
         <View style={styles.col}>
           <Btn
+            test-id="track-client"
             label="Track via LD client"
             onPress={run('track-client', trackViaLDClient)}
           />

--- a/sdk/@launchdarkly/react-native-ld-session-replay/ios/SessionReplayClientAdapter.swift
+++ b/sdk/@launchdarkly/react-native-ld-session-replay/ios/SessionReplayClientAdapter.swift
@@ -7,6 +7,24 @@ import LaunchDarklySessionReplay
 public class SessionReplayClientAdapter: NSObject {
   @objc public static let shared = SessionReplayClientAdapter()
 
+  // Shared marker so the whole native init sequence can be filtered from the
+  // device/Xcode console with a single search (e.g. `[SR init]`). Matches the
+  // Android adapter's LOG_PREFIX for cross-platform correlation.
+  fileprivate static let logPrefix = "[SR init]"
+
+  // Wall-clock time (ms since epoch) captured once per OS process, the first
+  // time this value is read. As a `static let` it is lazily initialized once
+  // and held for the process lifetime, so it survives a JS soft/OTA reload
+  // (same process) but is regenerated on a cold start (new process). The JS
+  // observability session uses it to tell a cold restart from a surviving
+  // process when deciding whether to resume a persisted session.
+  private static let processStartTimeMillisValue: Double =
+    Date().timeIntervalSince1970 * 1000
+
+  @objc public static func processStartTimeMillis() -> Double {
+    return processStartTimeMillisValue
+  }
+
   // Guarded by lock.
   private let lock = NSLock()
   private var mobileKey: String?
@@ -69,6 +87,27 @@ public class SessionReplayClientAdapter: NSObject {
     } else {
       self.backendUrl = nil
     }
+    // serviceName/enabled/sampleRate are read back from the incoming dictionary
+    // (mirroring sessionReplayOptionsFrom's defaults) rather than the parsed
+    // SessionReplayOptions, whose stored properties are not all publicly readable.
+    let trimmedServiceName = (options?["serviceName"] as? String)?
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+    let loggedServiceName = (trimmedServiceName?.isEmpty ?? true) ? "<sdk-default>" : trimmedServiceName!
+    let loggedEnabled = (options?["isEnabled"] as? Bool) ?? true
+    let loggedSampleRate = (options?["sampleRate"] as? NSNumber)?.doubleValue ?? 1.0
+    NSLog(
+      "%@ configure: serviceName=%@, serviceVersion=%@, otlpEndpoint=%@, backendUrl=%@, forwardedSessionId=%@, enabled=%@, sampleRate=%@",
+      Self.logPrefix,
+      loggedServiceName,
+      self.serviceVersion ?? "<sdk-default>",
+      self.otlpEndpoint ?? "<sdk-default>",
+      self.backendUrl ?? "<sdk-default>",
+      // A session id is not a secret; log the value so it can be matched against
+      // the JS observability session.id and the id the backend receives.
+      self.customSessionId ?? "<none>",
+      loggedEnabled ? "true" : "false",
+      String(loggedSampleRate)
+    )
   }
 
   private func makeConfig(mobileKey: String, options: SessionReplayOptions) -> LDConfig {
@@ -141,6 +180,7 @@ public class SessionReplayClientAdapter: NSObject {
     lock.lock()
     defer { lock.unlock() }
     guard let mobileKey = mobileKey, let sessionReplayOptions = sessionReplayOptions else {
+      NSLog("%@ start: configure() was not called — mobile key or options are missing", Self.logPrefix)
       completion(false, "Client not initialized. Call SetMobileKey first.")
       return
     }
@@ -150,6 +190,7 @@ public class SessionReplayClientAdapter: NSObject {
       await prev.value
       guard let self else { return }
       if !self.initialized {
+        NSLog("%@ start: first start — calling LDClient.start(offline, startWait=0)", Self.logPrefix)
         let config = self.makeConfig(mobileKey: mobileKey, options: sessionReplayOptions)
         let context = self.cachedContext
         await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
@@ -163,16 +204,15 @@ public class SessionReplayClientAdapter: NSObject {
         // (e.g. `click`) share the same `session.id`; otherwise start with a
         // generated session.
         if let customSessionId {
+          NSLog("%@ start: starting observability with forwarded JS session.id=%@", Self.logPrefix, customSessionId)
           LDObserve.shared.start(sessionId: customSessionId)
         } else {
+          NSLog("%@ start: starting observability with a native-generated session.id", Self.logPrefix)
           LDObserve.shared.start()
         }
         self.initialized = true
       } else {
-        NSLog(
-          "[SessionReplayClientAdapter] start: already initialized, re-applying isEnabled=%@",
-          sessionReplayOptions.isEnabled ? "true" : "false"
-        )
+        NSLog("%@ start: already initialized, re-applying isEnabled=%@", Self.logPrefix, sessionReplayOptions.isEnabled ? "true" : "false")
       }
       LDReplay.shared.isEnabled = sessionReplayOptions.isEnabled
       completion(true, nil)
@@ -216,10 +256,12 @@ public class SessionReplayClientAdapter: NSObject {
   @objc public func stop(completion: @escaping () -> Void) {
     lock.lock()
     defer { lock.unlock() }
+    NSLog("%@ stop: requested", Self.logPrefix)
     let prev = lastTask
     lastTask = Task { @MainActor in
       await prev.value
       LDReplay.shared.isEnabled = false
+      NSLog("%@ stop: completed", Self.logPrefix)
       completion()
     }
   }

--- a/sdk/@launchdarkly/react-native-ld-session-replay/ios/SessionReplayReactNative.mm
+++ b/sdk/@launchdarkly/react-native-ld-session-replay/ios/SessionReplayReactNative.mm
@@ -87,6 +87,18 @@ RCT_EXPORT_METHOD(afterIdentify:(NSDictionary *)contextKeys
 }
 
 #ifdef RCT_NEW_ARCH_ENABLED
+- (NSNumber *)getProcessStartTimeMillis
+{
+    return @([SessionReplayClientAdapter processStartTimeMillis]);
+}
+#else
+RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(getProcessStartTimeMillis)
+{
+    return @([SessionReplayClientAdapter processStartTimeMillis]);
+}
+#endif
+
+#ifdef RCT_NEW_ARCH_ENABLED
 - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:
     (const facebook::react::ObjCTurboModule::InitParams &)params
 {

--- a/sdk/@launchdarkly/react-native-ld-session-replay/src/NativeSessionReplayReactNative.ts
+++ b/sdk/@launchdarkly/react-native-ld-session-replay/src/NativeSessionReplayReactNative.ts
@@ -94,6 +94,20 @@ export interface Spec extends TurboModule {
     canonicalKey: string,
     completed: boolean
   ): Promise<void>;
+
+  /**
+   * Wall-clock time (ms since epoch) captured once, the first time this native
+   * module is touched in the current OS process. The value is held in
+   * process-global (static) native state, so it survives a JS soft/OTA reload
+   * (same process) but is regenerated on a cold start (new process).
+   *
+   * Consumers use it to distinguish a cold start from a surviving process:
+   * a persisted `session.lastActivityTime` that predates this value must have
+   * come from a previous process (i.e. a cold restart), whereas a later one
+   * means the process stayed alive across the reload. Synchronous so the
+   * observability session can make its resume decision before it resolves.
+   */
+  getProcessStartTimeMillis(): number;
 }
 
 export default TurboModuleRegistry.getEnforcing<Spec>(


### PR DESCRIPTION
## Summary

On a **cold start** (the app was terminated and relaunched) the native session-replay recording restarts its payload sequence at `0` on the new process. Previously the JS `SessionManager` could still *resume* the persisted session id if the reload landed inside the resume window, so the fresh native recording collided with — and corrupted — the previous session's recording on the backend.

This change makes a cold start always begin a **fresh** session, while a surviving process (soft/OTA reload) still resumes within the window as before.

## How it works

- The native session-replay modules now expose `getProcessStartTimeMillis()` — a wall-clock timestamp captured once per OS process (`static let` / companion value). It survives a JS soft/OTA reload (same process) and is regenerated on a cold start (new process).
- `SessionManager.resolveSession` compares the persisted session's `lastActivityTime` against the process start time:
  - activity **before** process start ⇒ it came from a prior process ⇒ **cold restart** ⇒ fresh session.
  - activity **after** process start ⇒ the process stayed alive across the reload ⇒ may **resume** within the window.
- When no native signal is available (observability-only app, React Native for Web, or an older native module) it falls back to the existing purely time-based resume, which is safe because the payload collision only exists when native session replay is present.

## Changes

- **JS** (`observability-react-native`):
  - `SessionManager.ts`: cold-start detection + fresh session; injectable `getProcessStartTimeMs` seam.
  - `nativeProcess.ts` (new): reads `getProcessStartTimeMillis` from the native module, `undefined` when unavailable.
  - `Options.ts` / `constants/sessions.ts`: clarified `sessionTimeout` docs (governs surviving-process reloads only).
  - `SessionManager.test.ts`: cold-start-starts-fresh and surviving-process-resumes cases.
- **Native** (`react-native-ld-session-replay`):
  - Android `SessionReplayClientAdapter.kt` + module: `processStartTimeMillis` + `getProcessStartTimeMillis()`.
  - iOS `SessionReplayClientAdapter.swift` + `.mm`: `processStartTimeMillis()` bridged for both old and new arch.
  - `NativeSessionReplayReactNative.ts`: `getProcessStartTimeMillis()` TurboModule spec method.
  - Cross-platform `[SR init]` native init logging for correlation; `test-id`s on example track buttons.

## Test plan

- [ ] `SessionManager` unit tests pass (cold start ⇒ fresh session; surviving process ⇒ resume within window).
- [ ] Manual: cold start after activity within the resume window starts a new `session.id` (no backend recording corruption).
- [ ] Manual: JS soft/OTA reload within the window resumes the same `session.id`.
- [ ] Manual: observability-only app (no session replay) still resumes purely by time.

Made with [Cursor](https://cursor.com)