### PR TITLE
feat(android): stop session replay on unrecoverable initialization errors

### DIFF
--- a/sdk/@launchdarkly/observability-android/README.md
+++ b/sdk/@launchdarkly/observability-android/README.md
@@ -443,6 +443,11 @@ LDReplay.start()
 
 Call `LDReplay.stop()` to pause recording.
 
+Recording can also end on its own: if LaunchDarkly refuses the session — for example when session replay is
+not available for the environment — the SDK stops capturing for the rest of the launch, and
+`LDReplay.isEnabled` reports `false`. The next launch withholds screenshots until the backend accepts a
+session again, so a refusal is not permanent.
+
 #### Masking sensitive UI
 
 Use `ldMask()` to mark views that should be masked in session replay. There are helpers for both XML-based Views and Jetpack Compose.

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/network/ErrorRecoverability.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/network/ErrorRecoverability.kt
@@ -1,0 +1,81 @@
+package com.launchdarkly.observability.network
+
+import java.net.HttpURLConnection
+
+/**
+ * Implemented by exceptions that carry the recoverability verdict of the request that failed, so the
+ * classification is made once — where the status code and the GraphQL `extensions` are still
+ * available — rather than re-derived from an error message.
+ */
+interface RecoverableFailure {
+    val isRecoverable: Boolean
+}
+
+/**
+ * Classifies request failures as recoverable (retrying may succeed) or unrecoverable (permanent for
+ * this launch). Lives outside Session Replay so every caller of the public graph can share one verdict
+ * instead of re-deriving it from status codes.
+ */
+object ErrorRecoverability {
+    private const val HTTP_TOO_MANY_REQUESTS = 429
+
+    /**
+     * Tests whether an HTTP error status represents a condition that might resolve on its own if we
+     * retry.
+     *
+     * @param statusCode the HTTP status
+     * @return `true` if retrying makes sense; `false` if it should be considered a permanent failure
+     */
+    fun isHttpErrorRecoverable(statusCode: Int): Boolean {
+        if (statusCode !in 400..499) return true
+
+        return when (statusCode) {
+            HttpURLConnection.HTTP_BAD_REQUEST, // bad request
+            HttpURLConnection.HTTP_CLIENT_TIMEOUT, // request timeout
+            HTTP_TOO_MANY_REQUESTS -> true // too many requests
+            else -> false // all other 4xx errors are unrecoverable
+        }
+    }
+
+    /**
+     * Classifies a [GraphQLResponse] that carries errors.
+     */
+    fun isErrorRecoverable(response: GraphQLResponse<*>): Boolean =
+        isErrorRecoverable(response.httpStatusCode, response.errors)
+
+    /**
+     * Classifies a failed request from the status it returned and the GraphQL errors it carried.
+     *
+     * @param statusCode the HTTP status, or `null` when the request never reached one
+     * @param errors the GraphQL errors the response carried, if any
+     */
+    fun isErrorRecoverable(statusCode: Int?, errors: List<GraphQLError>?): Boolean {
+        // An explicit server verdict is more specific than the status code, so it wins.
+        retryableFlag(errors)?.let { return it }
+        // Without a status the request timed out or lost connectivity, neither of which is permanent.
+        val status = statusCode ?: return true
+        // The public graph reports rejections as `200` + `errors`, so those are classified like a
+        // generic 4xx: unrecoverable unless the server marked an error retryable.
+        if (status == HttpURLConnection.HTTP_OK) return errors.isNullOrEmpty()
+
+        return isHttpErrorRecoverable(status)
+    }
+
+    /**
+     * Classifies a thrown failure. Errors of unknown origin are treated as recoverable: retrying costs
+     * a backed-off request, while a wrong permanent verdict silently disables a feature for the rest of
+     * the launch.
+     */
+    fun isErrorRecoverable(error: Throwable): Boolean = (error as? RecoverableFailure)?.isRecoverable ?: true
+
+    /**
+     * The server's retry verdict for a set of GraphQL errors, or `null` when none of them states one.
+     */
+    private fun retryableFlag(errors: List<GraphQLError>?): Boolean? {
+        if (errors.isNullOrEmpty()) return null
+        if (errors.any { it.extensions?.retryable == false }) return false
+        if (errors.any { it.extensions?.retryable == true }) return true
+
+        return null
+    }
+}

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/network/ErrorRecoverability.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/network/ErrorRecoverability.kt
@@ -38,35 +38,31 @@ object ErrorRecoverability {
     }
 
     /**
-     * Classifies a [GraphQLResponse] that carries errors.
+     * Classifies any failure thrown by [GraphQLClient]. Errors of unknown origin are treated as
+     * recoverable: retrying costs a backed-off request, while a wrong permanent verdict silently disables
+     * a feature for the rest of the launch.
      */
