### PR TITLE
fix(react-native): bump launchdarkly-observability-android to 0.61.1

### DIFF
--- a/sdk/@launchdarkly/react-native-ld-session-replay/android/build.gradle
+++ b/sdk/@launchdarkly/react-native-ld-session-replay/android/build.gradle
@@ -94,7 +94,7 @@ def kotlin_version = getExtOrDefault("kotlinVersion")
 dependencies {
   implementation "com.facebook.react:react-android"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  implementation "com.launchdarkly:launchdarkly-observability-android:0.60.1"
+  implementation "com.launchdarkly:launchdarkly-observability-android:0.61.1"
   implementation "com.launchdarkly:launchdarkly-android-client-sdk:5.13.1"
   // compileOnly: OTel Attributes appears in ObservabilityOptions parameter types; provided at
   // runtime transitively through launchdarkly-observability-android.


### PR DESCRIPTION
## Summary
- Bumps the `launchdarkly-observability-android` dependency in `@launchdarkly/react-native-ld-session-replay` from `0.60.1` to `0.61.1`.
- `0.61.1` includes the fix that skips touch-transparent overlays (e.g. React Native's `DebuggingOverlay`) when resolving Android click targets (#685), so click events report the real element's `nativeID`/`ldId` instead of the overlay.

## Test plan
- [ ] CI green
- [ ] Verify Android click events resolve to the tapped element's `nativeID`/`ldId` in a dev build (previously reported `DebuggingOverlay`).

Made with [Cursor](https://cursor.com)