-    fun isErrorRecoverable(response: GraphQLResponse<*>): Boolean =
-        isErrorRecoverable(response.httpStatusCode, response.errors)
-
-    /**
-     * Classifies a failed request from the status it returned and the GraphQL errors it carried.
-     *
-     * @param statusCode the HTTP status, or `null` when the request never reached one
-     * @param errors the GraphQL errors the response carried, if any
-     */
-    fun isErrorRecoverable(statusCode: Int?, errors: List<GraphQLError>?): Boolean {
-        // An explicit server verdict is more specific than the status code, so it wins.
-        retryableFlag(errors)?.let { return it }
-        // Without a status the request timed out or lost connectivity, neither of which is permanent.
-        val status = statusCode ?: return true
-        // The public graph reports rejections as `200` + `errors`, so those are classified like a
-        // generic 4xx: unrecoverable unless the server marked an error retryable.
-        if (status == HttpURLConnection.HTTP_OK) return errors.isNullOrEmpty()
-
-        return isHttpErrorRecoverable(status)
+    fun isErrorRecoverable(error: Throwable): Boolean = when (error) {
+        is GraphQLClientException -> isRecoverable(error)
+        is RecoverableFailure -> error.isRecoverable
+        else -> true
     }
 
-    /**
-     * Classifies a thrown failure. Errors of unknown origin are treated as recoverable: retrying costs
-     * a backed-off request, while a wrong permanent verdict silently disables a feature for the rest of
-     * the launch.
-     */
-    fun isErrorRecoverable(error: Throwable): Boolean = (error as? RecoverableFailure)?.isRecoverable ?: true
+    private fun isRecoverable(error: GraphQLClientException): Boolean = when (error) {
+        // A rejected request can still carry a GraphQL envelope, and an explicit `retryable` there is more
+        // specific than the status code, so it wins.
+        is GraphQLClientException.HttpStatus ->
+            retryableFlag(error.errors) ?: isHttpErrorRecoverable(error.statusCode)
+
+        // The public graph reports rejections as `200` + `errors`, so these are classified like a generic
+        // 4xx: unrecoverable unless the server marks an error retryable.
+        is GraphQLClientException.GraphQLErrors -> retryableFlag(error.errors) ?: false
+
+        // Timeouts, connectivity loss and malformed responses carry no permanent signal.
+        is GraphQLClientException.Transport,
+        is GraphQLClientException.Decoding,
+        is GraphQLClientException.MissingData -> true
+    }
 
     /**
      * The server's retry verdict for a set of GraphQL errors, or `null` when none of them states one.

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/network/GraphQLClient.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/network/GraphQLClient.kt
@@ -6,10 +6,10 @@ import kotlinx.coroutines.withContext
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.Transient
 import kotlinx.serialization.json.JsonElement
 import java.net.HttpURLConnection
 import java.net.URL
+import kotlin.coroutines.cancellation.CancellationException
 
 @Serializable
 data class GraphQLRequest(
@@ -17,17 +17,43 @@ data class GraphQLRequest(
     val variables: Map<String, JsonElement> = emptyMap()
 )
 
+/** Standard GraphQL envelope: `{ data, errors }`. */
 @Serializable
-data class GraphQLResponse<T>(
+private data class GraphQLResponse<T>(
     val data: T?,
-    val errors: List<GraphQLError>? = null,
-    /**
-     * The HTTP status the response was read from, or `null` when the request never reached one (a
-     * timeout, or connectivity loss). Not part of the GraphQL envelope: [GraphQLClient] fills it in so
-     * callers can classify a failure with [ErrorRecoverability] instead of parsing [GraphQLError.message].
-     */
-    @Transient val httpStatusCode: Int? = null
+    val errors: List<GraphQLError>? = null
 )
+
+/**
+ * Every way a [GraphQLClient.execute] call can fail, as the failure the caller can act on:
+ * [ErrorRecoverability] classifies these cases directly, so no caller has to re-derive a status code or a
+ * `retryable` flag from an error message.
+ */
+sealed class GraphQLClientException(message: String, cause: Throwable? = null) : RuntimeException(message, cause) {
+    /**
+     * The request was rejected with a non-2xx status. A rejected request can still return a GraphQL
+     * envelope, in which case its [errors] are carried here too.
+     */
+    class HttpStatus(
+        val statusCode: Int,
+        val body: String,
+        val errors: List<GraphQLError>? = null,
+    ) : GraphQLClientException("HTTP Error $statusCode: $body")
+
+    /** The response was accepted but carries `errors`, which is how the public graph reports rejections. */
+    class GraphQLErrors(
+        val errors: List<GraphQLError>,
+    ) : GraphQLClientException("GraphQL errors: ${errors.joinToString(" | ") { it.message }}")
+
+    /** The response carried neither `data` nor `errors`. */
+    class MissingData : GraphQLClientException("Missing `data` in GraphQL response")
+
+    /** The request never reached a status: connectivity loss, a timeout, or a request we failed to send. */
+    class Transport(cause: Throwable) : GraphQLClientException("Transport error: ${cause.message}", cause)
+
+    /** The response was not the shape the operation expects. */
+    class Decoding(cause: Throwable) : GraphQLClientException("Decoding error: ${cause.message}", cause)
+}
 
 @Serializable
 data class GraphQLError(
@@ -91,6 +117,7 @@ class GraphQLClient(
     companion object {
         private const val CONNECT_TIMEOUT = 10000
         private const val READ_TIMEOUT = 10000
+        private const val NO_ERROR_BODY = "No error body"
     }
 
     /**
@@ -98,16 +125,17 @@ class GraphQLClient(
      * @param query The GraphQL query string
      * @param variables Query variables
      * @param dataSerializer Kotlinx serialization serializer for the expected response data type
-     * @return GraphQLResponse containing either the deserialized data or error information
+     * @return the deserialized `data` of the response
+     * @throws GraphQLClientException for every failure, including a GraphQL `errors` response
      */
     suspend fun <T> execute(
         query: String,
         variables: Map<String, JsonElement> = emptyMap(),
         dataSerializer: KSerializer<T>,
         compress: Boolean = true
-    ): GraphQLResponse<T> = withContext(DispatcherProviderHolder.current.io) {
+    ): T = withContext(DispatcherProviderHolder.current.io) {
         var connection: HttpURLConnection? = null
-        val response: GraphQLResponse<T> = try {
+        try {
             val request = GraphQLRequest(
                 query = query,
                 variables = variables
@@ -145,52 +173,52 @@ class GraphQLClient(
             // Read response
             val responseCode = connectionLocal.responseCode
             if (responseCode != HttpURLConnection.HTTP_OK) {
-                val errorText = connectionLocal.errorStream?.bufferedReader()?.use { it.readText() } ?: "No error body"
-                rejectedResponse(responseCode, errorText)
-            } else {
-                val responseJson = connectionLocal.inputStream.bufferedReader().use { it.readText() }
-                json.decodeFromString(
-                    GraphQLResponse.serializer(dataSerializer),
-                    responseJson
-                ).copy(httpStatusCode = responseCode)
+                val body = connectionLocal.errorStream?.bufferedReader()?.use { it.readText() } ?: NO_ERROR_BODY
+                throw GraphQLClientException.HttpStatus(responseCode, body, errorsIn(body))
             }
+
+            val responseJson = connectionLocal.inputStream.bufferedReader().use { it.readText() }
+            val envelope = try {
+                json.decodeFromString(GraphQLResponse.serializer(dataSerializer), responseJson)
+            } catch (e: Exception) {
+                throw GraphQLClientException.Decoding(e)
+            }
+
+            envelope.errors?.takeIf { it.isNotEmpty() }?.let { throw GraphQLClientException.GraphQLErrors(it) }
+
+            envelope.data ?: throw GraphQLClientException.MissingData()
+        } catch (e: GraphQLClientException) {
+            logFailure(e)
+            throw e
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
-            // No status: the request failed before or while getting one, which carries no permanent
-            // signal (see `ErrorRecoverability`).
-            GraphQLResponse(
-                data = null,
-                errors = listOf(
-                    GraphQLError(message = e.message.toString())
-                )
-            )
+            // The request never reached a status, which carries no permanent signal (see
+            // `ErrorRecoverability`).
+            throw GraphQLClientException.Transport(e).also { logFailure(it) }
         } finally {
             connection?.disconnect()
         }
-
-        logErrors(response)
-        response
     }
 
     /**
-     * Turns a non-2xx response into the errors-carrying envelope callers expect. A rejected request can
-     * still return GraphQL errors, whose `extensions` are more specific than the status code, so they
-     * are read from the body when it is one.
+     * The GraphQL errors a rejected body carried, or `null` when it was not a GraphQL envelope. Their
+     * `extensions` are more specific than the status code, so they are worth reading off a rejection.
      */
-    private fun <T> rejectedResponse(statusCode: Int, body: String): GraphQLResponse<T> {
-        val errors = try {
-            json.decodeFromString(GraphQLErrorEnvelope.serializer(), body).errors
-        } catch (_: Exception) {
-            null
-        }?.takeIf { it.isNotEmpty() }
-            ?: listOf(GraphQLError(message = "HTTP Error $statusCode: $body"))
-
-        return GraphQLResponse(data = null, errors = errors, httpStatusCode = statusCode)
+    private fun errorsIn(body: String): List<GraphQLError>? = try {
+        json.decodeFromString(GraphQLErrorEnvelope.serializer(), body).errors?.takeIf { it.isNotEmpty() }
+    } catch (_: Exception) {
+        null
     }
 
-    private fun logErrors(response: GraphQLResponse<*>) {
-        val errors = response.errors?.takeIf { it.isNotEmpty() } ?: return
-        errors.forEach { error ->
-            logger.error("GraphQLClient error: ${error.message}")
+    private fun logFailure(failure: GraphQLClientException) {
+        logger.error("GraphQLClient error: ${failure.message}")
+        val errors = when (failure) {
+            is GraphQLClientException.GraphQLErrors -> failure.errors
+            is GraphQLClientException.HttpStatus -> failure.errors
+            else -> null
+        }
+        errors?.forEach { error ->
             error.locations?.forEach { location ->
                 logger.error("  at line ${location.line}, column ${location.column}")
             }

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/network/GraphQLClient.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/network/GraphQLClient.kt
@@ -136,6 +136,7 @@ class GraphQLClient(
     ): T = withContext(DispatcherProviderHolder.current.io) {
         var connection: HttpURLConnection? = null
         try {
+            GraphQLFaultInjection.failIfNeeded(query)
             val request = GraphQLRequest(
                 query = query,
                 variables = variables

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/network/GraphQLClient.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/network/GraphQLClient.kt
@@ -136,7 +136,6 @@ class GraphQLClient(
     ): T = withContext(DispatcherProviderHolder.current.io) {
         var connection: HttpURLConnection? = null
         try {
-            GraphQLFaultInjection.failIfNeeded(query)
             val request = GraphQLRequest(
                 query = query,
                 variables = variables

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/network/GraphQLClient.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/network/GraphQLClient.kt
@@ -6,8 +6,8 @@ import kotlinx.coroutines.withContext
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
 import kotlinx.serialization.json.JsonElement
-import java.io.IOException
 import java.net.HttpURLConnection
 import java.net.URL
 
@@ -20,14 +20,44 @@ data class GraphQLRequest(
 @Serializable
 data class GraphQLResponse<T>(
     val data: T?,
-    val errors: List<GraphQLError>? = null
+    val errors: List<GraphQLError>? = null,
+    /**
+     * The HTTP status the response was read from, or `null` when the request never reached one (a
+     * timeout, or connectivity loss). Not part of the GraphQL envelope: [GraphQLClient] fills it in so
+     * callers can classify a failure with [ErrorRecoverability] instead of parsing [GraphQLError.message].
+     */
+    @Transient val httpStatusCode: Int? = null
 )
 
 @Serializable
 data class GraphQLError(
     val message: String,
     val locations: List<GraphQLLocation>? = null,
-    val path: List<String>? = null
+    val path: List<String>? = null,
+    val extensions: GraphQLErrorExtensions? = null
+)
+
+/**
+ * Server-supplied metadata about a [GraphQLError].
+ */
+@Serializable
+data class GraphQLErrorExtensions(
+    /** Machine-readable error identifier, e.g. `SESSION_REPLAY_BLOCKED_IN_REGION`. */
+    val code: String? = null,
+    /**
+     * The server's own verdict on whether retrying the operation can succeed. Takes precedence over
+     * any status-code based classification when present.
+     */
+    val retryable: Boolean? = null
+)
+
+/**
+ * Errors-only view of the GraphQL envelope. The public graph also returns this shape alongside a
+ * non-2xx status, where `data` is absent, so error metadata can still be read from the raw body.
+ */
+@Serializable
+private data class GraphQLErrorEnvelope(
+    val errors: List<GraphQLError>? = null
 )
 
 @Serializable
@@ -114,18 +144,19 @@ class GraphQLClient(
 
             // Read response
             val responseCode = connectionLocal.responseCode
-            val responseJson = if (responseCode == HttpURLConnection.HTTP_OK) {
-                connectionLocal.inputStream.bufferedReader().use { it.readText() }
-            } else {
+            if (responseCode != HttpURLConnection.HTTP_OK) {
                 val errorText = connectionLocal.errorStream?.bufferedReader()?.use { it.readText() } ?: "No error body"
-                throw IOException("HTTP Error $responseCode: $errorText")
+                rejectedResponse(responseCode, errorText)
+            } else {
+                val responseJson = connectionLocal.inputStream.bufferedReader().use { it.readText() }
+                json.decodeFromString(
+                    GraphQLResponse.serializer(dataSerializer),
+                    responseJson
+                ).copy(httpStatusCode = responseCode)
             }
-
-            json.decodeFromString(
-                GraphQLResponse.serializer(dataSerializer),
-                responseJson
-            )
         } catch (e: Exception) {
+            // No status: the request failed before or while getting one, which carries no permanent
+            // signal (see `ErrorRecoverability`).
             GraphQLResponse(
                 data = null,
                 errors = listOf(
@@ -138,6 +169,22 @@ class GraphQLClient(
 
         logErrors(response)
         response
+    }
+
+    /**
+     * Turns a non-2xx response into the errors-carrying envelope callers expect. A rejected request can
+     * still return GraphQL errors, whose `extensions` are more specific than the status code, so they
+     * are read from the body when it is one.
+     */
+    private fun <T> rejectedResponse(statusCode: Int, body: String): GraphQLResponse<T> {
+        val errors = try {
+            json.decodeFromString(GraphQLErrorEnvelope.serializer(), body).errors
+        } catch (_: Exception) {
+            null
+        }?.takeIf { it.isNotEmpty() }
+            ?: listOf(GraphQLError(message = "HTTP Error $statusCode: $body"))
+
+        return GraphQLResponse(data = null, errors = errors, httpStatusCode = statusCode)
     }
 
     private fun logErrors(response: GraphQLResponse<*>) {

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/network/GraphQLFaultInjection.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/network/GraphQLFaultInjection.kt
@@ -1,0 +1,74 @@
+package com.launchdarkly.observability.network
+
+import com.launchdarkly.observability.BuildConfig
+import java.util.Calendar
+
+/**
+ * Debug-only helper for exercising Session Replay's recoverable and unrecoverable error paths on a device
+ * without a backend change. It fails `initializeSession` and `pushPayload` during even clock minutes and
+ * lets them through during odd ones, so a single run alternates between the two states every minute.
+ *
+ * Nothing calls this: it is deliberately left unwired, and does nothing outside a debug build. To use it,
+ * add the call at the top of [GraphQLClient.execute] and remove it again afterwards:
+ *
+ * ```kotlin
+ * GraphQLFaultInjection.responseIfNeeded<T>(query)?.let { return@withContext it }
+ * ```
+ */
+internal object GraphQLFaultInjection {
+    /** The failure to simulate. Change this to exercise a different branch of [ErrorRecoverability]. */
+    enum class Mode {
+        /**
+         * A GraphQL error carrying `retryable: false`: unrecoverable, so Session Replay stops taking
+         * screenshots immediately and the refusal is cached for the next launch.
+         */
+        NON_RETRYABLE_GRAPHQL_ERROR,
+
+        /** `403`: unrecoverable by status code. */
+        UNAUTHORIZED,
+
+        /** `429`: recoverable, so events stay buffered and the call is retried. */
+        TOO_MANY_REQUESTS,
+    }
+
+    val mode = Mode.NON_RETRYABLE_GRAPHQL_ERROR
+
+    /** Fragments identifying the operations covered by the Session Replay error handling. */
+    private val operationMarkers = listOf("mutation initializeSession", "mutation PushPayload")
+
+    /**
+     * The simulated failure for [query], or `null` when the call should be left alone.
+     */
+    fun <T> responseIfNeeded(query: String): GraphQLResponse<T>? {
+        if (!BuildConfig.DEBUG) return null
+        if (operationMarkers.none { query.contains(it) }) return null
+        if (!isFailingMinute()) return null
+
+        return when (mode) {
+            Mode.NON_RETRYABLE_GRAPHQL_ERROR -> GraphQLResponse(
+                data = null,
+                errors = listOf(
+                    GraphQLError(
+                        message = "Session replay is not available in this region.",
+                        extensions = GraphQLErrorExtensions(
+                            code = "SESSION_REPLAY_BLOCKED_IN_REGION",
+                            retryable = false,
+                        ),
+                    )
+                ),
+                httpStatusCode = 200,
+            )
+
+            Mode.UNAUTHORIZED -> httpFailure(403)
+            Mode.TOO_MANY_REQUESTS -> httpFailure(429)
+        }
+    }
+
+    private fun <T> httpFailure(statusCode: Int): GraphQLResponse<T> = GraphQLResponse(
+        data = null,
+        errors = listOf(GraphQLError(message = "HTTP Error $statusCode: injected failure")),
+        httpStatusCode = statusCode,
+    )
+
+    private fun isFailingMinute(): Boolean = Calendar.getInstance().get(Calendar.MINUTE) % 2 == 0
+}

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/network/GraphQLFaultInjection.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/network/GraphQLFaultInjection.kt
@@ -12,7 +12,7 @@ import java.util.Calendar
  * add the call at the top of [GraphQLClient.execute] and remove it again afterwards:
  *
  * ```kotlin
- * GraphQLFaultInjection.responseIfNeeded<T>(query)?.let { return@withContext it }
+ * GraphQLFaultInjection.failIfNeeded(query)
  * ```
  */
 internal object GraphQLFaultInjection {
@@ -37,17 +37,17 @@ internal object GraphQLFaultInjection {
     private val operationMarkers = listOf("mutation initializeSession", "mutation PushPayload")
 
     /**
-     * The simulated failure for [query], or `null` when the call should be left alone.
+     * Throws the simulated failure when [query] is one of the covered operations and this is a failing
+     * minute.
      */
-    fun <T> responseIfNeeded(query: String): GraphQLResponse<T>? {
-        if (!BuildConfig.DEBUG) return null
-        if (operationMarkers.none { query.contains(it) }) return null
-        if (!isFailingMinute()) return null
+    fun failIfNeeded(query: String) {
+        if (!BuildConfig.DEBUG) return
+        if (operationMarkers.none { query.contains(it) }) return
+        if (!isFailingMinute()) return
 
-        return when (mode) {
-            Mode.NON_RETRYABLE_GRAPHQL_ERROR -> GraphQLResponse(
-                data = null,
-                errors = listOf(
+        throw when (mode) {
+            Mode.NON_RETRYABLE_GRAPHQL_ERROR -> GraphQLClientException.GraphQLErrors(
+                listOf(
                     GraphQLError(
                         message = "Session replay is not available in this region.",
                         extensions = GraphQLErrorExtensions(
@@ -55,20 +55,13 @@ internal object GraphQLFaultInjection {
                             retryable = false,
                         ),
                     )
-                ),
-                httpStatusCode = 200,
+                )
             )
 
-            Mode.UNAUTHORIZED -> httpFailure(403)
-            Mode.TOO_MANY_REQUESTS -> httpFailure(429)
+            Mode.UNAUTHORIZED -> GraphQLClientException.HttpStatus(403, "injected failure")
+            Mode.TOO_MANY_REQUESTS -> GraphQLClientException.HttpStatus(429, "injected failure")
         }
     }
-
-    private fun <T> httpFailure(statusCode: Int): GraphQLResponse<T> = GraphQLResponse(
-        data = null,
-        errors = listOf(GraphQLError(message = "HTTP Error $statusCode: injected failure")),
-        httpStatusCode = statusCode,
-    )
 
     private fun isFailingMinute(): Boolean = Calendar.getInstance().get(Calendar.MINUTE) % 2 == 0
 }

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/network/SamplingApiService.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/network/SamplingApiService.kt
@@ -76,18 +76,15 @@ class SamplingApiService(
     suspend fun getSamplingConfig(organizationVerboseId: String): SamplingConfig? {
         try {
             val variables = mapOf("organization_verbose_id" to JsonPrimitive(organizationVerboseId))
-            val response = graphqlClient.execute(
+
+            return graphqlClient.execute(
                 query = GET_SAMPLING_CONFIG_QUERY,
                 variables = variables,
                 dataSerializer = SamplingResponse.serializer()
-            )
-
-            if (response.errors?.isNotEmpty() == true) {
-                return null
-            }
-
-            return response.data?.mapToEntity()
+            ).mapToEntity()
         } catch (e: Exception) {
+            // Sampling falls back to "sample everything" when the config cannot be read, so every failure
+            // is the same as an absent config here.
             println("Error fetching sampling config: ${e.message}")
             return null
         }

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/SessionReplayInitializationStore.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/SessionReplayInitializationStore.kt
@@ -1,0 +1,102 @@
+package com.launchdarkly.observability.replay
+
+import android.content.SharedPreferences
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import java.security.MessageDigest
+
+/**
+ * Outcome of an `initializeSession` / `pushPayload` attempt as far as recording is concerned. Reported by
+ * [com.launchdarkly.observability.replay.exporter.SessionReplayExporter], which is public, hence public.
+ */
+sealed interface SessionReplayInitializationVerdict {
+    /** The backend accepted the session, so recording may run. */
+    data object Allowed : SessionReplayInitializationVerdict
+
+    /**
+     * The backend refused in a way retrying cannot fix (an unrecoverable status, or a GraphQL error
+     * marked non-retryable), so recording must stop for this launch.
+     */
+    data class Unrecoverable(val reason: String) : SessionReplayInitializationVerdict
+}
+
+/**
+ * The last unrecoverable failure, as persisted between launches.
+ */
+@Serializable
+internal data class SessionReplayInitializationFailure(
+    val reason: String,
+    val timestamp: Long,
+    /**
+     * Fingerprint of the SDK key the failure was produced for. Entitlements differ per environment, so
+     * a verdict from one must not gate another.
+     */
+    val environment: String,
+)
+
+/**
+ * Disk cache of the last unrecoverable Session Replay initialization failure, so the next launch can
+ * hold off on taking screenshots until the backend has answered again.
+ *
+ * Only failures are stored: no record means "record immediately", which keeps the common path free of a
+ * startup write. The read shares the preference file
+ * [com.launchdarkly.observability.client.AppLaunchTracker] already loads during Observability start, so
+ * it does not add a disk hit of its own.
+ */
+internal class SessionReplayInitializationStore(
+    private val prefs: SharedPreferences,
+    sdkKey: String,
+) {
+    private val environment = fingerprint(sdkKey)
+
+    /** The stored failure, or `null` when there is none or it belongs to a different environment. */
+    fun loadFailure(): SessionReplayInitializationFailure? {
+        val stored = prefs.getString(KEY_LAST_UNRECOVERABLE_FAILURE, null) ?: return null
+
+        return decode(stored)?.takeIf { it.environment == environment }
+    }
+
+    fun store(reason: String, timestamp: Long = System.currentTimeMillis()) {
+        val failure = SessionReplayInitializationFailure(
+            reason = reason.take(MAX_REASON_LENGTH),
+            timestamp = timestamp,
+            environment = environment,
+        )
+        prefs.edit().putString(KEY_LAST_UNRECOVERABLE_FAILURE, encode(failure)).apply()
+    }
+
+    fun clearFailure() {
+        prefs.edit().remove(KEY_LAST_UNRECOVERABLE_FAILURE).apply()
+    }
+
+    internal companion object {
+        const val KEY_LAST_UNRECOVERABLE_FAILURE = "sessionReplayLastUnrecoverableFailure"
+
+        /**
+         * The reason is diagnostic only, and an error message can carry a whole response body, so it is
+         * kept short enough to stay cheap to read at every launch.
+         */
+        const val MAX_REASON_LENGTH = 512
+
+        private val json = Json { ignoreUnknownKeys = true }
+
+        fun encode(failure: SessionReplayInitializationFailure): String =
+            json.encodeToString(SessionReplayInitializationFailure.serializer(), failure)
+
+        fun decode(stored: String): SessionReplayInitializationFailure? = try {
+            json.decodeFromString(SessionReplayInitializationFailure.serializer(), stored)
+        } catch (_: Exception) {
+            null
+        }
+
+        /**
+         * Distinguishes environments without writing the SDK key itself to disk. Only equality matters,
+         * so a truncated digest is enough.
+         */
+        fun fingerprint(sdkKey: String): String =
+            MessageDigest.getInstance("SHA-256")
+                .digest(sdkKey.toByteArray())
+                .take(8)
+                .joinToString("") { "%02x".format(it) }
+    }
+}

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/SessionReplayInitializationStore.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/SessionReplayInitializationStore.kt
@@ -6,7 +6,8 @@ import kotlinx.serialization.json.Json
 import java.security.MessageDigest
 
 /**
- * Outcome of an `initializeSession` / `pushPayload` attempt as far as recording is concerned. Reported by
+ * Outcome of a Session Replay request as far as recording is concerned. Any of them can refuse the launch,
+ * including the `identifyReplaySession` that follows a successful `initializeReplaySession`. Reported by
  * [com.launchdarkly.observability.replay.exporter.SessionReplayExporter], which is public, hence public.
  */
 sealed interface SessionReplayInitializationVerdict {

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/SessionReplayInitializationStore.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/SessionReplayInitializationStore.kt
@@ -27,11 +27,6 @@ sealed interface SessionReplayInitializationVerdict {
 internal data class SessionReplayInitializationFailure(
     val reason: String,
     val timestamp: Long,
-    /**
-     * Fingerprint of the SDK key the failure was produced for. Entitlements differ per environment, so
-     * a verdict from one must not gate another.
-     */
-    val environment: String,
 )
 
 /**
@@ -47,30 +42,29 @@ internal class SessionReplayInitializationStore(
     private val prefs: SharedPreferences,
     sdkKey: String,
 ) {
-    private val environment = fingerprint(sdkKey)
+    private val failureKey = failureKey(sdkKey)
 
-    /** The stored failure, or `null` when there is none or it belongs to a different environment. */
+    /** The stored failure for this environment, or `null` when there is none. */
     fun loadFailure(): SessionReplayInitializationFailure? {
-        val stored = prefs.getString(KEY_LAST_UNRECOVERABLE_FAILURE, null) ?: return null
+        val stored = prefs.getString(failureKey, null) ?: return null
 
-        return decode(stored)?.takeIf { it.environment == environment }
+        return decode(stored)
     }
 
     fun store(reason: String, timestamp: Long = System.currentTimeMillis()) {
         val failure = SessionReplayInitializationFailure(
             reason = reason.take(MAX_REASON_LENGTH),
             timestamp = timestamp,
-            environment = environment,
         )
-        prefs.edit().putString(KEY_LAST_UNRECOVERABLE_FAILURE, encode(failure)).apply()
+        prefs.edit().putString(failureKey, encode(failure)).apply()
     }
 
     fun clearFailure() {
-        prefs.edit().remove(KEY_LAST_UNRECOVERABLE_FAILURE).apply()
+        prefs.edit().remove(failureKey).apply()
     }
 
     internal companion object {
-        const val KEY_LAST_UNRECOVERABLE_FAILURE = "sessionReplayLastUnrecoverableFailure"
+        const val KEY_PREFIX_LAST_UNRECOVERABLE_FAILURE = "sessionReplayLastUnrecoverableFailure"
 
         /**
          * The reason is diagnostic only, and an error message can carry a whole response body, so it is
@@ -90,10 +84,17 @@ internal class SessionReplayInitializationStore(
         }
 
         /**
+         * Entitlements differ per environment, so a verdict from one must neither gate another nor
+         * overwrite what is cached for it - hence a key per SDK key rather than a shared one.
+         */
+        fun failureKey(sdkKey: String): String =
+            "$KEY_PREFIX_LAST_UNRECOVERABLE_FAILURE.${fingerprint(sdkKey)}"
+
+        /**
          * Distinguishes environments without writing the SDK key itself to disk. Only equality matters,
          * so a truncated digest is enough.
          */
-        fun fingerprint(sdkKey: String): String =
+        private fun fingerprint(sdkKey: String): String =
             MessageDigest.getInstance("SHA-256")
                 .digest(sdkKey.toByteArray())
                 .take(8)

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/SessionReplayRecordingGate.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/SessionReplayRecordingGate.kt
@@ -1,0 +1,82 @@
+package com.launchdarkly.observability.replay
+
+/**
+ * Decides whether Session Replay may take screenshots, from the recording verdicts seen during this
+ * launch and the unrecoverable failure cached from a previous one.
+ *
+ * Kept separate from the service (like [SessionReplaySamplingSession]) so the orderings that matter — a
+ * refusal arriving before start, a launch that begins with screenshots withheld, a refusal after a
+ * recovery — are testable without a live service. Not thread-safe: the owner serializes access.
+ *
+ * Mirrors `SessionReplayRecordingGate` in the Swift session replay SDK.
+ */
+internal class SessionReplayRecordingGate(hasCachedFailure: Boolean) {
+    /** What the owning service must do in response to a verdict. */
+    sealed interface Outcome {
+        /** Nothing to do: the verdict confirms the state the gate is already in. */
+        data object None : Outcome
+
+        /**
+         * Screenshots were withheld and may now start. The cached failure is resolved, so it must be
+         * erased for the next launch to record from the start.
+         */
+        data object ReleaseScreenCapture : Outcome
+
+        /**
+         * Recording must end for this launch, and [reason] must be persisted so the next launch
+         * withholds screenshots until the backend has answered.
+         */
+        data class StopRecording(val reason: String) : Outcome
+    }
+
+    /**
+     * Whether screenshots are being held back until the backend accepts the session. Starts out set when
+     * a previous launch was refused.
+     */
+    private var isWithheld = hasCachedFailure
+    private var hasFailedUnrecoverably = false
+
+    /**
+     * Screenshots are taken from the start unless a previous launch was refused, in which case the
+     * backend has to accept the session first.
+     */
+    val isScreenCaptureAllowed: Boolean
+        get() = !hasFailedUnrecoverably && !isWithheld
+
+    /**
+     * Whether recording can start at all. A refused launch cannot record again: the exporter stops
+     * talking to the backend until the process is relaunched.
+     */
+    val canStartRecording: Boolean
+        get() = !hasFailedUnrecoverably
+
+    /**
+     * Whether a verdict is still owed while screenshots are withheld, which makes a foreground worth
+     * another attempt.
+     */
+    val isAwaitingVerdict: Boolean
+        get() = !hasFailedUnrecoverably && isWithheld
+
+    fun apply(verdict: SessionReplayInitializationVerdict): Outcome = when (verdict) {
+        is SessionReplayInitializationVerdict.Allowed -> {
+            // A refusal is final for this launch, and an acceptance changes nothing when screenshots are
+            // already being taken.
+            if (hasFailedUnrecoverably || !isWithheld) {
+                Outcome.None
+            } else {
+                isWithheld = false
+                Outcome.ReleaseScreenCapture
+            }
+        }
+
+        is SessionReplayInitializationVerdict.Unrecoverable -> {
+            if (hasFailedUnrecoverably) {
+                Outcome.None
+            } else {
+                hasFailedUnrecoverably = true
+                isWithheld = true
+                Outcome.StopRecording(verdict.reason)
+            }
+        }
+    }
+}

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/SessionReplayService.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/SessionReplayService.kt
@@ -290,24 +290,30 @@ class SessionReplayService(
      */
     private fun startCaptureStateObserver() {
         instrumentationScope.launch {
-            combine(shouldCapture, _isRunning, isScreenCaptureAllowed) { shouldRun, running, allowed ->
-                shouldRun && running && allowed
+            var hasEnabledTouchCapture = false
+
+            combine(shouldCapture, _isRunning, isScreenCaptureAllowed) { shouldRun, running, screenshotsAllowed ->
+                (shouldRun && running) to screenshotsAllowed
             }
-                .collect { shouldRun ->
-                    val running = captureJob?.isActive == true
-                    if (shouldRun == running) return@collect
-                    if (shouldRun) {
-                        // Session Replay needs the shared touch hook regardless of
-                        // `instrumentations.userTaps`. Both calls are idempotent: attach ensures the
-                        // current window is tracked (Observability already attaches at init), and
-                        // enable wraps that already-current window plus future ones - so capture
-                        // starting after the first activity is up still records its touches.
+                .collect { (isRecording, screenshotsAllowed) ->
+                    // Session Replay needs the shared touch hook regardless of
+                    // `instrumentations.userTaps`, and regardless of [isScreenCaptureAllowed]: while
+                    // screenshots are withheld, interactions still queue and are pushed once the backend
+                    // accepts the session. Both calls are idempotent: attach ensures the current window is
+                    // tracked (Observability already attaches at init), and enable wraps that
+                    // already-current window plus future ones - so capture starting after the first
+                    // activity is up still records its touches.
+                    if (isRecording && !hasEnabledTouchCapture) {
+                        hasEnabledTouchCapture = true
                         observabilityContext.userInteractionManager?.apply {
                             attachToApplication(observabilityContext.application)
                             enableTouchCapture()
                         }
-                        doRunCapture()
-                    } else doPauseCapture()
+                    }
+
+                    val shouldCaptureScreen = isRecording && screenshotsAllowed
+                    if (shouldCaptureScreen == (captureJob?.isActive == true)) return@collect
+                    if (shouldCaptureScreen) doRunCapture() else doPauseCapture()
                 }
         }
     }

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/SessionReplayService.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/SessionReplayService.kt
@@ -1,11 +1,13 @@
 package com.launchdarkly.observability.replay
 
 import android.app.Activity
+import android.content.Context
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ProcessLifecycleOwner
 import com.launchdarkly.observability.context.ObserveLogger
+import com.launchdarkly.observability.client.AppLaunchTracker
 import com.launchdarkly.observability.client.AppLifecycleSignal
 import com.launchdarkly.observability.client.ObservabilityContext
 import com.launchdarkly.observability.coroutines.DispatcherProviderHolder
@@ -83,6 +85,11 @@ class SessionReplayService(
     private val instrumentationScope = CoroutineScope(DispatcherProviderHolder.current.default + SupervisorJob())
     private var captureJob: Job? = null
     private val shouldCapture = MutableStateFlow(false)
+    /**
+     * Whether the backend has cleared this launch for screenshots. Starts withheld when a previous launch
+     * was refused, and is released once `initializeSession` succeeds.
+     */
+    private val isScreenCaptureAllowed = MutableStateFlow(true)
     private val _isEnabled = MutableStateFlow(options.enabled)
     private val _isRunning = MutableStateFlow(false)
     private val sampleRate = options.sampleRate
@@ -92,6 +99,13 @@ class SessionReplayService(
     private var exporter: SessionReplayExporter? = null
     private val pendingIdentifyLock = Any()
     private var pendingIdentify: IdentifyItemPayload? = null
+    private var initializationStore: SessionReplayInitializationStore? = null
+    /**
+     * Decides whether screenshots may be taken, from this launch's verdicts and the failure cached from a
+     * previous launch. Verdicts arrive on the export thread, so every access goes through [withGate].
+     */
+    private val recordingGateLock = Any()
+    private var recordingGate = SessionReplayRecordingGate(hasCachedFailure = false)
 
     /**
      * Installs replay instrumentation. Idempotent.
@@ -147,6 +161,21 @@ class SessionReplayService(
                 sessionId = null
             )
         }
+        val store = SessionReplayInitializationStore(
+            prefs = application.getSharedPreferences(AppLaunchTracker.PREFS_NAME, Context.MODE_PRIVATE),
+            sdkKey = observabilityContext.sdkKey,
+        )
+        val cachedFailure = store.loadFailure()
+        initializationStore = store
+        recordingGate = SessionReplayRecordingGate(hasCachedFailure = cachedFailure != null)
+        isScreenCaptureAllowed.value = recordingGate.isScreenCaptureAllowed
+        if (cachedFailure != null) {
+            logger.info(
+                "Session replay is holding screenshots until initializeSession succeeds, " +
+                    "previous launch failed with: ${cachedFailure.reason}"
+            )
+        }
+
         val exporter = SessionReplayExporter(
             organizationVerboseId = observabilityContext.sdkKey,
             backendUrl = observabilityContext.options.backendUrl,
@@ -156,6 +185,7 @@ class SessionReplayService(
             title = appName,
             logger = logger,
             initialAppLaunchItemPayload = initialAppLaunchItemPayload,
+            onInitializationVerdict = ::handleInitializationVerdict,
         )
         this@SessionReplayService.exporter = exporter
         batchWorker.addExporter(exporter)
@@ -260,7 +290,9 @@ class SessionReplayService(
      */
     private fun startCaptureStateObserver() {
         instrumentationScope.launch {
-            combine(shouldCapture, _isRunning) { shouldRun, running -> shouldRun && running }
+            combine(shouldCapture, _isRunning, isScreenCaptureAllowed) { shouldRun, running, allowed ->
+                shouldRun && running && allowed
+            }
                 .collect { shouldRun ->
                     val running = captureJob?.isActive == true
                     if (shouldRun == running) return@collect
@@ -332,10 +364,17 @@ class SessionReplayService(
         get() = _isEnabled.value
         set(value) {
             if (_isEnabled.value == value) return
-            _isEnabled.value = value
             if (value) {
+                // A launch the backend has refused cannot record again, so enabling must not report itself
+                // as enabled. The next launch tries again.
+                if (!withGate { canStartRecording }) {
+                    logger.info("Session replay cannot start, the backend refused this launch.")
+                    return
+                }
+                _isEnabled.value = true
                 attemptStart(ignoreSampling = false)
             } else {
+                _isEnabled.value = false
                 stopRecording()
             }
         }
@@ -349,12 +388,23 @@ class SessionReplayService(
 
     private fun attemptStart(ignoreSampling: Boolean): Boolean {
         if (_isRunning.value) return true
+        // The exporter stops talking to the backend after an unrecoverable refusal, so starting would only
+        // collect events that can never be pushed.
+        if (!withGate { canStartRecording }) {
+            logger.info("Session replay cannot start, the backend refused this launch.")
+            return false
+        }
         if (!samplingSession.shouldStartCapture(ignoreSampling, sampleRate)) {
             logger.info("Session replay skipped by sampling.")
             return false
         }
         _isRunning.value = true
         flushPendingIdentify()
+        // Ask the backend up front instead of waiting for the first export batch, so a refusal can stop
+        // (or keep withholding) screenshots at the very start of the launch. Input events keep flowing into
+        // the event queue meanwhile: they buffer there until the queue overflows, and are pushed as soon as
+        // the session is accepted.
+        startInitializationProbe()
         return true
     }
 
@@ -362,6 +412,60 @@ class SessionReplayService(
         samplingSession.reset()
         _isRunning.value = false
     }
+
+    /**
+     * Initializes the current session on the backend, off the export path.
+     */
+    private fun startInitializationProbe() {
+        if (!this::sessionManager.isInitialized) return
+        val exporterSnapshot = exporter ?: return
+
+        val sessionId = sessionManager.getSessionId()
+        instrumentationScope.launch { exporterSnapshot.prepareSession(sessionId) }
+    }
+
+    /**
+     * Asks the backend again while screenshots are withheld by a failure cached from a previous launch. A
+     * launch that starts in the background often probes with no network, or is suspended mid-request, and
+     * becoming visible is the moment worth retrying: with capture withheld there are no frames to export,
+     * so nothing else would trigger an attempt until the user happens to tap or navigate.
+     */
+    private fun retryInitializationIfWithheld() {
+        if (!_isRunning.value) return
+        if (!withGate { isAwaitingVerdict }) return
+
+        startInitializationProbe()
+    }
+
+    /**
+     * Applies a recording verdict from the exporter: an accepted session releases screen capture (and
+     * clears any cached failure), a refused one ends recording for this launch and is remembered so the
+     * next launch does not take screenshots before the backend has answered.
+     */
+    private fun handleInitializationVerdict(verdict: SessionReplayInitializationVerdict) {
+        when (val outcome = withGate { apply(verdict) }) {
+            is SessionReplayRecordingGate.Outcome.None -> Unit
+
+            is SessionReplayRecordingGate.Outcome.ReleaseScreenCapture -> {
+                initializationStore?.clearFailure()
+                logger.info("Session replay recovered, resuming screenshots.")
+                isScreenCaptureAllowed.value = true
+            }
+
+            is SessionReplayRecordingGate.Outcome.StopRecording -> {
+                initializationStore?.store(outcome.reason)
+                logger.error("Session replay stopped, the backend refused this launch: ${outcome.reason}")
+                isScreenCaptureAllowed.value = false
+                // Recording is over for this launch, so report replay as disabled rather than leaving
+                // `isEnabled` claiming otherwise.
+                _isEnabled.value = false
+                stopRecording()
+            }
+        }
+    }
+
+    private inline fun <T> withGate(block: SessionReplayRecordingGate.() -> T): T =
+        synchronized(recordingGateLock) { recordingGate.block() }
 
     override fun flush() {
         batchWorker.flush()
@@ -380,6 +484,7 @@ class SessionReplayService(
             // activity transitions and configuration changes don't flicker capture.
             override fun onResume(owner: LifecycleOwner) {
                 runCapture()
+                retryInitializationIfWithheld()
             }
 
             override fun onPause(owner: LifecycleOwner) {

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/SessionReplayService.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/SessionReplayService.kt
@@ -406,7 +406,14 @@ class SessionReplayService(
             logger.info("Session replay skipped by sampling.")
             return false
         }
-        _isRunning.value = true
+        // Re-checked while holding the gate's lock, the one a verdict is applied under, because a refusal
+        // can land while sampling is being evaluated above: without this, its `stopRecording` would be
+        // undone here and the collectors would keep running for a launch reporting itself disabled.
+        val canStart = withGate { canStartRecording.also { if (it) _isRunning.value = true } }
+        if (!canStart) {
+            logger.info("Session replay cannot start, the backend refused this launch.")
+            return false
+        }
         flushPendingIdentify()
         // Ask the backend up front instead of waiting for the first export batch, so a refusal can stop
         // (or keep withholding) screenshots at the very start of the launch. Input events keep flowing into

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/SessionReplayService.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/SessionReplayService.kt
@@ -372,12 +372,14 @@ class SessionReplayService(
             if (_isEnabled.value == value) return
             if (value) {
                 // A launch the backend has refused cannot record again, so enabling must not report itself
-                // as enabled. The next launch tries again.
-                if (!withGate { canStartRecording }) {
+                // as enabled. The next launch tries again. Checking and enabling under the gate's lock, the
+                // same one a verdict is applied under, keeps a refusal that lands in between from being
+                // overwritten by the enable that raced it.
+                val canStart = withGate { canStartRecording.also { if (it) _isEnabled.value = true } }
+                if (!canStart) {
                     logger.info("Session replay cannot start, the backend refused this launch.")
                     return
                 }
-                _isEnabled.value = true
                 attemptStart(ignoreSampling = false)
             } else {
                 _isEnabled.value = false
@@ -449,7 +451,16 @@ class SessionReplayService(
      * next launch does not take screenshots before the backend has answered.
      */
     private fun handleInitializationVerdict(verdict: SessionReplayInitializationVerdict) {
-        when (val outcome = withGate { apply(verdict) }) {
+        // Recording is over for this launch, so report replay as disabled rather than leaving `isEnabled`
+        // claiming otherwise. Set under the gate's lock, together with the verdict that decided it, so an
+        // `isEnabled = true` racing this refusal cannot end up as the last write.
+        val outcome = withGate {
+            apply(verdict).also {
+                if (it is SessionReplayRecordingGate.Outcome.StopRecording) _isEnabled.value = false
+            }
+        }
+
+        when (outcome) {
             is SessionReplayRecordingGate.Outcome.None -> Unit
 
             is SessionReplayRecordingGate.Outcome.ReleaseScreenCapture -> {
@@ -462,9 +473,6 @@ class SessionReplayService(
                 initializationStore?.store(outcome.reason)
                 logger.error("Session replay stopped, the backend refused this launch: ${outcome.reason}")
                 isScreenCaptureAllowed.value = false
-                // Recording is over for this launch, so report replay as disabled rather than leaving
-                // `isEnabled` claiming otherwise.
-                _isEnabled.value = false
                 stopRecording()
             }
         }

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/exporter/SessionReplayApiService.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/exporter/SessionReplayApiService.kt
@@ -1,8 +1,10 @@
 package com.launchdarkly.observability.replay.exporter
 
 import com.launchdarkly.observability.BuildConfig
+import com.launchdarkly.observability.network.ErrorRecoverability
 import com.launchdarkly.observability.network.GraphQLClient
 import com.launchdarkly.observability.network.GraphQLResponse
+import com.launchdarkly.observability.network.RecoverableFailure
 import com.launchdarkly.observability.replay.Event
 import com.launchdarkly.observability.replay.IdentifySessionResponse
 import com.launchdarkly.observability.replay.InitializeReplaySessionResponse
@@ -257,8 +259,15 @@ class SessionReplayApiService(
     private fun <T> throwOnErrors(response: GraphQLResponse<T>, operation: String) {
         val errors = response.errors?.takeIf { it.isNotEmpty() } ?: return
         val message = errors.joinToString("; ") { it.message }
-        throw SessionReplayApiException("$operation failed: $message")
+        // Classify here, while the status code and the error `extensions` are still available.
+        throw SessionReplayApiException(
+            message = "$operation failed: $message",
+            isRecoverable = ErrorRecoverability.isErrorRecoverable(response),
+        )
     }
 }
 
-internal class SessionReplayApiException(message: String) : RuntimeException(message)
+internal class SessionReplayApiException(
+    message: String,
+    override val isRecoverable: Boolean = true,
+) : RuntimeException(message), RecoverableFailure

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/exporter/SessionReplayApiService.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/exporter/SessionReplayApiService.kt
@@ -3,13 +3,14 @@ package com.launchdarkly.observability.replay.exporter
 import com.launchdarkly.observability.BuildConfig
 import com.launchdarkly.observability.network.ErrorRecoverability
 import com.launchdarkly.observability.network.GraphQLClient
-import com.launchdarkly.observability.network.GraphQLResponse
+import com.launchdarkly.observability.network.GraphQLClientException
 import com.launchdarkly.observability.network.RecoverableFailure
 import com.launchdarkly.observability.replay.Event
 import com.launchdarkly.observability.replay.IdentifySessionResponse
 import com.launchdarkly.observability.replay.InitializeReplaySessionResponse
 import com.launchdarkly.observability.replay.PushPayloadResponse
 import com.launchdarkly.observability.replay.ReplayEventsInput
+import kotlinx.serialization.KSerializer
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
@@ -177,12 +178,12 @@ class SessionReplayApiService(
             "privacy_setting" to JsonPrimitive("none"), // TODO: O11Y-631 - remove hardcoded params
             "id" to JsonPrimitive("") // TODO: O11Y-631 - remove hardcoded params
         )
-        val response = graphqlClient.execute(
+        execute(
+            operation = "initializeReplaySession",
             query = INITIALIZE_REPLAY_SESSION_QUERY,
             variables = variables,
             dataSerializer = InitializeReplaySessionResponse.serializer()
         )
-        throwOnErrors(response, "initializeReplaySession")
     }
 
     /**
@@ -201,13 +202,12 @@ class SessionReplayApiService(
             "user_identifier" to JsonPrimitive(userIdentifier),
             "user_object" to userObject
         )
-        val response = graphqlClient.execute(
+        execute(
+            operation = "identifyReplaySession",
             query = IDENTIFY_REPLAY_SESSION_QUERY,
             variables = variables,
             dataSerializer = IdentifySessionResponse.serializer()
         )
-
-        throwOnErrors(response, "identifyReplaySession")
     }
 
     /**
@@ -247,27 +247,39 @@ class SessionReplayApiService(
             "errors" to JsonArray(emptyList()),
         )
 
-        val response = graphqlClient.execute(
+        execute(
+            operation = "pushPayload",
             query = PUSH_PAYLOAD_QUERY,
             variables = variables,
             dataSerializer = PushPayloadResponse.serializer()
         )
-
-        throwOnErrors(response, "pushPayload")
     }
 
-    private fun <T> throwOnErrors(response: GraphQLResponse<T>, operation: String) {
-        val errors = response.errors?.takeIf { it.isNotEmpty() } ?: return
-        val message = errors.joinToString("; ") { it.message }
-        // Classify here, while the status code and the error `extensions` are still available.
-        throw SessionReplayApiException(
-            message = "$operation failed: $message",
-            isRecoverable = ErrorRecoverability.isErrorRecoverable(response),
-        )
+    /**
+     * Runs [query] and discards the response data, which none of these mutations reports anything useful
+     * in, naming the operation in whatever it throws.
+     */
+    private suspend fun <T> execute(
+        operation: String,
+        query: String,
+        variables: Map<String, JsonElement>,
+        dataSerializer: KSerializer<T>,
+    ) {
+        try {
+            graphqlClient.execute(query = query, variables = variables, dataSerializer = dataSerializer)
+        } catch (e: GraphQLClientException) {
+            throw SessionReplayApiException(operation, e)
+        }
     }
 }
 
+/**
+ * A failed session replay operation, named. Adds the operation to the failure the client threw and takes
+ * its recoverability from it, so no verdict is derived twice.
+ */
 internal class SessionReplayApiException(
-    message: String,
-    override val isRecoverable: Boolean = true,
-) : RuntimeException(message), RecoverableFailure
+    operation: String,
+    cause: GraphQLClientException,
+) : RuntimeException("$operation failed: ${cause.message}", cause), RecoverableFailure {
+    override val isRecoverable: Boolean = ErrorRecoverability.isErrorRecoverable(cause)
+}

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/exporter/SessionReplayExporter.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/exporter/SessionReplayExporter.kt
@@ -310,8 +310,13 @@ class SessionReplayExporter(
                 try {
                     replayApiService.identifyReplaySession(sessionId, newIdentifyEvent)
                     identifyItemPayload = newIdentifyEvent
+                } catch (e: CancellationException) {
+                    throw e
                 } catch (e: Exception) {
+                    // There is nothing to retry an identify with, so the failure is only logged - but a
+                    // refusal ends recording here like it does for any other request.
                     logger.error(e)
+                    reportIfUnrecoverable(e)
                 }
             }
         }

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/exporter/SessionReplayExporter.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/exporter/SessionReplayExporter.kt
@@ -117,6 +117,9 @@ class SessionReplayExporter(
         if (hasFailedUnrecoverably) return
 
         exportMutex.withLock {
+            // The refusal can also arrive while this batch waits for the lock, from the startup probe.
+            if (hasFailedUnrecoverably) return@withLock
+
             val lastCaptureSnapshot = lastCaptureState
             val payloadIdSnapshot = payloadIdCounter
             val pushedCanvasSnapshot = pushedCanvasSize
@@ -201,6 +204,11 @@ class SessionReplayExporter(
                 // Send all events grouped by session
                 for ((sessionId, events) in eventsBySession) {
                     if (events.isNotEmpty()) {
+                        // A refusal can also land part-way through a batch, from a wake-up push whose
+                        // failure is swallowed below, and a refused session accepts no payloads. What is
+                        // left of the batch is dropped rather than retried, like any batch after a refusal.
+                        if (hasFailedUnrecoverably) return@withLock
+
                         // Events can belong to a session no capture has been taken of yet — while
                         // screenshots are withheld, or from a touch that precedes the first frame — and the
                         // backend only accepts payloads for an initialized session.

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/exporter/SessionReplayExporter.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/exporter/SessionReplayExporter.kt
@@ -228,7 +228,14 @@ class SessionReplayExporter(
                 pushedCanvasSize = pushedCanvasSnapshot
                 shouldWakeUpSession = shouldWakeUpSnapshot
                 eventGenerator.restoreState(generatorSnapshot)
+                if (e is CancellationException) throw e
+
                 reportIfUnrecoverable(e)
+                // A refusal is not a retryable export failure: rethrowing it would have the worker back
+                // off (up to a minute) still holding a batch nothing accepts any more, so the drain would
+                // only start once that backoff expires.
+                if (hasFailedUnrecoverably) return@withLock
+
                 throw e
             }
         }

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/exporter/SessionReplayExporter.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/exporter/SessionReplayExporter.kt
@@ -293,6 +293,10 @@ class SessionReplayExporter(
 
     suspend fun sendIdentifyAndCache(newIdentifyEvent: IdentifyItemPayload) {
         exportMutex.withLock {
+            // The identify hook stays registered after recording ends, so without this the abandoned
+            // session would keep receiving identify calls.
+            if (hasFailedUnrecoverably) return@withLock
+
             val sessionId = newIdentifyEvent.sessionId
             if (sessionId != null) {
                 try {

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/exporter/SessionReplayExporter.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/exporter/SessionReplayExporter.kt
@@ -252,6 +252,7 @@ class SessionReplayExporter(
             replayApiService.initializeReplaySession(organizationVerboseId, sessionId)
             // Accepting the session is the recording verdict on its own: reporting it here rather than
             // after `identifyReplaySession` keeps a transient identify failure from withholding screenshots.
+            // An unrecoverable identify failure still refuses the launch, through the catch below.
             report(SessionReplayInitializationVerdict.Allowed)
             replayApiService.identifyReplaySession(sessionId, identifyItemPayload)
         } catch (e: Exception) {

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/exporter/SessionReplayExporter.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/exporter/SessionReplayExporter.kt
@@ -1,13 +1,16 @@
 package com.launchdarkly.observability.replay.exporter
 
 import com.launchdarkly.observability.context.ObserveLogger
+import com.launchdarkly.observability.network.ErrorRecoverability
 import com.launchdarkly.observability.network.GraphQLClient
 import com.launchdarkly.observability.replay.Event
+import com.launchdarkly.observability.replay.SessionReplayInitializationVerdict
 import com.launchdarkly.observability.replay.capture.ExportFrame
 import com.launchdarkly.observability.replay.transport.EventExporting
 import com.launchdarkly.observability.replay.transport.EventQueueItem
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlin.coroutines.cancellation.CancellationException
 
 // size limit of accumulated continues canvas operations on the RRWeb player
 private const val RRWEB_CANVAS_BUFFER_LIMIT =  10_000_000 // ~10mb
@@ -42,6 +45,11 @@ class SessionReplayExporter(
      * is never read from the shared context on the export thread.
      */
     initialAppLaunchItemPayload: AppLaunchItemPayload? = null,
+    /**
+     * Receives every recording verdict, so the service can withhold or stop screenshots. Invoked from
+     * the export thread.
+     */
+    private val onInitializationVerdict: ((SessionReplayInitializationVerdict) -> Unit)? = null,
 ) : EventExporting {
     private val exportMutex = Mutex()
 
@@ -65,6 +73,17 @@ class SessionReplayExporter(
     private var shouldWakeUpSession = true
     private val eventGenerator = RRWebEventGenerator(canvasDrawEntourage, title)
 
+    /** Sessions the backend has accepted, so they are initialized at most once. Guarded by [exportMutex]. */
+    private val initializedSessions = mutableSetOf<String>()
+
+    /**
+     * Set once the backend rejects the session unrecoverably. Recording cannot come back within this
+     * process — a new attempt is made only on a fresh launch — so no further requests are made and queued
+     * items are drained instead of retried. Read before taking [exportMutex], hence volatile.
+     */
+    @Volatile
+    private var hasFailedUnrecoverably = false
+
     private data class LastCaptureState(
         val sessionId: String?,
         val height: Int,
@@ -74,8 +93,28 @@ class SessionReplayExporter(
     private var lastCaptureState = LastCaptureState(sessionId = null, height = 0, width = 0)
     private var pushedCanvasSize = 0
 
+    /**
+     * Initializes [sessionId] without waiting for the first export batch, so an unrecoverable rejection
+     * can stop capture at the very start of the launch. The verdict is delivered through
+     * [onInitializationVerdict] and the export retry loop owns any retry, so failures are not rethrown.
+     */
+    suspend fun prepareSession(sessionId: String) {
+        exportMutex.withLock {
+            try {
+                initializeSessionIfNeeded(sessionId)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                logger.error(e)
+            }
+        }
+    }
+
     override suspend fun export(items: List<EventQueueItem>) {
         if (items.isEmpty()) return
+        // Return without pushing so the queue drains: recording is over for this launch, and holding the
+        // items would only keep the buffer full.
+        if (hasFailedUnrecoverably) return
 
         exportMutex.withLock {
             val lastCaptureSnapshot = lastCaptureState
@@ -156,14 +195,16 @@ class SessionReplayExporter(
 
                 // Initialize sessions that need it
                 for (sessionId in sessionsNeedingInit) {
-                    replayApiService.initializeReplaySession(organizationVerboseId, sessionId)
-                    replayApiService.identifyReplaySession(sessionId, identifyItemPayload)
-                    // TODO: O11Y-624 - handle request failures
+                    initializeSessionIfNeeded(sessionId)
                 }
 
                 // Send all events grouped by session
                 for ((sessionId, events) in eventsBySession) {
                     if (events.isNotEmpty()) {
+                        // Events can belong to a session no capture has been taken of yet — while
+                        // screenshots are withheld, or from a touch that precedes the first frame — and the
+                        // backend only accepts payloads for an initialized session.
+                        initializeSessionIfNeeded(sessionId)
                         replayApiService.pushPayload(sessionId, "${nextPayloadId()}", events)
                         // flushes generating canvas size into pushedCanvasSize
                         pushedCanvasSize = eventGenerator.accumulatedCanvasSize
@@ -179,9 +220,46 @@ class SessionReplayExporter(
                 pushedCanvasSize = pushedCanvasSnapshot
                 shouldWakeUpSession = shouldWakeUpSnapshot
                 eventGenerator.restoreState(generatorSnapshot)
+                reportIfUnrecoverable(e)
                 throw e
             }
         }
+    }
+
+    /**
+     * Initializes [sessionId] once, and reports what the backend made of it. A failure leaves the session
+     * uninitialized so the next attempt retries both calls, and is rethrown for the export retry loop.
+     */
+    private suspend fun initializeSessionIfNeeded(sessionId: String) {
+        if (hasFailedUnrecoverably || !initializedSessions.add(sessionId)) return
+
+        try {
+            replayApiService.initializeReplaySession(organizationVerboseId, sessionId)
+            // Accepting the session is the recording verdict on its own: reporting it here rather than
+            // after `identifyReplaySession` keeps a transient identify failure from withholding screenshots.
+            report(SessionReplayInitializationVerdict.Allowed)
+            replayApiService.identifyReplaySession(sessionId, identifyItemPayload)
+        } catch (e: Exception) {
+            initializedSessions.remove(sessionId)
+            reportIfUnrecoverable(e)
+            throw e
+        }
+    }
+
+    /**
+     * Classifies a failed request: recoverable errors are left to the export retry loop (items stay
+     * buffered until the queue overflows), while an unrecoverable one ends recording for this launch.
+     */
+    private fun reportIfUnrecoverable(error: Throwable) {
+        if (hasFailedUnrecoverably || ErrorRecoverability.isErrorRecoverable(error)) return
+
+        hasFailedUnrecoverably = true
+        logger.error("Session replay stopped, unrecoverable error", error)
+        report(SessionReplayInitializationVerdict.Unrecoverable(error.message ?: error.toString()))
+    }
+
+    private fun report(verdict: SessionReplayInitializationVerdict) {
+        onInitializationVerdict?.invoke(verdict)
     }
 
     private suspend fun wakeUpEvents(
@@ -201,6 +279,7 @@ class SessionReplayExporter(
         } catch (e: Exception) {
             // put wake up in the try/catch do not break buffering logic
             logger.error(e)
+            reportIfUnrecoverable(e)
         }
     }
 

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/exporter/SessionReplayExporter.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/exporter/SessionReplayExporter.kt
@@ -305,19 +305,27 @@ class SessionReplayExporter(
             // session would keep receiving identify calls.
             if (hasFailedUnrecoverably) return@withLock
 
-            val sessionId = newIdentifyEvent.sessionId
-            if (sessionId != null) {
-                try {
-                    replayApiService.identifyReplaySession(sessionId, newIdentifyEvent)
-                    identifyItemPayload = newIdentifyEvent
-                } catch (e: CancellationException) {
-                    throw e
-                } catch (e: Exception) {
-                    // There is nothing to retry an identify with, so the failure is only logged - but a
-                    // refusal ends recording here like it does for any other request.
-                    logger.error(e)
-                    reportIfUnrecoverable(e)
-                }
+            val sessionId = newIdentifyEvent.sessionId ?: return@withLock
+
+            // The backend only accepts identify for a session it has already accepted, and the startup
+            // probe can still be in flight - identifying now would be answered with an error that a
+            // refusal cannot be told apart from. Caching is enough: initialization sends the payload it
+            // finds here, so the latest one reaches the backend either way.
+            if (sessionId !in initializedSessions) {
+                identifyItemPayload = newIdentifyEvent
+                return@withLock
+            }
+
+            try {
+                replayApiService.identifyReplaySession(sessionId, newIdentifyEvent)
+                identifyItemPayload = newIdentifyEvent
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                // There is nothing to retry an identify with, so the failure is only logged - but a
+                // refusal ends recording here like it does for any other request.
+                logger.error(e)
+                reportIfUnrecoverable(e)
             }
         }
     }

--- a/sdk/@launchdarkly/observability-android/lib/src/test/kotlin/com/launchdarkly/observability/network/ErrorRecoverabilityTest.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/test/kotlin/com/launchdarkly/observability/network/ErrorRecoverabilityTest.kt
@@ -3,6 +3,7 @@ package com.launchdarkly.observability.network
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import java.io.IOException
 
 class ErrorRecoverabilityTest {
 
@@ -35,26 +36,26 @@ class ErrorRecoverabilityTest {
     }
 
     @Test
-    fun `graph errors on a 200 are unrecoverable`() {
-        val response = response(statusCode = 200, errors = listOf(GraphQLError(message = "session replay blocked")))
+    fun `graph errors are unrecoverable`() {
+        val failure = GraphQLClientException.GraphQLErrors(listOf(GraphQLError(message = "session replay blocked")))
 
-        assertFalse(ErrorRecoverability.isErrorRecoverable(response))
+        assertFalse(ErrorRecoverability.isErrorRecoverable(failure))
     }
 
     @Test
-    fun `a retryable graph error is recoverable despite the 200`() {
-        val response = response(
-            statusCode = 200,
-            errors = listOf(GraphQLError(message = "try later", extensions = GraphQLErrorExtensions(retryable = true))),
+    fun `a retryable graph error is recoverable`() {
+        val failure = GraphQLClientException.GraphQLErrors(
+            listOf(GraphQLError(message = "try later", extensions = GraphQLErrorExtensions(retryable = true)))
         )
 
-        assertTrue(ErrorRecoverability.isErrorRecoverable(response))
+        assertTrue(ErrorRecoverability.isErrorRecoverable(failure))
     }
 
     @Test
     fun `a non retryable graph error wins over a recoverable status`() {
-        val response = response(
+        val failure = GraphQLClientException.HttpStatus(
             statusCode = 429,
+            body = "rejected",
             errors = listOf(
                 GraphQLError(
                     message = "blocked in region",
@@ -63,45 +64,51 @@ class ErrorRecoverabilityTest {
             ),
         )
 
-        assertFalse(ErrorRecoverability.isErrorRecoverable(response))
+        assertFalse(ErrorRecoverability.isErrorRecoverable(failure))
     }
 
     @Test
     fun `a retryable graph error wins over an unrecoverable status`() {
-        val response = response(
+        val failure = GraphQLClientException.HttpStatus(
             statusCode = 403,
+            body = "rejected",
             errors = listOf(GraphQLError(message = "expired token", extensions = GraphQLErrorExtensions(retryable = true))),
         )
 
-        assertTrue(ErrorRecoverability.isErrorRecoverable(response))
+        assertTrue(ErrorRecoverability.isErrorRecoverable(failure))
     }
 
     @Test
-    fun `one non retryable error makes the whole response unrecoverable`() {
-        val response = response(
-            statusCode = 200,
-            errors = listOf(
+    fun `one non retryable error makes the whole failure unrecoverable`() {
+        val failure = GraphQLClientException.GraphQLErrors(
+            listOf(
                 GraphQLError(message = "try later", extensions = GraphQLErrorExtensions(retryable = true)),
                 GraphQLError(message = "blocked", extensions = GraphQLErrorExtensions(retryable = false)),
-            ),
+            )
         )
 
-        assertFalse(ErrorRecoverability.isErrorRecoverable(response))
+        assertFalse(ErrorRecoverability.isErrorRecoverable(failure))
     }
 
     @Test
-    fun `errors without extensions fall back to the status code`() {
+    fun `a rejection without extensions falls back to the status code`() {
         val errors = listOf(GraphQLError(message = "rejected"))
 
-        assertFalse(ErrorRecoverability.isErrorRecoverable(response(statusCode = 403, errors = errors)))
-        assertTrue(ErrorRecoverability.isErrorRecoverable(response(statusCode = 503, errors = errors)))
+        assertFalse(ErrorRecoverability.isErrorRecoverable(GraphQLClientException.HttpStatus(403, "rejected", errors)))
+        assertTrue(ErrorRecoverability.isErrorRecoverable(GraphQLClientException.HttpStatus(503, "rejected", errors)))
     }
 
     @Test
-    fun `a failure without a status is recoverable`() {
-        val response = response(statusCode = null, errors = listOf(GraphQLError(message = "timeout")))
+    fun `a rejection with no GraphQL body is classified by its status`() {
+        assertFalse(ErrorRecoverability.isErrorRecoverable(GraphQLClientException.HttpStatus(403, "Forbidden")))
+        assertTrue(ErrorRecoverability.isErrorRecoverable(GraphQLClientException.HttpStatus(429, "Slow down")))
+    }
 
-        assertTrue(ErrorRecoverability.isErrorRecoverable(response))
+    @Test
+    fun `failures that never reached a status are recoverable`() {
+        assertTrue(ErrorRecoverability.isErrorRecoverable(GraphQLClientException.Transport(IOException("timeout"))))
+        assertTrue(ErrorRecoverability.isErrorRecoverable(GraphQLClientException.Decoding(IOException("bad shape"))))
+        assertTrue(ErrorRecoverability.isErrorRecoverable(GraphQLClientException.MissingData()))
     }
 
     @Test
@@ -114,9 +121,6 @@ class ErrorRecoverabilityTest {
     fun `an unclassified failure is recoverable`() {
         assertTrue(ErrorRecoverability.isErrorRecoverable(IllegalStateException("something went wrong")))
     }
-
-    private fun response(statusCode: Int?, errors: List<GraphQLError>) =
-        GraphQLResponse<String>(data = null, errors = errors, httpStatusCode = statusCode)
 
     private class ClassifiedFailure(override val isRecoverable: Boolean) : RuntimeException(), RecoverableFailure
 }

--- a/sdk/@launchdarkly/observability-android/lib/src/test/kotlin/com/launchdarkly/observability/network/ErrorRecoverabilityTest.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/test/kotlin/com/launchdarkly/observability/network/ErrorRecoverabilityTest.kt
@@ -1,0 +1,122 @@
+package com.launchdarkly.observability.network
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class ErrorRecoverabilityTest {
+
+    @Test
+    fun `unauthorized statuses are unrecoverable`() {
+        listOf(401, 402, 403, 404, 405, 409, 410, 418, 451).forEach { status ->
+            assertFalse(ErrorRecoverability.isHttpErrorRecoverable(status), "status $status")
+        }
+    }
+
+    @Test
+    fun `bad request timeout and rate limit are recoverable`() {
+        listOf(400, 408, 429).forEach { status ->
+            assertTrue(ErrorRecoverability.isHttpErrorRecoverable(status), "status $status")
+        }
+    }
+
+    @Test
+    fun `server errors are recoverable`() {
+        listOf(500, 502, 503, 504).forEach { status ->
+            assertTrue(ErrorRecoverability.isHttpErrorRecoverable(status), "status $status")
+        }
+    }
+
+    @Test
+    fun `non error statuses are recoverable`() {
+        listOf(200, 204, 301, 302).forEach { status ->
+            assertTrue(ErrorRecoverability.isHttpErrorRecoverable(status), "status $status")
+        }
+    }
+
+    @Test
+    fun `graph errors on a 200 are unrecoverable`() {
+        val response = response(statusCode = 200, errors = listOf(GraphQLError(message = "session replay blocked")))
+
+        assertFalse(ErrorRecoverability.isErrorRecoverable(response))
+    }
+
+    @Test
+    fun `a retryable graph error is recoverable despite the 200`() {
+        val response = response(
+            statusCode = 200,
+            errors = listOf(GraphQLError(message = "try later", extensions = GraphQLErrorExtensions(retryable = true))),
+        )
+
+        assertTrue(ErrorRecoverability.isErrorRecoverable(response))
+    }
+
+    @Test
+    fun `a non retryable graph error wins over a recoverable status`() {
+        val response = response(
+            statusCode = 429,
+            errors = listOf(
+                GraphQLError(
+                    message = "blocked in region",
+                    extensions = GraphQLErrorExtensions(code = "SESSION_REPLAY_BLOCKED_IN_REGION", retryable = false),
+                )
+            ),
+        )
+
+        assertFalse(ErrorRecoverability.isErrorRecoverable(response))
+    }
+
+    @Test
+    fun `a retryable graph error wins over an unrecoverable status`() {
+        val response = response(
+            statusCode = 403,
+            errors = listOf(GraphQLError(message = "expired token", extensions = GraphQLErrorExtensions(retryable = true))),
+        )
+
+        assertTrue(ErrorRecoverability.isErrorRecoverable(response))
+    }
+
+    @Test
+    fun `one non retryable error makes the whole response unrecoverable`() {
+        val response = response(
+            statusCode = 200,
+            errors = listOf(
+                GraphQLError(message = "try later", extensions = GraphQLErrorExtensions(retryable = true)),
+                GraphQLError(message = "blocked", extensions = GraphQLErrorExtensions(retryable = false)),
+            ),
+        )
+
+        assertFalse(ErrorRecoverability.isErrorRecoverable(response))
+    }
+
+    @Test
+    fun `errors without extensions fall back to the status code`() {
+        val errors = listOf(GraphQLError(message = "rejected"))
+
+        assertFalse(ErrorRecoverability.isErrorRecoverable(response(statusCode = 403, errors = errors)))
+        assertTrue(ErrorRecoverability.isErrorRecoverable(response(statusCode = 503, errors = errors)))
+    }
+
+    @Test
+    fun `a failure without a status is recoverable`() {
+        val response = response(statusCode = null, errors = listOf(GraphQLError(message = "timeout")))
+
+        assertTrue(ErrorRecoverability.isErrorRecoverable(response))
+    }
+
+    @Test
+    fun `a classified failure keeps its verdict`() {
+        assertFalse(ErrorRecoverability.isErrorRecoverable(ClassifiedFailure(isRecoverable = false)))
+        assertTrue(ErrorRecoverability.isErrorRecoverable(ClassifiedFailure(isRecoverable = true)))
+    }
+
+    @Test
+    fun `an unclassified failure is recoverable`() {
+        assertTrue(ErrorRecoverability.isErrorRecoverable(IllegalStateException("something went wrong")))
+    }
+
+    private fun response(statusCode: Int?, errors: List<GraphQLError>) =
+        GraphQLResponse<String>(data = null, errors = errors, httpStatusCode = statusCode)
+
+    private class ClassifiedFailure(override val isRecoverable: Boolean) : RuntimeException(), RecoverableFailure
+}

--- a/sdk/@launchdarkly/observability-android/lib/src/test/kotlin/com/launchdarkly/observability/network/GraphQLClientTest.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/test/kotlin/com/launchdarkly/observability/network/GraphQLClientTest.kt
@@ -9,10 +9,11 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonPrimitive
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertNotNull
-import org.junit.jupiter.api.assertNull
+import org.junit.jupiter.api.assertThrows
 import java.io.ByteArrayInputStream
 import java.io.IOException
 import java.net.HttpURLConnection
@@ -57,10 +58,8 @@ class GraphQLClientTest {
     }
 
     @Test
-    fun `execute should make successful GraphQL request and return a valid response`() = runTest {
-        val responseJson = """{"data": {"id": "123", "name": "John Doe"}}"""
-
-        every { mockConnection.inputStream } returns ByteArrayInputStream(responseJson.toByteArray())
+    fun `execute should make successful GraphQL request and return the data`() = runTest {
+        respondWith("""{"data": {"id": "123", "name": "John Doe"}}""")
 
         val result = graphQLClient.execute(
             query = testQuery,
@@ -68,49 +67,86 @@ class GraphQLClientTest {
             dataSerializer = TestData.serializer()
         )
 
-        assertNull(result.errors)
-        assertNotNull(result.data)
-        assertEquals("123", result.data.id)
-        assertEquals("John Doe", result.data.name)
+        assertEquals("123", result.id)
+        assertEquals("John Doe", result.name)
         assertEquals(openConnectionWasCalled.first, true)
         assertEquals(openConnectionWasCalled.second, "https://api.example.com/graphql")
     }
 
     @Test
-    fun `execute should handle GraphQL errors in response`() = runTest {
-        val responseJson = """{"data": null, "errors": [{"message": "User not found", "locations": [{"line": 1, "column": 2}], "path": ["user"]}]}"""
-
-        every { mockConnection.inputStream } returns ByteArrayInputStream(responseJson.toByteArray())
-
-        val result = graphQLClient.execute(
-            query = testQuery,
-            dataSerializer = TestData.serializer()
+    fun `execute should throw the GraphQL errors in a response`() = runTest {
+        respondWith(
+            """{"data": null, "errors": [{"message": "User not found", "locations": [{"line": 1, "column": 2}], "path": ["user"]}]}"""
         )
 
-        assertNull(result.data)
-        assertNotNull(result.errors)
-        assertEquals(1, result.errors.size)
-        assertEquals("User not found", result.errors.first().message)
-        assertEquals(1, result.errors.first().locations?.first()?.line)
-        assertEquals(2, result.errors.first().locations?.first()?.column)
-        assertEquals(listOf("user"), result.errors.first().path)
+        val failure = assertThrows<GraphQLClientException.GraphQLErrors> { execute() }
+
+        assertEquals(1, failure.errors.size)
+        assertEquals("User not found", failure.errors.first().message)
+        assertEquals(1, failure.errors.first().locations?.first()?.line)
+        assertEquals(2, failure.errors.first().locations?.first()?.column)
+        assertEquals(listOf("user"), failure.errors.first().path)
+        assertTrue(failure.message!!.contains("User not found"))
     }
 
     @Test
-    fun `execute should handle HTTP error responses`() = runTest {
-        val errorResponse = """{"error": "Unauthorized"}"""
+    fun `execute should read error extensions so failures can be classified`() = runTest {
+        respondWith(
+            """
+            {"data": null, "errors": [{
+                "message": "Session replay is not available in this region.",
+                "extensions": {"code": "SESSION_REPLAY_BLOCKED_IN_REGION", "retryable": false}
+            }]}
+            """.trimIndent()
+        )
 
+        val failure = assertThrows<GraphQLClientException.GraphQLErrors> { execute() }
+
+        assertEquals("SESSION_REPLAY_BLOCKED_IN_REGION", failure.errors.first().extensions?.code)
+        assertEquals(false, failure.errors.first().extensions?.retryable)
+    }
+
+    @Test
+    fun `execute should throw missing data when a response carries neither data nor errors`() = runTest {
+        respondWith("""{"data": null}""")
+
+        assertThrows<GraphQLClientException.MissingData> { execute() }
+    }
+
+    @Test
+    fun `execute should throw a decoding failure for an unexpected response shape`() = runTest {
+        respondWith("""{"data": {"unexpected": true}}""")
+
+        assertThrows<GraphQLClientException.Decoding> { execute() }
+    }
+
+    @Test
+    fun `execute should keep the status of an HTTP error response`() = runTest {
+        val errorResponse = """{"error": "Unauthorized"}"""
         every { mockConnection.responseCode } returns HttpURLConnection.HTTP_UNAUTHORIZED
         every { mockConnection.errorStream } returns ByteArrayInputStream(errorResponse.toByteArray())
 
-        val result = graphQLClient.execute(
-            query = testQuery,
-            dataSerializer = TestData.serializer()
+        val failure = assertThrows<GraphQLClientException.HttpStatus> { execute() }
+
+        assertEquals(HttpURLConnection.HTTP_UNAUTHORIZED, failure.statusCode)
+        assertEquals(errorResponse, failure.body)
+        // Not a GraphQL envelope, so there is nothing more specific than the status.
+        assertNull(failure.errors)
+        assertEquals("HTTP Error ${HttpURLConnection.HTTP_UNAUTHORIZED}: $errorResponse", failure.message)
+    }
+
+    @Test
+    fun `execute should keep the GraphQL errors a rejected response carries`() = runTest {
+        every { mockConnection.responseCode } returns HttpURLConnection.HTTP_FORBIDDEN
+        every { mockConnection.errorStream } returns ByteArrayInputStream(
+            """{"errors": [{"message": "blocked", "extensions": {"retryable": true}}]}""".toByteArray()
         )
 
-        assertNull(result.data)
-        assertNotNull(result.errors)
-        assertEquals("HTTP Error ${HttpURLConnection.HTTP_UNAUTHORIZED}: $errorResponse", result.errors.first().message)
+        val failure = assertThrows<GraphQLClientException.HttpStatus> { execute() }
+
+        assertEquals(HttpURLConnection.HTTP_FORBIDDEN, failure.statusCode)
+        assertEquals("blocked", failure.errors?.first()?.message)
+        assertEquals(true, failure.errors?.first()?.extensions?.retryable)
     }
 
     @Test
@@ -118,42 +154,26 @@ class GraphQLClientTest {
         every { mockConnection.responseCode } returns HttpURLConnection.HTTP_INTERNAL_ERROR
         every { mockConnection.errorStream } returns null
 
-        val result = graphQLClient.execute(
-            query = testQuery,
-            dataSerializer = TestData.serializer()
-        )
+        val failure = assertThrows<GraphQLClientException.HttpStatus> { execute() }
 
-        assertNull(result.data)
-        assertNotNull(result.errors)
-        assertEquals(1, result.errors.size)
-        assertEquals("HTTP Error ${HttpURLConnection.HTTP_INTERNAL_ERROR}: No error body", result.errors.first().message)
+        assertEquals(HttpURLConnection.HTTP_INTERNAL_ERROR, failure.statusCode)
+        assertEquals("HTTP Error ${HttpURLConnection.HTTP_INTERNAL_ERROR}: No error body", failure.message)
     }
 
     @Test
-    fun `execute should handle IOException during request`() = runTest {
+    fun `execute should report an IOException during the request as a transport failure`() = runTest {
         every { mockConnection.outputStream } throws IOException("Connection failed")
 
-        val result = graphQLClient.execute(
-            query = testQuery,
-            dataSerializer = TestData.serializer()
-        )
+        val failure = assertThrows<GraphQLClientException.Transport> { execute() }
 
-        assertNull(result.data)
-        assertNotNull(result.errors)
-        assertEquals(1, result.errors.size)
-        assertEquals("Connection failed", result.errors.first().message)
+        assertEquals("Connection failed", failure.cause?.message)
     }
 
     @Test
     fun `execute should set correct HTTP headers`() = runTest {
-        val responseJson = """{"data": {"id": "123", "name": "John Doe"}}"""
+        respondWith("""{"data": {"id": "123", "name": "John Doe"}}""")
 
-        every { mockConnection.inputStream } returns ByteArrayInputStream(responseJson.toByteArray())
-
-        graphQLClient.execute(
-            query = testQuery,
-            dataSerializer = TestData.serializer()
-        )
+        execute()
 
         verify {
             mockConnection.requestMethod = "POST"
@@ -164,4 +184,11 @@ class GraphQLClientTest {
             mockConnection.readTimeout = 10000
         }
     }
+
+    private fun respondWith(responseJson: String) {
+        every { mockConnection.inputStream } returns ByteArrayInputStream(responseJson.toByteArray())
+    }
+
+    private suspend fun execute(): TestData =
+        graphQLClient.execute(query = testQuery, dataSerializer = TestData.serializer())
 }

--- a/sdk/@launchdarkly/observability-android/lib/src/test/kotlin/com/launchdarkly/observability/network/SamplingApiServiceTest.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/test/kotlin/com/launchdarkly/observability/network/SamplingApiServiceTest.kt
@@ -47,18 +47,13 @@ class SamplingApiServiceTest {
                     )
                 )
             )
-            val graphqlResponse = GraphQLResponse(
-                data = samplingResponse,
-                errors = null
-            )
-
             coEvery {
                 mockGraphqlClient.execute(
                     any(),
                     mapOf("organization_verbose_id" to JsonPrimitive(organizationId)),
                     SamplingResponse.serializer()
                 )
-            } returns graphqlResponse
+            } returns samplingResponse
 
             val result = service.getSamplingConfig(organizationId)
 
@@ -77,16 +72,10 @@ class SamplingApiServiceTest {
         @Test
         fun `should return null when network response has errors`() = runTest {
             val organizationId = "test-org"
-            val graphqlResponse = GraphQLResponse<SamplingResponse>(
-                data = null,
-                errors = listOf(
-                    GraphQLError(message = "Organization not found")
-                )
-            )
 
             coEvery {
                 mockGraphqlClient.execute<SamplingResponse>(any(), any(), any())
-            } returns graphqlResponse
+            } throws GraphQLClientException.GraphQLErrors(listOf(GraphQLError(message = "Organization not found")))
 
             val result = service.getSamplingConfig(organizationId)
 
@@ -96,14 +85,10 @@ class SamplingApiServiceTest {
         @Test
         fun `should return null when network response has no data and no errors`() = runTest {
             val organizationId = "test-org"
-            val graphqlResponse = GraphQLResponse<SamplingResponse>(
-                data = null,
-                errors = emptyList()
-            )
 
             coEvery {
                 mockGraphqlClient.execute<SamplingResponse>(any(), any(), any())
-            } returns graphqlResponse
+            } throws GraphQLClientException.MissingData()
 
             val result = service.getSamplingConfig(organizationId)
 
@@ -113,15 +98,10 @@ class SamplingApiServiceTest {
         @Test
         fun `should return null when sampling config data is null`() = runTest {
             val organizationId = "test-org"
-            val samplingResponse = SamplingResponse(sampling = null)
-            val graphqlResponse = GraphQLResponse(
-                data = samplingResponse,
-                errors = null
-            )
 
             coEvery {
                 mockGraphqlClient.execute<SamplingResponse>(any(), any(), any())
-            } returns graphqlResponse
+            } returns SamplingResponse(sampling = null)
 
             val result = service.getSamplingConfig(organizationId)
 

--- a/sdk/@launchdarkly/observability-android/lib/src/test/kotlin/com/launchdarkly/observability/replay/SessionReplayExporterErrorHandlingTest.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/test/kotlin/com/launchdarkly/observability/replay/SessionReplayExporterErrorHandlingTest.kt
@@ -197,9 +197,7 @@ class SessionReplayExporterErrorHandlingTest {
         coEvery { mockService.pushPayload(any(), any(), any()) } throws refusal("pushPayload")
         exporter.export(captureItems("session-a"))
 
-        exporter.sendIdentifyAndCache(
-            IdentifyItemPayload(attributes = mapOf("key" to "user-2"), timestamp = 1L, sessionId = "session-a")
-        )
+        exporter.sendIdentifyAndCache(identify("user-2"))
 
         // Only the identify that came with the initialization, none for the abandoned session.
         coVerify(exactly = 1) { mockService.identifyReplaySession(any<String>(), any<IdentifyItemPayload>()) }
@@ -212,15 +210,39 @@ class SessionReplayExporterErrorHandlingTest {
 
         coEvery { mockService.identifyReplaySession(any<String>(), any<IdentifyItemPayload>()) } throws
             refusal("identifyReplaySession")
-        exporter.sendIdentifyAndCache(
-            IdentifyItemPayload(attributes = mapOf("key" to "user-2"), timestamp = 1L, sessionId = "session-a")
-        )
+        exporter.sendIdentifyAndCache(identify("user-2"))
 
         assertEquals(1, verdicts.count { it is SessionReplayInitializationVerdict.Unrecoverable })
         // Recording is over, so the batch that follows drains rather than being pushed or retried.
         assertNull(exportFailure(captureItems("session-b")))
         coVerify(exactly = 0) { mockService.pushPayload("session-b", any(), any()) }
     }
+
+    @Test
+    fun `an identify before the session is accepted is cached rather than sent`() = runTest {
+        coEvery { mockService.identifyReplaySession(any<String>(), any<IdentifyItemPayload>()) } throws
+            refusal("identifyReplaySession")
+
+        exporter.sendIdentifyAndCache(identify("user-2"))
+
+        // The probe has not accepted the session yet, so nothing is sent and the error the backend would
+        // answer with cannot end the launch.
+        coVerify(exactly = 0) { mockService.identifyReplaySession(any<String>(), any<IdentifyItemPayload>()) }
+        assertTrue(verdicts.isEmpty())
+    }
+
+    @Test
+    fun `an identify cached before initialization is the one initialization sends`() = runTest {
+        val pending = identify("user-2")
+        exporter.sendIdentifyAndCache(pending)
+
+        exporter.prepareSession("session-a")
+
+        coVerify(exactly = 1) { mockService.identifyReplaySession("session-a", pending) }
+    }
+
+    private fun identify(key: String) =
+        IdentifyItemPayload(attributes = mapOf("key" to key), timestamp = 1L, sessionId = "session-a")
 
     /** A refusal the backend cannot be retried out of: a GraphQL error marked non-retryable. */
     private fun refusal(operation: String) = SessionReplayApiException(

--- a/sdk/@launchdarkly/observability-android/lib/src/test/kotlin/com/launchdarkly/observability/replay/SessionReplayExporterErrorHandlingTest.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/test/kotlin/com/launchdarkly/observability/replay/SessionReplayExporterErrorHandlingTest.kt
@@ -190,6 +190,19 @@ class SessionReplayExporterErrorHandlingTest {
         assertEquals(listOf(SessionReplayInitializationVerdict.Allowed), verdicts)
     }
 
+    @Test
+    fun `a refused session is not identified again`() = runTest {
+        coEvery { mockService.pushPayload(any(), any(), any()) } throws refusal("pushPayload")
+        assertNotNull(exportFailure(captureItems("session-a")))
+
+        exporter.sendIdentifyAndCache(
+            IdentifyItemPayload(attributes = mapOf("key" to "user-2"), timestamp = 1L, sessionId = "session-a")
+        )
+
+        // Only the identify that came with the initialization, none for the abandoned session.
+        coVerify(exactly = 1) { mockService.identifyReplaySession(any<String>(), any<IdentifyItemPayload>()) }
+    }
+
     /** A refusal the backend cannot be retried out of: a GraphQL error marked non-retryable. */
     private fun refusal(operation: String) = SessionReplayApiException(
         operation,

--- a/sdk/@launchdarkly/observability-android/lib/src/test/kotlin/com/launchdarkly/observability/replay/SessionReplayExporterErrorHandlingTest.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/test/kotlin/com/launchdarkly/observability/replay/SessionReplayExporterErrorHandlingTest.kt
@@ -1,5 +1,8 @@
 package com.launchdarkly.observability.replay
 
+import com.launchdarkly.observability.network.GraphQLClientException
+import com.launchdarkly.observability.network.GraphQLError
+import com.launchdarkly.observability.network.GraphQLErrorExtensions
 import com.launchdarkly.observability.replay.capture.ExportFrame
 import com.launchdarkly.observability.replay.exporter.IdentifyItemPayload
 import com.launchdarkly.observability.replay.exporter.ImageItemPayload
@@ -70,12 +73,15 @@ class SessionReplayExporterErrorHandlingTest {
 
     @Test
     fun `an unrecoverable initialization failure stops further exports`() = runTest {
-        coEvery { mockService.initializeReplaySession(any(), any()) } throws
-            SessionReplayApiException("initializeReplaySession failed: blocked in region", isRecoverable = false)
+        coEvery { mockService.initializeReplaySession(any(), any()) } throws refusal("initializeReplaySession")
 
         assertNotNull(exportFailure(captureItems("session-a")))
         assertEquals(
-            listOf(SessionReplayInitializationVerdict.Unrecoverable("initializeReplaySession failed: blocked in region")),
+            listOf(
+                SessionReplayInitializationVerdict.Unrecoverable(
+                    "initializeReplaySession failed: GraphQL errors: blocked in region"
+                )
+            ),
             verdicts
         )
 
@@ -87,8 +93,7 @@ class SessionReplayExporterErrorHandlingTest {
 
     @Test
     fun `an unrecoverable push failure stops further exports`() = runTest {
-        coEvery { mockService.pushPayload(any(), any(), any()) } throws
-            SessionReplayApiException("pushPayload failed: blocked in region", isRecoverable = false)
+        coEvery { mockService.pushPayload(any(), any(), any()) } throws refusal("pushPayload")
 
         assertNotNull(exportFailure(captureItems("session-a")))
         assertEquals(1, verdicts.count { it is SessionReplayInitializationVerdict.Unrecoverable })
@@ -100,7 +105,7 @@ class SessionReplayExporterErrorHandlingTest {
     @Test
     fun `a recoverable failure is retried and never reported`() = runTest {
         coEvery { mockService.initializeReplaySession(any(), any()) } throws
-            SessionReplayApiException("initializeReplaySession failed: too many requests", isRecoverable = true)
+            transientFailure("initializeReplaySession")
 
         assertNotNull(exportFailure(captureItems("session-a")))
         assertNotNull(exportFailure(captureItems("session-a")))
@@ -124,12 +129,16 @@ class SessionReplayExporterErrorHandlingTest {
     @Test
     fun `prepareSession reports a refusal without throwing`() = runTest {
         coEvery { mockService.initializeReplaySession(any(), any()) } throws
-            SessionReplayApiException("initializeReplaySession failed: unauthorized", isRecoverable = false)
+            SessionReplayApiException("initializeReplaySession", GraphQLClientException.HttpStatus(403, "Forbidden"))
 
         exporter.prepareSession("session-a")
 
         assertEquals(
-            listOf(SessionReplayInitializationVerdict.Unrecoverable("initializeReplaySession failed: unauthorized")),
+            listOf(
+                SessionReplayInitializationVerdict.Unrecoverable(
+                    "initializeReplaySession failed: HTTP Error 403: Forbidden"
+                )
+            ),
             verdicts
         )
     }
@@ -137,13 +146,29 @@ class SessionReplayExporterErrorHandlingTest {
     @Test
     fun `a transient identify failure does not withhold recording`() = runTest {
         coEvery { mockService.identifyReplaySession(any<String>(), any<IdentifyItemPayload>()) } throws
-            SessionReplayApiException("identifyReplaySession failed: too many requests", isRecoverable = true)
+            transientFailure("identifyReplaySession")
 
         assertNotNull(exportFailure(captureItems("session-a")))
 
         // The session itself was accepted, so screenshots start even though identify has to be retried.
         assertEquals(listOf(SessionReplayInitializationVerdict.Allowed), verdicts)
     }
+
+    /** A refusal the backend cannot be retried out of: a GraphQL error marked non-retryable. */
+    private fun refusal(operation: String) = SessionReplayApiException(
+        operation,
+        GraphQLClientException.GraphQLErrors(
+            listOf(
+                GraphQLError(
+                    message = "blocked in region",
+                    extensions = GraphQLErrorExtensions(code = "SESSION_REPLAY_BLOCKED_IN_REGION", retryable = false),
+                )
+            )
+        ),
+    )
+
+    private fun transientFailure(operation: String) =
+        SessionReplayApiException(operation, GraphQLClientException.HttpStatus(429, "Slow down"))
 
     private fun captureItems(sessionId: String): List<EventQueueItem> =
         listOf(EventQueueItem(ImageItemPayload(ExportFrame("base64data", 800, 600, 1000L, sessionId))))

--- a/sdk/@launchdarkly/observability-android/lib/src/test/kotlin/com/launchdarkly/observability/replay/SessionReplayExporterErrorHandlingTest.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/test/kotlin/com/launchdarkly/observability/replay/SessionReplayExporterErrorHandlingTest.kt
@@ -1,0 +1,158 @@
+package com.launchdarkly.observability.replay
+
+import com.launchdarkly.observability.replay.capture.ExportFrame
+import com.launchdarkly.observability.replay.exporter.IdentifyItemPayload
+import com.launchdarkly.observability.replay.exporter.ImageItemPayload
+import com.launchdarkly.observability.replay.exporter.SessionReplayApiException
+import com.launchdarkly.observability.replay.exporter.SessionReplayApiService
+import com.launchdarkly.observability.replay.exporter.SessionReplayExporter
+import com.launchdarkly.observability.replay.transport.EventQueueItem
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * How the exporter classifies failed session initialization and payload pushes, and what it reports back
+ * to the service.
+ */
+class SessionReplayExporterErrorHandlingTest {
+
+    private lateinit var mockService: SessionReplayApiService
+    private lateinit var exporter: SessionReplayExporter
+    private val verdicts = mutableListOf<SessionReplayInitializationVerdict>()
+
+    @BeforeEach
+    fun setUp() {
+        verdicts.clear()
+        mockService = mockk(relaxed = true)
+        exporter = SessionReplayExporter(
+            organizationVerboseId = "test-org",
+            backendUrl = "http://test.com",
+            serviceName = "test-service",
+            serviceVersion = "1.0.0",
+            initialIdentifyItemPayload = IdentifyItemPayload(
+                attributes = mapOf("key" to "user"),
+                timestamp = 0L,
+                sessionId = null,
+            ),
+            title = "test-app",
+            injectedReplayApiService = mockService,
+            logger = mockk(relaxed = true),
+            onInitializationVerdict = { verdicts.add(it) },
+        )
+    }
+
+    @Test
+    fun `an accepted session is reported as allowed`() = runTest {
+        exporter.export(captureItems("session-a"))
+
+        assertEquals(listOf(SessionReplayInitializationVerdict.Allowed), verdicts)
+    }
+
+    @Test
+    fun `prepareSession initializes without a capture, and the export does not repeat it`() = runTest {
+        exporter.prepareSession("session-a")
+
+        coVerify(exactly = 1) { mockService.initializeReplaySession("test-org", "session-a") }
+        assertEquals(listOf(SessionReplayInitializationVerdict.Allowed), verdicts)
+
+        exporter.export(captureItems("session-a"))
+
+        coVerify(exactly = 1) { mockService.initializeReplaySession("test-org", "session-a") }
+    }
+
+    @Test
+    fun `an unrecoverable initialization failure stops further exports`() = runTest {
+        coEvery { mockService.initializeReplaySession(any(), any()) } throws
+            SessionReplayApiException("initializeReplaySession failed: blocked in region", isRecoverable = false)
+
+        assertNotNull(exportFailure(captureItems("session-a")))
+        assertEquals(
+            listOf(SessionReplayInitializationVerdict.Unrecoverable("initializeReplaySession failed: blocked in region")),
+            verdicts
+        )
+
+        // Recording is over for this launch: the next batch is dropped rather than retried, so the queue
+        // drains instead of filling up.
+        assertNull(exportFailure(captureItems("session-a")))
+        coVerify(exactly = 1) { mockService.initializeReplaySession(any(), any()) }
+    }
+
+    @Test
+    fun `an unrecoverable push failure stops further exports`() = runTest {
+        coEvery { mockService.pushPayload(any(), any(), any()) } throws
+            SessionReplayApiException("pushPayload failed: blocked in region", isRecoverable = false)
+
+        assertNotNull(exportFailure(captureItems("session-a")))
+        assertEquals(1, verdicts.count { it is SessionReplayInitializationVerdict.Unrecoverable })
+
+        assertNull(exportFailure(captureItems("session-a")))
+        coVerify(exactly = 1) { mockService.pushPayload(any(), any(), any()) }
+    }
+
+    @Test
+    fun `a recoverable failure is retried and never reported`() = runTest {
+        coEvery { mockService.initializeReplaySession(any(), any()) } throws
+            SessionReplayApiException("initializeReplaySession failed: too many requests", isRecoverable = true)
+
+        assertNotNull(exportFailure(captureItems("session-a")))
+        assertNotNull(exportFailure(captureItems("session-a")))
+
+        // Both batches were attempted, and the failures stay with the export retry loop.
+        coVerify(exactly = 2) { mockService.initializeReplaySession(any(), any()) }
+        assertTrue(verdicts.isEmpty())
+    }
+
+    @Test
+    fun `a failure of unknown origin is treated as recoverable`() = runTest {
+        coEvery { mockService.initializeReplaySession(any(), any()) } throws RuntimeException("socket closed")
+
+        assertNotNull(exportFailure(captureItems("session-a")))
+        assertNotNull(exportFailure(captureItems("session-a")))
+
+        coVerify(exactly = 2) { mockService.initializeReplaySession(any(), any()) }
+        assertTrue(verdicts.isEmpty())
+    }
+
+    @Test
+    fun `prepareSession reports a refusal without throwing`() = runTest {
+        coEvery { mockService.initializeReplaySession(any(), any()) } throws
+            SessionReplayApiException("initializeReplaySession failed: unauthorized", isRecoverable = false)
+
+        exporter.prepareSession("session-a")
+
+        assertEquals(
+            listOf(SessionReplayInitializationVerdict.Unrecoverable("initializeReplaySession failed: unauthorized")),
+            verdicts
+        )
+    }
+
+    @Test
+    fun `a transient identify failure does not withhold recording`() = runTest {
+        coEvery { mockService.identifyReplaySession(any<String>(), any<IdentifyItemPayload>()) } throws
+            SessionReplayApiException("identifyReplaySession failed: too many requests", isRecoverable = true)
+
+        assertNotNull(exportFailure(captureItems("session-a")))
+
+        // The session itself was accepted, so screenshots start even though identify has to be retried.
+        assertEquals(listOf(SessionReplayInitializationVerdict.Allowed), verdicts)
+    }
+
+    private fun captureItems(sessionId: String): List<EventQueueItem> =
+        listOf(EventQueueItem(ImageItemPayload(ExportFrame("base64data", 800, 600, 1000L, sessionId))))
+
+    /** The exception [SessionReplayExporter.export] threw, or `null` when it succeeded. */
+    private suspend fun exportFailure(items: List<EventQueueItem>): Throwable? = try {
+        exporter.export(items)
+        null
+    } catch (e: Exception) {
+        e
+    }
+}

--- a/sdk/@launchdarkly/observability-android/lib/src/test/kotlin/com/launchdarkly/observability/replay/SessionReplayExporterErrorHandlingTest.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/test/kotlin/com/launchdarkly/observability/replay/SessionReplayExporterErrorHandlingTest.kt
@@ -205,6 +205,23 @@ class SessionReplayExporterErrorHandlingTest {
         coVerify(exactly = 1) { mockService.identifyReplaySession(any<String>(), any<IdentifyItemPayload>()) }
     }
 
+    @Test
+    fun `an identify refused after the session was accepted ends recording`() = runTest {
+        exporter.export(captureItems("session-a"))
+        assertEquals(listOf(SessionReplayInitializationVerdict.Allowed), verdicts)
+
+        coEvery { mockService.identifyReplaySession(any<String>(), any<IdentifyItemPayload>()) } throws
+            refusal("identifyReplaySession")
+        exporter.sendIdentifyAndCache(
+            IdentifyItemPayload(attributes = mapOf("key" to "user-2"), timestamp = 1L, sessionId = "session-a")
+        )
+
+        assertEquals(1, verdicts.count { it is SessionReplayInitializationVerdict.Unrecoverable })
+        // Recording is over, so the batch that follows drains rather than being pushed or retried.
+        assertNull(exportFailure(captureItems("session-b")))
+        coVerify(exactly = 0) { mockService.pushPayload("session-b", any(), any()) }
+    }
+
     /** A refusal the backend cannot be retried out of: a GraphQL error marked non-retryable. */
     private fun refusal(operation: String) = SessionReplayApiException(
         operation,

--- a/sdk/@launchdarkly/observability-android/lib/src/test/kotlin/com/launchdarkly/observability/replay/SessionReplayExporterErrorHandlingTest.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/test/kotlin/com/launchdarkly/observability/replay/SessionReplayExporterErrorHandlingTest.kt
@@ -77,7 +77,9 @@ class SessionReplayExporterErrorHandlingTest {
     fun `an unrecoverable initialization failure stops further exports`() = runTest {
         coEvery { mockService.initializeReplaySession(any(), any()) } throws refusal("initializeReplaySession")
 
-        assertNotNull(exportFailure(captureItems("session-a")))
+        // The refusal is not surfaced as an export failure: it would earn the batch a retry with backoff,
+        // when nothing will accept it any more.
+        assertNull(exportFailure(captureItems("session-a")))
         assertEquals(
             listOf(
                 SessionReplayInitializationVerdict.Unrecoverable(
@@ -97,7 +99,7 @@ class SessionReplayExporterErrorHandlingTest {
     fun `an unrecoverable push failure stops further exports`() = runTest {
         coEvery { mockService.pushPayload(any(), any(), any()) } throws refusal("pushPayload")
 
-        assertNotNull(exportFailure(captureItems("session-a")))
+        assertNull(exportFailure(captureItems("session-a")))
         assertEquals(1, verdicts.count { it is SessionReplayInitializationVerdict.Unrecoverable })
 
         assertNull(exportFailure(captureItems("session-a")))
@@ -193,7 +195,7 @@ class SessionReplayExporterErrorHandlingTest {
     @Test
     fun `a refused session is not identified again`() = runTest {
         coEvery { mockService.pushPayload(any(), any(), any()) } throws refusal("pushPayload")
-        assertNotNull(exportFailure(captureItems("session-a")))
+        exporter.export(captureItems("session-a"))
 
         exporter.sendIdentifyAndCache(
             IdentifyItemPayload(attributes = mapOf("key" to "user-2"), timestamp = 1L, sessionId = "session-a")

--- a/sdk/@launchdarkly/observability-android/lib/src/test/kotlin/com/launchdarkly/observability/replay/SessionReplayExporterErrorHandlingTest.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/test/kotlin/com/launchdarkly/observability/replay/SessionReplayExporterErrorHandlingTest.kt
@@ -13,6 +13,8 @@ import com.launchdarkly.observability.replay.transport.EventQueueItem
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -141,6 +143,40 @@ class SessionReplayExporterErrorHandlingTest {
             ),
             verdicts
         )
+    }
+
+    @Test
+    fun `a refusal while a batch waits for the export lock stops that batch`() = runTest {
+        val probeReachedBackend = CompletableDeferred<Unit>()
+        val releaseProbe = CompletableDeferred<Unit>()
+        coEvery { mockService.initializeReplaySession(any(), any()) } coAnswers {
+            probeReachedBackend.complete(Unit)
+            releaseProbe.await()
+            throw refusal("initializeReplaySession")
+        }
+
+        // The probe holds the export lock while it waits on the backend, so the batch below queues up
+        // behind it and only sees the refusal after acquiring the lock.
+        launch { exporter.prepareSession("session-a") }
+        probeReachedBackend.await()
+        val export = launch { exportFailure(captureItems("session-a")) }
+        releaseProbe.complete(Unit)
+        export.join()
+
+        coVerify(exactly = 0) { mockService.pushPayload(any(), any(), any()) }
+    }
+
+    @Test
+    fun `a refusal part-way through a batch stops the remaining sessions`() = runTest {
+        // The first session's wake-up push is refused. That failure is swallowed to protect the buffering
+        // logic, so only the recording verdict can stop the rest of the batch.
+        coEvery { mockService.pushPayload("session-a", "2", any()) } throws refusal("pushPayload")
+
+        exportFailure(captureItems("session-a") + captureItems("session-b"))
+
+        coVerify(exactly = 1) { mockService.pushPayload("session-a", "1", any()) }
+        coVerify(exactly = 0) { mockService.pushPayload("session-b", any(), any()) }
+        assertEquals(1, verdicts.count { it is SessionReplayInitializationVerdict.Unrecoverable })
     }
 
     @Test

--- a/sdk/@launchdarkly/observability-android/lib/src/test/kotlin/com/launchdarkly/observability/replay/SessionReplayExporterTest.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/test/kotlin/com/launchdarkly/observability/replay/SessionReplayExporterTest.kt
@@ -82,7 +82,7 @@ class SessionReplayExporterTest {
     }
 
     @Test
-    fun `sendIdentifyAndCache should call identifyReplaySession`() = runTest {
+    fun `sendIdentifyAndCache should call identifyReplaySession for an accepted session`() = runTest {
         val updatedIdentify = IdentifyItemPayload(
             attributes = mapOf("key" to "updated-user"),
             timestamp = 1L,
@@ -91,6 +91,8 @@ class SessionReplayExporterTest {
 
         coEvery { mockService.identifyReplaySession(any<String>(), any<IdentifyItemPayload>()) } just Runs
 
+        // The backend only accepts identify for a session it has accepted, so this follows initialization.
+        exporter.prepareSession("session-a")
         exporter.sendIdentifyAndCache(updatedIdentify)
 
         coVerify(exactly = 1) { mockService.identifyReplaySession("session-a", updatedIdentify) }

--- a/sdk/@launchdarkly/observability-android/lib/src/test/kotlin/com/launchdarkly/observability/replay/SessionReplayInitializationStoreTest.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/test/kotlin/com/launchdarkly/observability/replay/SessionReplayInitializationStoreTest.kt
@@ -1,0 +1,102 @@
+package com.launchdarkly.observability.replay
+
+import android.content.SharedPreferences
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class SessionReplayInitializationStoreTest {
+
+    @Test
+    fun `no failure is stored by default`() {
+        val store = SessionReplayInitializationStore(prefs = fakePrefs(), sdkKey = "mob-key")
+
+        assertNull(store.loadFailure())
+    }
+
+    @Test
+    fun `stored failure survives a new store for the same environment`() {
+        val prefs = fakePrefs()
+        SessionReplayInitializationStore(prefs, sdkKey = "mob-key")
+            .store(reason = "SESSION_REPLAY_BLOCKED_IN_REGION", timestamp = 42L)
+
+        val failure = SessionReplayInitializationStore(prefs, sdkKey = "mob-key").loadFailure()
+
+        assertEquals("SESSION_REPLAY_BLOCKED_IN_REGION", failure?.reason)
+        assertEquals(42L, failure?.timestamp)
+    }
+
+    @Test
+    fun `failure from another environment is ignored`() {
+        val prefs = fakePrefs()
+        SessionReplayInitializationStore(prefs, sdkKey = "mob-staging").store(reason = "unauthorized")
+
+        assertNull(SessionReplayInitializationStore(prefs, sdkKey = "mob-production").loadFailure())
+        assertNotNull(SessionReplayInitializationStore(prefs, sdkKey = "mob-staging").loadFailure())
+    }
+
+    @Test
+    fun `clearing removes the stored failure`() {
+        val store = SessionReplayInitializationStore(fakePrefs(), sdkKey = "mob-key")
+        store.store(reason = "unauthorized")
+        store.clearFailure()
+
+        assertNull(store.loadFailure())
+    }
+
+    @Test
+    fun `long reasons are truncated`() {
+        val store = SessionReplayInitializationStore(fakePrefs(), sdkKey = "mob-key")
+        store.store(reason = "x".repeat(SessionReplayInitializationStore.MAX_REASON_LENGTH * 3))
+
+        assertEquals(
+            SessionReplayInitializationStore.MAX_REASON_LENGTH,
+            store.loadFailure()?.reason?.length
+        )
+    }
+
+    @Test
+    fun `unreadable stored values are ignored`() {
+        val prefs = fakePrefs()
+        prefs.edit()
+            .putString(SessionReplayInitializationStore.KEY_LAST_UNRECOVERABLE_FAILURE, "not json")
+            .apply()
+
+        assertNull(SessionReplayInitializationStore(prefs, sdkKey = "mob-key").loadFailure())
+    }
+
+    @Test
+    fun `the sdk key is never written to disk`() {
+        val prefs = fakePrefs()
+        SessionReplayInitializationStore(prefs, sdkKey = "mob-secret-key").store(reason = "unauthorized")
+
+        val stored = prefs.getString(SessionReplayInitializationStore.KEY_LAST_UNRECOVERABLE_FAILURE, null)
+
+        assertNotNull(stored)
+        assertFalse(stored!!.contains("mob-secret-key"))
+    }
+
+    /** In-memory stand-in for [SharedPreferences], enough for the string get/put/remove this store uses. */
+    private fun fakePrefs(): SharedPreferences {
+        val values = mutableMapOf<String, String>()
+        val editor = mockk<SharedPreferences.Editor>(relaxed = true)
+        val prefs = mockk<SharedPreferences>(relaxed = true)
+
+        every { prefs.getString(any(), any()) } answers { values[firstArg()] ?: secondArg() }
+        every { prefs.edit() } returns editor
+        every { editor.putString(any(), any()) } answers {
+            values[firstArg()] = secondArg()
+            editor
+        }
+        every { editor.remove(any()) } answers {
+            values.remove(firstArg<String>())
+            editor
+        }
+
+        return prefs
+    }
+}

--- a/sdk/@launchdarkly/observability-android/lib/src/test/kotlin/com/launchdarkly/observability/replay/SessionReplayInitializationStoreTest.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/test/kotlin/com/launchdarkly/observability/replay/SessionReplayInitializationStoreTest.kt
@@ -40,6 +40,25 @@ class SessionReplayInitializationStoreTest {
     }
 
     @Test
+    fun `one environment's failure does not displace another's`() {
+        val prefs = fakePrefs()
+        val staging = SessionReplayInitializationStore(prefs, sdkKey = "mob-staging")
+        val production = SessionReplayInitializationStore(prefs, sdkKey = "mob-production")
+
+        staging.store(reason = "unauthorized", timestamp = 1L)
+        production.store(reason = "blocked in region", timestamp = 2L)
+
+        assertEquals("unauthorized", staging.loadFailure()?.reason)
+        assertEquals("blocked in region", production.loadFailure()?.reason)
+
+        // Clearing is scoped the same way: recovering in one environment leaves the other withheld.
+        production.clearFailure()
+
+        assertEquals("unauthorized", staging.loadFailure()?.reason)
+        assertNull(production.loadFailure())
+    }
+
+    @Test
     fun `clearing removes the stored failure`() {
         val store = SessionReplayInitializationStore(fakePrefs(), sdkKey = "mob-key")
         store.store(reason = "unauthorized")
@@ -63,7 +82,7 @@ class SessionReplayInitializationStoreTest {
     fun `unreadable stored values are ignored`() {
         val prefs = fakePrefs()
         prefs.edit()
-            .putString(SessionReplayInitializationStore.KEY_LAST_UNRECOVERABLE_FAILURE, "not json")
+            .putString(SessionReplayInitializationStore.failureKey("mob-key"), "not json")
             .apply()
 
         assertNull(SessionReplayInitializationStore(prefs, sdkKey = "mob-key").loadFailure())
@@ -74,10 +93,13 @@ class SessionReplayInitializationStoreTest {
         val prefs = fakePrefs()
         SessionReplayInitializationStore(prefs, sdkKey = "mob-secret-key").store(reason = "unauthorized")
 
-        val stored = prefs.getString(SessionReplayInitializationStore.KEY_LAST_UNRECOVERABLE_FAILURE, null)
+        val key = SessionReplayInitializationStore.failureKey("mob-secret-key")
+        val stored = prefs.getString(key, null)
 
         assertNotNull(stored)
         assertFalse(stored!!.contains("mob-secret-key"))
+        // The environment is part of the key name now, so that has to stay a fingerprint too.
+        assertFalse(key.contains("mob-secret-key"))
     }
 
     /** In-memory stand-in for [SharedPreferences], enough for the string get/put/remove this store uses. */

--- a/sdk/@launchdarkly/observability-android/lib/src/test/kotlin/com/launchdarkly/observability/replay/SessionReplayInitializationStoreTest.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/test/kotlin/com/launchdarkly/observability/replay/SessionReplayInitializationStoreTest.kt
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 class SessionReplayInitializationStoreTest {
@@ -100,6 +101,21 @@ class SessionReplayInitializationStoreTest {
         assertFalse(stored!!.contains("mob-secret-key"))
         // The environment is part of the key name now, so that has to stay a fingerprint too.
         assertFalse(key.contains("mob-secret-key"))
+    }
+
+    @Test
+    fun `the environment fingerprint is a fixed-length hex digest`() {
+        val prefix = "${SessionReplayInitializationStore.KEY_PREFIX_LAST_UNRECOVERABLE_FAILURE}."
+
+        // Across this many keys some digests start with a byte whose high bit is set, which is where a
+        // sign-extending hex conversion would widen the fingerprint past the 8 bytes it is meant to be.
+        val fingerprints = (1..64).map { SessionReplayInitializationStore.failureKey("mob-key-$it").removePrefix(prefix) }
+
+        fingerprints.forEach { fingerprint ->
+            assertEquals(16, fingerprint.length, "unexpected fingerprint: $fingerprint")
+            assertTrue(fingerprint.all { it in "0123456789abcdef" }, "unexpected fingerprint: $fingerprint")
+        }
+        assertEquals(fingerprints.size, fingerprints.distinct().size)
     }
 
     /** In-memory stand-in for [SharedPreferences], enough for the string get/put/remove this store uses. */

--- a/sdk/@launchdarkly/observability-android/lib/src/test/kotlin/com/launchdarkly/observability/replay/SessionReplayRecordingGateTest.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/test/kotlin/com/launchdarkly/observability/replay/SessionReplayRecordingGateTest.kt
@@ -1,0 +1,98 @@
+package com.launchdarkly.observability.replay
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class SessionReplayRecordingGateTest {
+
+    @Test
+    fun `a launch with no cached failure records from the start`() {
+        val gate = SessionReplayRecordingGate(hasCachedFailure = false)
+
+        assertTrue(gate.isScreenCaptureAllowed)
+        assertTrue(gate.canStartRecording)
+        assertFalse(gate.isAwaitingVerdict)
+
+        // The session was accepted, which is what the gate already assumed.
+        assertEquals(
+            SessionReplayRecordingGate.Outcome.None,
+            gate.apply(SessionReplayInitializationVerdict.Allowed)
+        )
+        assertTrue(gate.isScreenCaptureAllowed)
+    }
+
+    @Test
+    fun `a cached failure withholds screenshots until the backend accepts the session`() {
+        val gate = SessionReplayRecordingGate(hasCachedFailure = true)
+
+        assertFalse(gate.isScreenCaptureAllowed)
+        assertTrue(gate.canStartRecording)
+        assertTrue(gate.isAwaitingVerdict)
+
+        assertEquals(
+            SessionReplayRecordingGate.Outcome.ReleaseScreenCapture,
+            gate.apply(SessionReplayInitializationVerdict.Allowed)
+        )
+        assertTrue(gate.isScreenCaptureAllowed)
+        assertFalse(gate.isAwaitingVerdict)
+
+        // Later sessions initialize too; the failure is already cleared, so there is nothing to do.
+        assertEquals(
+            SessionReplayRecordingGate.Outcome.None,
+            gate.apply(SessionReplayInitializationVerdict.Allowed)
+        )
+    }
+
+    @Test
+    fun `a refusal ends recording for the launch`() {
+        val gate = SessionReplayRecordingGate(hasCachedFailure = false)
+
+        assertEquals(
+            SessionReplayRecordingGate.Outcome.StopRecording("blocked"),
+            gate.apply(SessionReplayInitializationVerdict.Unrecoverable("blocked"))
+        )
+        assertFalse(gate.isScreenCaptureAllowed)
+        assertFalse(gate.canStartRecording)
+        // Nothing is owed anymore: the exporter stops talking to the backend until the next launch.
+        assertFalse(gate.isAwaitingVerdict)
+
+        assertEquals(
+            SessionReplayRecordingGate.Outcome.None,
+            gate.apply(SessionReplayInitializationVerdict.Unrecoverable("blocked again"))
+        )
+    }
+
+    @Test
+    fun `a refusal after a recovery still ends recording`() {
+        val gate = SessionReplayRecordingGate(hasCachedFailure = true)
+        assertEquals(
+            SessionReplayRecordingGate.Outcome.ReleaseScreenCapture,
+            gate.apply(SessionReplayInitializationVerdict.Allowed)
+        )
+
+        assertEquals(
+            SessionReplayRecordingGate.Outcome.StopRecording("blocked"),
+            gate.apply(SessionReplayInitializationVerdict.Unrecoverable("blocked"))
+        )
+        assertFalse(gate.isScreenCaptureAllowed)
+        assertFalse(gate.canStartRecording)
+    }
+
+    @Test
+    fun `an acceptance after a refusal cannot resume recording`() {
+        val gate = SessionReplayRecordingGate(hasCachedFailure = true)
+        assertEquals(
+            SessionReplayRecordingGate.Outcome.StopRecording("blocked"),
+            gate.apply(SessionReplayInitializationVerdict.Unrecoverable("blocked"))
+        )
+
+        assertEquals(
+            SessionReplayRecordingGate.Outcome.None,
+            gate.apply(SessionReplayInitializationVerdict.Allowed)
+        )
+        assertFalse(gate.isScreenCaptureAllowed)
+        assertFalse(gate.canStartRecording)
+    }
+}


### PR DESCRIPTION
## Summary

The Android port of [swift-launchdarkly-observability#255](https://github.com/launchdarkly/swift-launchdarkly-observability/pull/255), and the `O11Y-624` "handle request failures" TODO in `SessionReplayExporter`. Session replay kept taking screenshots and retrying even when the backend had refused the session permanently, so recording could not be turned off early in a launch.

### `GraphQLClient` now fails like the Swift client (breaking)

`execute` returned a `GraphQLResponse` and reduced every failure to message strings: a non-2xx was thrown as `IOException("HTTP Error 403: …")` and caught by its own handler, and `GraphQLError` had no `extensions`, so neither signal a classifier needs survived. It now returns `data` and throws `GraphQLClientException` — `HttpStatus` (with the status and any GraphQL errors the rejected body carried), `GraphQLErrors`, `MissingData`, `Transport`, `Decoding` — mirroring `NetworkError` / `GraphQLClientError` on iOS. The envelope is private to the client again, as it is on iOS.

Callers changed accordingly: `SamplingApiService` still answers `null` for any failure, and `SessionReplayApiException` now names the failed operation and takes its recoverability from the failure it wraps, replacing `throwOnErrors`.

### Recoverability

- `ErrorRecoverability` (in `network`, outside session replay, so any caller of the public graph can reuse it) switches on those cases the same way the Swift one does: 4xx is unrecoverable except 400, 408 and 429; transport, decoding and missing-data failures stay recoverable; GraphQL errors are treated as a 4xx unless `extensions.retryable` says otherwise, and an explicit `retryable` wins over the status code either way. Errors of unknown origin are recoverable, so a misclassification can never silently disable recording.
- `SessionReplayExporter` acts on the verdict: an unrecoverable failure of any of its requests (`initializeReplaySession`, `identifyReplaySession`, `pushPayload`) stops recording for the launch and drops later batches so `EventQueue` drains, while recoverable ones keep the existing `BatchWorker` backoff (events stay queued until it overflows). Session initialization moved into an idempotent `initializeSessionIfNeeded`, which also fixes payloads being pushed for a session that was never initialized (possible for touch/track/navigate events that arrive before the first frame).
- `SessionReplayService` withholds screenshots — nothing else — while a cached refusal is unresolved, and stops recording (reporting `isEnabled == false`) when the backend refuses. The refusal is cached in the preference file `AppLaunchTracker` already reads at startup, keyed by a SHA-256 fingerprint of the SDK key so environments don't gate each other and the key itself is never written.
- `initializeSession` is now probed eagerly at start rather than waiting for the first capture, and retried on foreground while screenshots are withheld. On Android this is what makes recovery possible at all: initialization used to be triggered by the first captured frame, so a launch with capture withheld would never ask the backend again.

The recording decision lives in `SessionReplayRecordingGate`, in the style of `SessionReplaySamplingSession`, so the orderings that matter are unit-testable.

`GraphQLFaultInjection` is a debug-only, deliberately unwired helper for exercising both paths on a device; its KDoc says how to hook it up temporarily. Happy to drop it if you'd rather not carry it.

## Test plan

- [x] `./gradlew :lib:testDebugUnitTest` passes: 400 tests, 0 failures
- [x] `GraphQLClientTest` rewritten for the throwing contract, and covers the status and GraphQL errors of a rejected body, `extensions` parsing, missing data, and decoding vs transport failures
- [x] `ErrorRecoverabilityTest` covers the status matrix, the `retryable` precedence rules in both directions, and every exception case
- [x] `SessionReplayRecordingGateTest` covers a clean launch, a withheld launch that recovers, a refusal, a refusal after recovery, and an acceptance arriving after a refusal
- [x] `SessionReplayInitializationStoreTest` covers round-tripping, clearing, environment scoping, reason truncation, unreadable values, and that the SDK key never reaches disk
- [x] `SessionReplayExporterErrorHandlingTest` covers the reported verdicts, the eager probe not re-initializing, unrecoverable init/push failures ending the launch, and recoverable ones staying with the retry loop
- [ ] Manual: wire up `GraphQLFaultInjection` and confirm a launch on an even minute stops screenshots immediately, and the next launch withholds them until the probe succeeds

## Notes for reviewers

- `GraphQLClient.execute` is source-breaking: it returns `data` and throws instead of returning an envelope, and `GraphQLResponse` is no longer public. Everything in this repo that calls it is updated here; the RN and Flutter wrappers go through the plugin, not the client.
- Behaviour change worth a look: the eager probe creates a backend session at start for a sampled-in launch even if no screenshot is ever taken (matches iOS).
- `SessionReplayInitializationVerdict` is public because `SessionReplayExporter` is; everything else added here is `internal`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large behavioral change to session replay and a breaking `GraphQLClient` API; misclassified recoverability could disable replay for a launch, while wrong permanent handling affects privacy-sensitive screenshot capture.
> 
> **Overview**
> Session replay on Android now **stops recording** when the backend permanently refuses the session (region blocks, auth, non-retryable GraphQL errors), instead of retrying forever and keeping screenshots on.
> 
> **`GraphQLClient` (breaking):** `execute` returns deserialized `data` and throws typed `GraphQLClientException` cases (`HttpStatus` with optional GraphQL errors in the body, `GraphQLErrors`, `Transport`, etc.). `GraphQLError` gains `extensions` (`code`, `retryable`). Call sites (`SamplingApiService`, session replay API) catch instead of reading an envelope.
> 
> **Recoverability & exporter:** Shared `ErrorRecoverability` maps HTTP status and GraphQL `retryable` to retry vs permanent failure. `SessionReplayExporter` uses idempotent `initializeSessionIfNeeded`, reports `SessionReplayInitializationVerdict` to the service, drains the queue on unrecoverable failure (no long backoff on dead sessions), and adds an eager `prepareSession` probe.
> 
> **Service & persistence:** `SessionReplayRecordingGate` separates screenshot withholding from “recording stopped for this launch.” A cached unrecoverable failure in `SharedPreferences` (per SDK key fingerprint) withholds screenshots until `initializeSession` succeeds; foreground retries while awaiting a verdict. `isEnabled` / screen capture react to backend verdicts; README documents automatic stop and next-launch behavior.
> 
> Tests cover the client contract, recoverability matrix, gate, store, and exporter error paths; optional debug `GraphQLFaultInjection` is included unwired.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4778a70315984535fa38ef438635094b73bedb5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

