### PR TITLE
feat(highlight.run): stop session replay when uploads cannot succeed

### DIFF
--- a/sdk/highlight-run/src/__tests__/client-worker-stop.test.ts
+++ b/sdk/highlight-run/src/__tests__/client-worker-stop.test.ts
@@ -37,6 +37,8 @@ describe('Highlight worker stop handling', () => {
 
 		expect(shutdown).not.toHaveBeenCalled()
 		expect(highlight.state).toBe('NotRecording')
+		// Keeps the page visibility listener, which outlives a stop, from restarting us.
+		expect(highlight.manualStopped).toBe(true)
 	})
 
 	it('shuts telemetry down when the SDK itself stops', () => {

--- a/sdk/highlight-run/src/__tests__/client-worker-stop.test.ts
+++ b/sdk/highlight-run/src/__tests__/client-worker-stop.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { Highlight } from '../client'
+import { MessageType, StopReason } from '../client/workers/types'
+
+const shutdown = vi.fn()
+vi.mock('../client/otel', async (importOriginal) => ({
+	...(await importOriginal<typeof import('../client/otel')>()),
+	shutdown: () => shutdown(),
+}))
+
+describe('Highlight worker stop handling', () => {
+	let highlight: Highlight
+
+	beforeEach(() => {
+		vi.useFakeTimers()
+		shutdown.mockClear()
+		highlight = new Highlight({
+			organizationID: '1',
+			sessionSecureID: 'seed',
+			backendUrl: 'https://pub.observability.app.launchdarkly.com',
+		})
+	})
+
+	afterEach(() => {
+		vi.useRealTimers()
+	})
+
+	it('keeps telemetry running when the worker stops replay', () => {
+		highlight._worker.onmessage({
+			data: {
+				response: {
+					type: MessageType.Stop,
+					reason: StopReason.UnrecoverableError,
+				},
+			},
+		} as MessageEvent<any>)
+
+		expect(shutdown).not.toHaveBeenCalled()
+		expect(highlight.state).toBe('NotRecording')
+	})
+
+	it('shuts telemetry down when the SDK itself stops', () => {
+		highlight.stopRecording(true)
+
+		expect(shutdown).toHaveBeenCalledTimes(1)
+		expect(highlight.state).toBe('NotRecording')
+	})
+})

--- a/sdk/highlight-run/src/__tests__/record-worker-stop.test.ts
+++ b/sdk/highlight-run/src/__tests__/record-worker-stop.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { RecordSDK } from '../sdk/record'
+import { MessageType, StopReason } from '../client/workers/types'
+
+const recordStop = vi.fn()
+vi.mock('@highlight-run/rrweb', () => ({
+	addCustomEvent: vi.fn(),
+	record: () => recordStop,
+}))
+
+vi.mock('../client/graph/generated/operations', () => ({
+	getSdk: () => ({
+		initializeSession: vi.fn().mockResolvedValue({
+			initializeSession: {
+				secure_id: 'test-session',
+				project_id: '1',
+			},
+		}),
+	}),
+}))
+
+vi.mock('../client/workers/highlight-client-worker?worker&inline', () => ({
+	default: class MockWorker {
+		onmessage: any
+		postMessage() {}
+	},
+}))
+
+async function startedSDK(): Promise<RecordSDK> {
+	const sdk = new RecordSDK({
+		organizationID: '1',
+		sessionSecureID: 'seed',
+	})
+	await sdk.start()
+	return sdk
+}
+
+/** Delivers a worker response to the SDK the way the real worker would. */
+function postToSDK(sdk: RecordSDK, response: unknown) {
+	sdk._worker.onmessage({ data: { response } } as MessageEvent<any>)
+}
+
+describe('RecordSDK worker stop handling', () => {
+	beforeEach(() => {
+		vi.useFakeTimers()
+		recordStop.mockClear()
+	})
+
+	afterEach(() => {
+		vi.useRealTimers()
+	})
+
+	it.each([
+		StopReason.PushPayloadTimeout,
+		StopReason.UnrecoverableError,
+		StopReason.RetriesExhausted,
+	])(
+		'releases the recorder when the worker stops us (%s)',
+		async (reason) => {
+			const sdk = await startedSDK()
+			sdk.events.push({ type: 3, data: {}, timestamp: 1 } as any)
+
+			postToSDK(sdk, { type: MessageType.Stop, reason })
+
+			expect(recordStop).toHaveBeenCalledTimes(1)
+			expect(sdk.events).toEqual([])
+			expect(sdk.getRecordingState()).toBe('NotRecording')
+		},
+	)
+
+	it('keeps recording while the worker only reports uploads', async () => {
+		const sdk = await startedSDK()
+		sdk.events.push({ type: 3, data: {}, timestamp: 1 } as any)
+
+		postToSDK(sdk, {
+			type: MessageType.AsyncEvents,
+			id: 1,
+			eventsSize: 100,
+			compressedSize: 50,
+		})
+
+		expect(recordStop).not.toHaveBeenCalled()
+		expect(sdk.events).toHaveLength(1)
+		expect(sdk.getRecordingState()).toBe('Recording')
+	})
+})

--- a/sdk/highlight-run/src/__tests__/record-worker-stop.test.ts
+++ b/sdk/highlight-run/src/__tests__/record-worker-stop.test.ts
@@ -3,9 +3,10 @@ import { RecordSDK } from '../sdk/record'
 import { MessageType, StopReason } from '../client/workers/types'
 
 const recordStop = vi.fn()
+const recordSpy = vi.fn(() => recordStop)
 vi.mock('@highlight-run/rrweb', () => ({
 	addCustomEvent: vi.fn(),
-	record: () => recordStop,
+	record: () => recordSpy(),
 }))
 
 vi.mock('../client/graph/generated/operations', () => ({
@@ -26,10 +27,13 @@ vi.mock('../client/workers/highlight-client-worker?worker&inline', () => ({
 	},
 }))
 
-async function startedSDK(): Promise<RecordSDK> {
+async function startedSDK(
+	options: Partial<ConstructorParameters<typeof RecordSDK>[0]> = {},
+): Promise<RecordSDK> {
 	const sdk = new RecordSDK({
 		organizationID: '1',
 		sessionSecureID: 'seed',
+		...options,
 	})
 	await sdk.start()
 	return sdk
@@ -44,6 +48,7 @@ describe('RecordSDK worker stop handling', () => {
 	beforeEach(() => {
 		vi.useFakeTimers()
 		recordStop.mockClear()
+		recordSpy.mockClear()
 	})
 
 	afterEach(() => {
@@ -67,6 +72,23 @@ describe('RecordSDK worker stop handling', () => {
 			expect(sdk.getRecordingState()).toBe('NotRecording')
 		},
 	)
+
+	// The page visibility listener stays attached once recording has ever started, so it is the
+	// one thing that can restart us after the worker has given up.
+	it('stays stopped when the tab becomes visible again', async () => {
+		const sdk = await startedSDK({ disableBackgroundRecording: true })
+
+		postToSDK(sdk, {
+			type: MessageType.Stop,
+			reason: StopReason.UnrecoverableError,
+		})
+		recordSpy.mockClear()
+		sdk._lastVisibilityChangeTime = 0 // clear the debounce frozen fake timers impose
+		await sdk._visibilityHandler(false)
+
+		expect(recordSpy).not.toHaveBeenCalled()
+		expect(sdk.getRecordingState()).toBe('NotRecording')
+	})
 
 	it('keeps recording while the worker only reports uploads', async () => {
 		const sdk = await startedSDK()

--- a/sdk/highlight-run/src/client/index.tsx
+++ b/sdk/highlight-run/src/client/index.tsx
@@ -112,7 +112,7 @@ import { getDefaultDataURLOptions, isMetricSafeNumber } from './utils/utils'
 import { type HighlightClientRequestWorker } from './workers/highlight-client-worker'
 import { payloadToBase64 } from './utils/payload'
 import HighlightClientWorker from './workers/highlight-client-worker?worker&inline'
-import { MessageType, PropertyType, StopReason } from './workers/types'
+import { MessageType, PropertyType } from './workers/types'
 import { parseError } from './utils/errors'
 import {
 	Attributes,
@@ -297,18 +297,16 @@ export class Highlight {
 					e.data.response.payload,
 				)
 			} else if (e.data.response?.type === MessageType.Stop) {
-				const { reason } = e.data.response
 				HighlightWarning(
-					`Stopping recording due to worker failure: ${reason}`,
+					`Stopping recording due to worker failure: ${e.data.response.reason}`,
 					e.data.response,
 				)
 				this.stopRecording(false)
-				if (reason === StopReason.UnrecoverableError) {
-					// Nothing more will be uploaded during this page load, so detach the
-					// recorder and drop what it buffered instead of growing the buffer forever.
-					this._stopRecorder()
-					this.events = []
-				}
+				// The worker only asks us to stop when it cannot upload what we record, and
+				// `_save` no longer runs once we are not recording, so detach the recorder and
+				// drop its buffer instead of filling memory for the rest of this page load.
+				this._stopRecorder()
+				this.events = []
 			}
 		}
 

--- a/sdk/highlight-run/src/client/index.tsx
+++ b/sdk/highlight-run/src/client/index.tsx
@@ -201,6 +201,10 @@ export class Highlight {
 	events!: eventWithTime[]
 	sessionData!: SessionData
 	ready!: boolean
+	/**
+	 * Recording must not resume on its own: either the app stopped us, or the worker gave up on
+	 * uploading. Starting again explicitly clears it.
+	 */
 	manualStopped!: boolean
 	state!: 'NotRecording' | 'Recording'
 	logger!: Logger
@@ -303,8 +307,10 @@ export class Highlight {
 				)
 				// Replay is what failed, so tracing and metrics keep running. `_save` no longer
 				// runs once we are not recording, so detach the recorder and drop its buffer
-				// instead of filling memory for the rest of this page load.
+				// instead of filling memory for the rest of this page load. The visibility
+				// listener outlives a stop by design, so mark the stop as one it must not undo.
 				this._stopCapture(true)
+				this.manualStopped = true
 				this.events = []
 			}
 		}

--- a/sdk/highlight-run/src/client/index.tsx
+++ b/sdk/highlight-run/src/client/index.tsx
@@ -301,11 +301,10 @@ export class Highlight {
 					`Stopping recording due to worker failure: ${e.data.response.reason}`,
 					e.data.response,
 				)
-				this.stopRecording(false)
-				// The worker only asks us to stop when it cannot upload what we record, and
-				// `_save` no longer runs once we are not recording, so detach the recorder and
-				// drop its buffer instead of filling memory for the rest of this page load.
-				this._stopRecorder()
+				// Replay is what failed, so tracing and metrics keep running. `_save` no longer
+				// runs once we are not recording, so detach the recorder and drop its buffer
+				// instead of filling memory for the rest of this page load.
+				this._stopCapture(true)
 				this.events = []
 			}
 		}
@@ -1445,14 +1444,24 @@ SessionSecureID: ${this.sessionData.sessionSecureID}`,
 				'H.stop() was called which stops Highlight from recording.',
 			)
 		}
+		this._stopCapture(manual)
+		void shutdown()
+	}
+
+	/**
+	 * Stops session replay and leaves telemetry alone. `stopRecording` shuts OTel down as well,
+	 * which is right when the whole SDK is stopping but not when only replay uploads have failed.
+	 *
+	 * @param detachRecorder also release rrweb's observers.
+	 */
+	_stopCapture(detachRecorder?: boolean) {
 		this.state = 'NotRecording'
-		if (manual) {
+		if (detachRecorder) {
 			this._stopRecorder()
 		}
 		// stop all other event listeners, to be restarted on initialize()
 		this.listeners.forEach((stop) => stop())
 		this.listeners = []
-		void shutdown()
 	}
 
 	/**

--- a/sdk/highlight-run/src/client/index.tsx
+++ b/sdk/highlight-run/src/client/index.tsx
@@ -112,7 +112,7 @@ import { getDefaultDataURLOptions, isMetricSafeNumber } from './utils/utils'
 import { type HighlightClientRequestWorker } from './workers/highlight-client-worker'
 import { payloadToBase64 } from './utils/payload'
 import HighlightClientWorker from './workers/highlight-client-worker?worker&inline'
-import { MessageType, PropertyType } from './workers/types'
+import { MessageType, PropertyType, StopReason } from './workers/types'
 import { parseError } from './utils/errors'
 import {
 	Attributes,
@@ -297,11 +297,18 @@ export class Highlight {
 					e.data.response.payload,
 				)
 			} else if (e.data.response?.type === MessageType.Stop) {
+				const { reason } = e.data.response
 				HighlightWarning(
-					'Stopping recording due to worker failure',
+					`Stopping recording due to worker failure: ${reason}`,
 					e.data.response,
 				)
 				this.stopRecording(false)
+				if (reason === StopReason.UnrecoverableError) {
+					// Nothing more will be uploaded during this page load, so detach the
+					// recorder and drop what it buffered instead of growing the buffer forever.
+					this._stopRecorder()
+					this.events = []
+				}
 			}
 		}
 
@@ -1441,15 +1448,25 @@ SessionSecureID: ${this.sessionData.sessionSecureID}`,
 			)
 		}
 		this.state = 'NotRecording'
-		// stop rrweb recording mutation observers
-		if (manual && this._recordStop) {
-			this._recordStop()
-			this._recordStop = undefined
+		if (manual) {
+			this._stopRecorder()
 		}
 		// stop all other event listeners, to be restarted on initialize()
 		this.listeners.forEach((stop) => stop())
 		this.listeners = []
 		void shutdown()
+	}
+
+	/**
+	 * Stops rrweb's recording mutation observers. `stopRecording` only does this on a manual stop
+	 * because rrweb's stop -> restart path is unreliable (eg. iframe listeners), so call this only
+	 * when recording will not resume during this page load.
+	 */
+	_stopRecorder() {
+		if (this._recordStop) {
+			this._recordStop()
+			this._recordStop = undefined
+		}
 	}
 
 	getCurrentSessionTimestamp() {

--- a/sdk/highlight-run/src/client/utils/error-recoverability.test.ts
+++ b/sdk/highlight-run/src/client/utils/error-recoverability.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest'
+import { ClientError } from 'graphql-request'
+import { PublicGraphError } from '../graph/generated/schemas'
+import {
+	isErrorRecoverable,
+	isHttpErrorRecoverable,
+} from './error-recoverability'
+
+type TestGraphQLError = {
+	message: string
+	extensions?: { retryable?: boolean }
+}
+
+function clientError(status: number, errors?: TestGraphQLError[]): ClientError {
+	return new ClientError(
+		{ status, errors } as unknown as ClientError['response'],
+		{ query: 'mutation pushPayload { pushPayload }' },
+	)
+}
+
+describe('isHttpErrorRecoverable', () => {
+	it('treats transient 4xx statuses as recoverable', () => {
+		expect(isHttpErrorRecoverable(400)).toBe(true)
+		expect(isHttpErrorRecoverable(408)).toBe(true)
+		expect(isHttpErrorRecoverable(429)).toBe(true)
+	})
+
+	it('treats every other 4xx status as unrecoverable', () => {
+		expect(isHttpErrorRecoverable(401)).toBe(false)
+		expect(isHttpErrorRecoverable(402)).toBe(false)
+		expect(isHttpErrorRecoverable(403)).toBe(false)
+		expect(isHttpErrorRecoverable(404)).toBe(false)
+		expect(isHttpErrorRecoverable(422)).toBe(false)
+	})
+
+	it('treats server errors and non-error statuses as recoverable', () => {
+		expect(isHttpErrorRecoverable(500)).toBe(true)
+		expect(isHttpErrorRecoverable(502)).toBe(true)
+		expect(isHttpErrorRecoverable(503)).toBe(true)
+		expect(isHttpErrorRecoverable(504)).toBe(true)
+		expect(isHttpErrorRecoverable(200)).toBe(true)
+		expect(isHttpErrorRecoverable(0)).toBe(true)
+	})
+})
+
+describe('isErrorRecoverable', () => {
+	it('treats errors of unknown origin as recoverable', () => {
+		expect(isErrorRecoverable(new Error('Failed to fetch'))).toBe(true)
+		expect(isErrorRecoverable(new TypeError('NetworkError'))).toBe(true)
+		expect(isErrorRecoverable(undefined)).toBe(true)
+	})
+
+	it('classifies a rejected request by its status', () => {
+		expect(isErrorRecoverable(clientError(403))).toBe(false)
+		expect(isErrorRecoverable(clientError(404))).toBe(false)
+		expect(isErrorRecoverable(clientError(429))).toBe(true)
+		expect(isErrorRecoverable(clientError(503))).toBe(true)
+	})
+
+	it('treats a 200 carrying GraphQL errors as unrecoverable', () => {
+		expect(
+			isErrorRecoverable(clientError(200, [{ message: 'not allowed' }])),
+		).toBe(false)
+	})
+
+	it('honors an explicit retryable flag over the status', () => {
+		expect(
+			isErrorRecoverable(
+				clientError(403, [
+					{ message: 'try again', extensions: { retryable: true } },
+				]),
+			),
+		).toBe(true)
+		expect(
+			isErrorRecoverable(
+				clientError(429, [
+					{ message: 'give up', extensions: { retryable: false } },
+				]),
+			),
+		).toBe(false)
+		expect(
+			isErrorRecoverable(
+				clientError(200, [
+					{ message: 'try again', extensions: { retryable: true } },
+				]),
+			),
+		).toBe(true)
+	})
+
+	it('takes the most pessimistic retryable flag when errors disagree', () => {
+		expect(
+			isErrorRecoverable(
+				clientError(200, [
+					{ message: 'try again', extensions: { retryable: true } },
+					{ message: 'give up', extensions: { retryable: false } },
+				]),
+			),
+		).toBe(false)
+	})
+
+	it('ignores a retryable flag on a permanent public graph error', () => {
+		expect(
+			isErrorRecoverable(
+				clientError(200, [
+					{
+						message: PublicGraphError.BillingQuotaExceeded,
+						extensions: { retryable: true },
+					},
+				]),
+			),
+		).toBe(false)
+	})
+})

--- a/sdk/highlight-run/src/client/utils/error-recoverability.ts
+++ b/sdk/highlight-run/src/client/utils/error-recoverability.ts
@@ -1,0 +1,74 @@
+import { ClientError } from 'graphql-request'
+import { PublicGraphError } from '../graph/generated/schemas'
+
+type GraphQLErrors = NonNullable<ClientError['response']['errors']>
+
+// Public graph errors that are permanent whatever the transport reports.
+const UNRECOVERABLE_ERRORS: string[] = [
+	PublicGraphError.BillingQuotaExceeded.toString(),
+]
+
+/**
+ * Tests whether an HTTP error status represents a condition that might resolve on its own if we
+ * retry. 4xx statuses are permanent apart from the three that describe a transient condition;
+ * anything else, including 5xx, is worth another attempt.
+ */
+export const isHttpErrorRecoverable = (statusCode: number): boolean => {
+	if (statusCode < 400 || statusCode >= 500) {
+		return true
+	}
+
+	switch (statusCode) {
+		case 400: // bad request
+		case 408: // request timeout
+		case 429: // too many requests
+			return true
+		default:
+			return false // all other 4xx errors are unrecoverable
+	}
+}
+
+/**
+ * Classifies a failed public graph request as recoverable (retrying may succeed) or unrecoverable
+ * (permanent for this page load). Errors of unknown origin count as recoverable: retrying costs a
+ * backed-off request, while a wrong permanent verdict silently disables recording.
+ */
+export const isErrorRecoverable = (error: unknown): boolean => {
+	if (!(error instanceof ClientError)) {
+		// Offline, DNS and aborted-fetch failures reject with the raw error and carry no
+		// permanent signal.
+		return true
+	}
+
+	const errors = error.response.errors
+	if (errors?.some((e) => UNRECOVERABLE_ERRORS.includes(e.message))) {
+		return false
+	}
+
+	// An explicit `retryable` is more specific than the status code, so it wins.
+	const retryable = retryableFlag(errors)
+	if (retryable !== undefined) {
+		return retryable
+	}
+
+	if (error.response.status >= 400) {
+		return isHttpErrorRecoverable(error.response.status)
+	}
+
+	// The public graph also reports a rejected request as `200` + `errors`. Classify those like a
+	// generic 4xx: permanent unless the server marked an error retryable.
+	return !errors?.length
+}
+
+/** The server's retry verdict for a set of GraphQL errors, or `undefined` when none states one. */
+const retryableFlag = (
+	errors: GraphQLErrors | undefined,
+): boolean | undefined => {
+	if (errors?.some((e) => e.extensions?.retryable === false)) {
+		return false
+	}
+	if (errors?.some((e) => e.extensions?.retryable === true)) {
+		return true
+	}
+	return undefined
+}

--- a/sdk/highlight-run/src/client/utils/graph.test.ts
+++ b/sdk/highlight-run/src/client/utils/graph.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ClientError } from 'graphql-request'
+import {
+	getGraphQLRequestWrapper,
+	MAX_PUBLIC_GRAPH_RETRY_ATTEMPTS,
+} from './graph'
+
+function clientError(status: number): ClientError {
+	return new ClientError({ status } as unknown as ClientError['response'], {
+		query: 'mutation pushPayload { pushPayload }',
+	})
+}
+
+/** Runs the wrapper to completion, letting every backoff timer fire immediately. */
+async function withoutBackoff<T>(request: Promise<T>): Promise<T> {
+	const settled = request.then(
+		(value) => ({ value }),
+		(error) => ({ error }),
+	)
+	await vi.runAllTimersAsync()
+	const outcome = await settled
+	if ('error' in outcome) {
+		throw outcome.error
+	}
+	return outcome.value
+}
+
+describe('getGraphQLRequestWrapper', () => {
+	beforeEach(() => {
+		vi.useFakeTimers()
+		vi.spyOn(console, 'error').mockImplementation(() => {})
+	})
+
+	afterEach(() => {
+		vi.useRealTimers()
+		vi.restoreAllMocks()
+	})
+
+	it('does not retry a request that succeeds', async () => {
+		const requestFn = vi.fn().mockResolvedValue('ok')
+
+		await expect(
+			withoutBackoff(
+				getGraphQLRequestWrapper()(requestFn, 'pushPayload'),
+			),
+		).resolves.toBe('ok')
+		expect(requestFn).toHaveBeenCalledTimes(1)
+	})
+
+	it('retries a recoverable failure until it succeeds', async () => {
+		const requestFn = vi
+			.fn()
+			.mockRejectedValueOnce(clientError(503))
+			.mockRejectedValueOnce(new Error('Failed to fetch'))
+			.mockResolvedValue('ok')
+
+		await expect(
+			withoutBackoff(
+				getGraphQLRequestWrapper()(requestFn, 'pushPayload'),
+			),
+		).resolves.toBe('ok')
+		expect(requestFn).toHaveBeenCalledTimes(3)
+	})
+
+	it('gives up on a recoverable failure after the retry budget', async () => {
+		const error = clientError(503)
+		const requestFn = vi.fn().mockRejectedValue(error)
+
+		await expect(
+			withoutBackoff(
+				getGraphQLRequestWrapper()(requestFn, 'pushPayload'),
+			),
+		).rejects.toBe(error)
+		expect(requestFn).toHaveBeenCalledTimes(
+			MAX_PUBLIC_GRAPH_RETRY_ATTEMPTS + 1,
+		)
+	})
+
+	it('throws an unrecoverable failure without retrying', async () => {
+		const error = clientError(403)
+		const requestFn = vi.fn().mockRejectedValue(error)
+
+		await expect(
+			withoutBackoff(
+				getGraphQLRequestWrapper()(requestFn, 'pushPayload'),
+			),
+		).rejects.toBe(error)
+		expect(requestFn).toHaveBeenCalledTimes(1)
+	})
+})

--- a/sdk/highlight-run/src/client/utils/graph.ts
+++ b/sdk/highlight-run/src/client/utils/graph.ts
@@ -1,22 +1,10 @@
-import { ClientError } from 'graphql-request'
-import { PublicGraphError } from '../graph/generated/schemas'
+import { isErrorRecoverable } from './error-recoverability'
 
 export const MAX_PUBLIC_GRAPH_RETRY_ATTEMPTS = 3
 
 // Initial backoff for retrying graphql requests.
 export const BASE_DELAY_MS = 1000
 export const BACKOFF_DELAY_MS = 500
-
-// Do not retry if any of these public graph errors are thrown
-const NON_RETRYABLE_ERRORS = [PublicGraphError.BillingQuotaExceeded.toString()]
-
-// A `ClientError` is retryable if none of the response errors is non-retryable
-const isErrorRetryable = (error: ClientError): boolean => {
-	const match = error.response.errors?.find((e) =>
-		NON_RETRYABLE_ERRORS.includes(e.message),
-	)
-	return match === undefined
-}
 
 export const getGraphQLRequestWrapper = () => {
 	const graphQLRequestWrapper = async <T>(
@@ -29,7 +17,9 @@ export const getGraphQLRequestWrapper = () => {
 		try {
 			return await requestFn()
 		} catch (error: any) {
-			if (error instanceof ClientError && !isErrorRetryable(error)) {
+			// Retrying an unrecoverable failure only delays the caller and adds load the backend
+			// already rejected.
+			if (!isErrorRecoverable(error)) {
 				throw error
 			}
 

--- a/sdk/highlight-run/src/client/workers/highlight-client-worker-errors.test.ts
+++ b/sdk/highlight-run/src/client/workers/highlight-client-worker-errors.test.ts
@@ -11,14 +11,27 @@ import {
 	StopReason,
 } from './types'
 
-// Every operation the worker performs rejects with this, so a single knob decides whether the
-// worker sees a recoverable or an unrecoverable failure.
-const graph = vi.hoisted(() => ({ error: undefined as unknown }))
+// Every operation the worker performs rejects with `error`, so a single knob decides whether the
+// worker sees a recoverable or an unrecoverable failure. Setting `hang` holds the next operation
+// open instead, and `failInFlight` is how the test answers it later.
+const graph = vi.hoisted(() => ({
+	error: undefined as unknown,
+	hang: false,
+	failInFlight: undefined as ((e: unknown) => void) | undefined,
+}))
 
 vi.mock('../graph/generated/operations', async (importOriginal) => {
 	const actual =
 		await importOriginal<typeof import('../graph/generated/operations')>()
-	const reject = () => Promise.reject(graph.error)
+	const reject = (): Promise<never> => {
+		if (graph.hang) {
+			graph.hang = false
+			return new Promise<never>((_, rejectInFlight) => {
+				graph.failInFlight = rejectInFlight
+			})
+		}
+		return Promise.reject(graph.error)
+	}
 	return {
 		...actual,
 		getSdk: () => ({
@@ -66,6 +79,14 @@ function identifyMessage(userIdentifier: string): HighlightClientWorkerParams {
 	}
 }
 
+/**
+ * A worker that ignores a failure says nothing about it, so telling that apart from one still on
+ * its way means giving the worker time to answer.
+ */
+function settle(): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, 300))
+}
+
 describe('highlight-client-worker error handling', () => {
 	let worker: TestWorker
 	let responses: HighlightClientWorkerResponse[]
@@ -91,6 +112,8 @@ describe('highlight-client-worker error handling', () => {
 
 	beforeEach(() => {
 		vi.resetModules()
+		graph.hang = false
+		graph.failInFlight = undefined
 		vi.spyOn(console, 'warn').mockImplementation(() => {})
 		// See highlight-client-worker.test.ts: the source module (rather than the `?worker&inline`
 		// build output) is what @vitest/web-worker can run for real.
@@ -207,6 +230,48 @@ describe('highlight-client-worker error handling', () => {
 		expect(pendingCount).toBe(0)
 		expect(initialized).toBe(false)
 	})
+
+	it.each([
+		['initializes again', [initializeMessage()]],
+		[
+			'is reset for a new session',
+			[
+				{ message: { type: MessageType.Reset } },
+				initializeMessage(),
+			] as HighlightClientWorkerParams[],
+		],
+	] as [string, HighlightClientWorkerParams[]][])(
+		'ignores a refusal owed to a session that ended before the client %s',
+		async (_name, revival) => {
+			graph.error = clientError(403)
+
+			// A request the backend never answers, so it is still open when the stop below lands.
+			graph.hang = true
+			worker.postMessage(initializeMessage())
+			worker.postMessage(identifyMessage('slow-user'))
+			await vi.waitFor(() => {
+				expect(graph.failInFlight).toBeDefined()
+			})
+
+			worker.postMessage(identifyMessage('refused-user'))
+			await vi.waitFor(() => {
+				expect(
+					responsesOfType<StopEventResponse>(MessageType.Stop),
+				).toHaveLength(1)
+			})
+
+			revival.forEach((message) => worker.postMessage(message))
+			expect((await status()).initialized).toBe(true)
+
+			graph.failInFlight!(clientError(403))
+			await settle()
+
+			expect((await status()).initialized).toBe(true)
+			expect(
+				responsesOfType<StopEventResponse>(MessageType.Stop),
+			).toHaveLength(1)
+		},
+	)
 
 	it('resumes after a new session initializes', async () => {
 		graph.error = clientError(403)

--- a/sdk/highlight-run/src/client/workers/highlight-client-worker-errors.test.ts
+++ b/sdk/highlight-run/src/client/workers/highlight-client-worker-errors.test.ts
@@ -1,0 +1,183 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ClientError } from 'graphql-request'
+import {
+	CustomEventResponse,
+	HighlightClientWorkerParams,
+	HighlightClientWorkerResponse,
+	MessageType,
+	StatusResponse,
+	StopEventResponse,
+	StopReason,
+} from './types'
+
+// Every operation the worker performs rejects with this, so a single knob decides whether the
+// worker sees a recoverable or an unrecoverable failure.
+const graph = vi.hoisted(() => ({ error: undefined as unknown }))
+
+vi.mock('../graph/generated/operations', async (importOriginal) => {
+	const actual =
+		await importOriginal<typeof import('../graph/generated/operations')>()
+	const reject = () => Promise.reject(graph.error)
+	return {
+		...actual,
+		getSdk: () => ({
+			identifySession: reject,
+			addSessionProperties: reject,
+			PushSessionEvents: reject,
+			pushMetrics: reject,
+		}),
+	}
+})
+
+interface TestWorker {
+	postMessage: (params: HighlightClientWorkerParams) => void
+	onmessage:
+		| ((event: MessageEvent<HighlightClientWorkerResponse>) => void)
+		| null
+	terminate: () => void
+}
+
+function clientError(status: number): ClientError {
+	return new ClientError({ status } as unknown as ClientError['response'], {
+		query: 'mutation identifySession { identifySession }',
+	})
+}
+
+function initializeMessage(): HighlightClientWorkerParams {
+	return {
+		message: {
+			type: MessageType.Initialize,
+			backend: 'https://test.highlight.io/graphql',
+			sessionSecureID: 'test-session-123',
+			debug: false,
+			recordingStartTime: Date.now(),
+		},
+	}
+}
+
+function identifyMessage(userIdentifier: string): HighlightClientWorkerParams {
+	return {
+		message: {
+			type: MessageType.Identify,
+			userIdentifier,
+			userObject: { name: 'Test User' },
+		},
+	}
+}
+
+describe('highlight-client-worker error handling', () => {
+	let worker: TestWorker
+	let responses: HighlightClientWorkerResponse[]
+
+	const responsesOfType = <T>(type: MessageType): T[] =>
+		responses
+			.filter((r) => r.response?.type === type)
+			.map((r) => r.response as T)
+
+	const status = async (): Promise<StatusResponse> => {
+		const before = responsesOfType<StatusResponse>(
+			MessageType.GetStatus,
+		).length
+		worker.postMessage({ message: { type: MessageType.GetStatus } })
+		await vi.waitFor(() => {
+			expect(
+				responsesOfType<StatusResponse>(MessageType.GetStatus).length,
+			).toBeGreaterThan(before)
+		})
+		const all = responsesOfType<StatusResponse>(MessageType.GetStatus)
+		return all[all.length - 1]
+	}
+
+	beforeEach(() => {
+		vi.resetModules()
+		vi.spyOn(console, 'warn').mockImplementation(() => {})
+		// See highlight-client-worker.test.ts: the source module (rather than the `?worker&inline`
+		// build output) is what @vitest/web-worker can run for real.
+		worker = new Worker(
+			new URL('./highlight-client-worker.ts', import.meta.url),
+			{ type: 'module' },
+		) as unknown as TestWorker
+		responses = []
+		worker.onmessage = (event) => {
+			responses.push(event.data)
+		}
+	})
+
+	afterEach(() => {
+		worker.terminate()
+		vi.restoreAllMocks()
+	})
+
+	it('stops recording when the backend rejects a request permanently', async () => {
+		graph.error = clientError(403)
+
+		worker.postMessage(initializeMessage())
+		worker.postMessage(identifyMessage('refused-user'))
+
+		await vi.waitFor(() => {
+			const stops = responsesOfType<StopEventResponse>(MessageType.Stop)
+			expect(stops).toHaveLength(1)
+			expect(stops[0].reason).toBe(StopReason.UnrecoverableError)
+		})
+
+		expect((await status()).initialized).toBe(false)
+	})
+
+	it('drops later messages after a permanent rejection', async () => {
+		graph.error = clientError(403)
+
+		worker.postMessage(initializeMessage())
+		worker.postMessage(identifyMessage('refused-user'))
+
+		await vi.waitFor(() => {
+			expect(
+				responsesOfType<StopEventResponse>(MessageType.Stop),
+			).toHaveLength(1)
+		})
+
+		worker.postMessage(identifyMessage('dropped-user'))
+
+		const { pendingCount } = await status()
+		expect(pendingCount).toBe(0)
+		expect(
+			responsesOfType<CustomEventResponse>(MessageType.CustomEvent).some(
+				(e) => e.payload?.includes('dropped-user'),
+			),
+		).toBe(false)
+	})
+
+	it('keeps recording when the failure may resolve on its own', async () => {
+		graph.error = clientError(503)
+
+		worker.postMessage(initializeMessage())
+		worker.postMessage(identifyMessage('retried-user'))
+
+		await vi.waitFor(() => {
+			expect(
+				responsesOfType<CustomEventResponse>(
+					MessageType.CustomEvent,
+				).some((e) => e.payload?.includes('retried-user')),
+			).toBe(true)
+		})
+
+		expect(responsesOfType<StopEventResponse>(MessageType.Stop)).toEqual([])
+		expect((await status()).initialized).toBe(true)
+	})
+
+	it('resumes after a new session initializes', async () => {
+		graph.error = clientError(403)
+
+		worker.postMessage(initializeMessage())
+		worker.postMessage(identifyMessage('refused-user'))
+
+		await vi.waitFor(() => {
+			expect(
+				responsesOfType<StopEventResponse>(MessageType.Stop),
+			).toHaveLength(1)
+		})
+
+		worker.postMessage(initializeMessage())
+
+		expect((await status()).initialized).toBe(true)
+	})
+})

--- a/sdk/highlight-run/src/client/workers/highlight-client-worker-errors.test.ts
+++ b/sdk/highlight-run/src/client/workers/highlight-client-worker-errors.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ClientError } from 'graphql-request'
+import { MAX_PUBLIC_GRAPH_RETRY_ATTEMPTS } from './constants'
 import {
 	CustomEventResponse,
 	HighlightClientWorkerParams,
@@ -162,6 +163,27 @@ describe('highlight-client-worker error handling', () => {
 
 		expect(responsesOfType<StopEventResponse>(MessageType.Stop)).toEqual([])
 		expect((await status()).initialized).toBe(true)
+	})
+
+	it('stops recording once the retry budget is spent', async () => {
+		graph.error = clientError(503)
+
+		worker.postMessage(initializeMessage())
+		for (let i = 0; i < MAX_PUBLIC_GRAPH_RETRY_ATTEMPTS; i++) {
+			worker.postMessage(identifyMessage(`retried-user-${i}`))
+		}
+
+		await vi.waitFor(() => {
+			const stops = responsesOfType<StopEventResponse>(MessageType.Stop)
+			expect(stops).toHaveLength(1)
+			expect(stops[0].reason).toBe(StopReason.RetriesExhausted)
+		})
+
+		worker.postMessage(identifyMessage('dropped-user'))
+
+		const { pendingCount, initialized } = await status()
+		expect(pendingCount).toBe(0)
+		expect(initialized).toBe(false)
 	})
 
 	it('resumes after a new session initializes', async () => {

--- a/sdk/highlight-run/src/client/workers/highlight-client-worker-errors.test.ts
+++ b/sdk/highlight-run/src/client/workers/highlight-client-worker-errors.test.ts
@@ -124,6 +124,28 @@ describe('highlight-client-worker error handling', () => {
 		expect((await status()).initialized).toBe(false)
 	})
 
+	it('does not report the stop as a timeline event', async () => {
+		graph.error = clientError(403)
+
+		worker.postMessage(initializeMessage())
+		worker.postMessage(identifyMessage('refused-user'))
+
+		await vi.waitFor(() => {
+			expect(
+				responsesOfType<StopEventResponse>(MessageType.Stop),
+			).toHaveLength(1)
+		})
+
+		// The client is NotRecording by the time it handles this, so a Track event could never be
+		// captured; it would only leave `addCustomEvent` polling every 500ms for the rest of the
+		// page load.
+		expect(
+			responsesOfType<CustomEventResponse>(MessageType.CustomEvent).map(
+				(e) => e.tag,
+			),
+		).not.toContain('Track')
+	})
+
 	it('drops later messages after a permanent rejection', async () => {
 		graph.error = clientError(403)
 

--- a/sdk/highlight-run/src/client/workers/highlight-client-worker-errors.test.ts
+++ b/sdk/highlight-run/src/client/workers/highlight-client-worker-errors.test.ts
@@ -13,21 +13,26 @@ import {
 
 // Every operation the worker performs rejects with `error`, so a single knob decides whether the
 // worker sees a recoverable or an unrecoverable failure. Setting `hang` holds the next operation
-// open instead, and `failInFlight` is how the test answers it later.
+// open instead, and `answerInFlight` is how the test settles it later.
 const graph = vi.hoisted(() => ({
 	error: undefined as unknown,
 	hang: false,
-	failInFlight: undefined as ((e: unknown) => void) | undefined,
+	answerInFlight: undefined as
+		| { succeed: () => void; fail: (e: unknown) => void }
+		| undefined,
 }))
 
 vi.mock('../graph/generated/operations', async (importOriginal) => {
 	const actual =
 		await importOriginal<typeof import('../graph/generated/operations')>()
-	const reject = (): Promise<never> => {
+	const reject = (): Promise<any> => {
 		if (graph.hang) {
 			graph.hang = false
-			return new Promise<never>((_, rejectInFlight) => {
-				graph.failInFlight = rejectInFlight
+			return new Promise<any>((resolve, rejectInFlight) => {
+				graph.answerInFlight = {
+					succeed: () => resolve({}),
+					fail: rejectInFlight,
+				}
 			})
 		}
 		return Promise.reject(graph.error)
@@ -79,6 +84,22 @@ function identifyMessage(userIdentifier: string): HighlightClientWorkerParams {
 	}
 }
 
+function asyncEventsMessage(id: number): HighlightClientWorkerParams {
+	return {
+		message: {
+			type: MessageType.AsyncEvents,
+			id,
+			hasSessionUnloaded: false,
+			highlightLogs: '',
+			events: [],
+			messages: [],
+			errors: [],
+			resourcesString: '[]',
+			webSocketEventsString: '[]',
+		},
+	}
+}
+
 /**
  * A worker that ignores a failure says nothing about it, so telling that apart from one still on
  * its way means giving the worker time to answer.
@@ -113,7 +134,7 @@ describe('highlight-client-worker error handling', () => {
 	beforeEach(() => {
 		vi.resetModules()
 		graph.hang = false
-		graph.failInFlight = undefined
+		graph.answerInFlight = undefined
 		vi.spyOn(console, 'warn').mockImplementation(() => {})
 		// See highlight-client-worker.test.ts: the source module (rather than the `?worker&inline`
 		// build output) is what @vitest/web-worker can run for real.
@@ -250,7 +271,7 @@ describe('highlight-client-worker error handling', () => {
 			worker.postMessage(initializeMessage())
 			worker.postMessage(identifyMessage('slow-user'))
 			await vi.waitFor(() => {
-				expect(graph.failInFlight).toBeDefined()
+				expect(graph.answerInFlight).toBeDefined()
 			})
 
 			worker.postMessage(identifyMessage('refused-user'))
@@ -263,7 +284,7 @@ describe('highlight-client-worker error handling', () => {
 			revival.forEach((message) => worker.postMessage(message))
 			expect((await status()).initialized).toBe(true)
 
-			graph.failInFlight!(clientError(403))
+			graph.answerInFlight!.fail(clientError(403))
 			await settle()
 
 			expect((await status()).initialized).toBe(true)
@@ -272,6 +293,54 @@ describe('highlight-client-worker error handling', () => {
 			).toHaveLength(1)
 		},
 	)
+
+	it('does not restore the retry budget of a new session with a stale success', async () => {
+		// A request the backend answers only after the session that sent it has been replaced.
+		graph.hang = true
+		worker.postMessage(initializeMessage())
+		worker.postMessage(identifyMessage('slow-user'))
+		await vi.waitFor(() => {
+			expect(graph.answerInFlight).toBeDefined()
+		})
+
+		worker.postMessage(initializeMessage())
+
+		// One short of the budget, so what the stale answer does to the count is what decides
+		// whether the next failure stops recording.
+		graph.error = clientError(503)
+		for (let i = 0; i < MAX_PUBLIC_GRAPH_RETRY_ATTEMPTS - 1; i++) {
+			worker.postMessage(identifyMessage(`retried-user-${i}`))
+		}
+		await settle()
+
+		graph.answerInFlight!.succeed()
+		await settle()
+
+		worker.postMessage(identifyMessage('last-straw'))
+		await vi.waitFor(() => {
+			const stops = responsesOfType<StopEventResponse>(MessageType.Stop)
+			expect(stops).toHaveLength(1)
+			expect(stops[0].reason).toBe(StopReason.RetriesExhausted)
+		})
+	})
+
+	it('does not report a payload uploaded for a session that has ended', async () => {
+		// The client counts the bytes of every payload the worker reports towards its next full
+		// snapshot, and this one was recorded by a session it is no longer replaying.
+		graph.hang = true
+		worker.postMessage(initializeMessage())
+		worker.postMessage(asyncEventsMessage(1))
+		await vi.waitFor(() => {
+			expect(graph.answerInFlight).toBeDefined()
+		})
+
+		worker.postMessage(initializeMessage())
+		graph.answerInFlight!.succeed()
+		await settle()
+
+		expect(responsesOfType(MessageType.AsyncEvents)).toHaveLength(0)
+		expect((await status()).initialized).toBe(true)
+	})
 
 	it('resumes after a new session initializes', async () => {
 		graph.error = clientError(403)

--- a/sdk/highlight-run/src/client/workers/highlight-client-worker.ts
+++ b/sdk/highlight-run/src/client/workers/highlight-client-worker.ts
@@ -103,7 +103,7 @@ function stringifyProperties(
 	let sessionSecureID: string
 	let numberOfFailedRequests: number = 0
 	let numberOfFailedPushPayloads: number = 0
-	let hasFailedUnrecoverably: boolean = false
+	let hasStoppedRecording: boolean = false
 	let debug: boolean = false
 	let recordingStartTime: number = 0
 	let logger = new Logger(false, '[worker]')
@@ -120,9 +120,8 @@ function stringifyProperties(
 
 	const shouldSendRequest = (): boolean => {
 		return (
-			!hasFailedUnrecoverably &&
+			!hasStoppedRecording &&
 			recordingStartTime !== 0 &&
-			numberOfFailedRequests < MAX_PUBLIC_GRAPH_RETRY_ATTEMPTS &&
 			!!sessionSecureID?.length
 		)
 	}
@@ -137,6 +136,11 @@ function stringifyProperties(
 		})
 	}
 
+	/**
+	 * Asks the client to stop recording and stops accepting work until it initializes again.
+	 * Everything buffered here is dropped: the client stops handing us events, so a queue kept
+	 * across a stop would only hold memory for data that will never be uploaded.
+	 */
 	const stopRecording = (
 		reason: StopReason,
 		details?: Pick<
@@ -144,6 +148,10 @@ function stringifyProperties(
 			'requestStart' | 'asyncEventsResponse'
 		>,
 	) => {
+		hasStoppedRecording = true
+		pendingMessages.length = 0
+		metricsPayload.length = 0
+
 		worker.postMessage({
 			response: {
 				type: MessageType.Stop,
@@ -162,26 +170,30 @@ function stringifyProperties(
 	}
 
 	/**
-	 * Accounts for a message we could not send. A recoverable failure spends part of the retry
-	 * budget, while an unrecoverable one ends recording for this page load: the backend would
-	 * reject every later request the same way, so continuing only buffers events that can never
-	 * be uploaded.
+	 * Accounts for a message we could not send. An unrecoverable failure ends recording right
+	 * away, because the backend would reject every later request the same way. A recoverable one
+	 * spends part of the retry budget, and exhausting that budget also ends recording: the client
+	 * would otherwise keep producing payloads that pile up here unsent.
 	 */
 	const handleFailedMessage = (e: unknown) => {
 		if (debug) {
 			console.error(e)
 		}
 
-		if (isErrorRecoverable(e)) {
-			numberOfFailedRequests += 1
+		if (!isErrorRecoverable(e)) {
+			console.warn(`Session data was rejected, stopping recording.`, e)
+			stopRecording(StopReason.UnrecoverableError)
 			return
 		}
 
-		console.warn(`Session data was rejected, stopping recording.`, e)
-		hasFailedUnrecoverably = true
-		pendingMessages.length = 0
-		metricsPayload.length = 0
-		stopRecording(StopReason.UnrecoverableError)
+		numberOfFailedRequests += 1
+		if (numberOfFailedRequests >= MAX_PUBLIC_GRAPH_RETRY_ATTEMPTS) {
+			console.warn(
+				`Session data failed to upload ${numberOfFailedRequests} times, stopping recording.`,
+				e,
+			)
+			stopRecording(StopReason.RetriesExhausted)
+		}
 	}
 
 	const processAsyncEventsMessage = async (msg: AsyncEventsMessage) => {
@@ -427,9 +439,10 @@ function stringifyProperties(
 			debug = e.data.message.debug
 			recordingStartTime = e.data.message.recordingStartTime
 			logger.debug = debug
-			// The client only initializes after `initializeSession` succeeded, so an earlier
-			// rejection no longer applies.
-			hasFailedUnrecoverably = false
+			// The client only initializes after `initializeSession` succeeded, so whatever made
+			// us stop no longer applies.
+			hasStoppedRecording = false
+			numberOfFailedRequests = 0
 			graphqlSDK = getSdk(
 				new GraphQLClient(backend, {
 					headers: {},
@@ -448,7 +461,7 @@ function stringifyProperties(
 			metricsPayload.length = 0
 			numberOfFailedRequests = 0
 			numberOfFailedPushPayloads = 0
-			hasFailedUnrecoverably = false
+			hasStoppedRecording = false
 			// Reset sessionSecureID and recordingStartTime so that messages arriving
 			// between Reset and new Initialize are queued rather than processed with
 			// the old session SecureID
@@ -469,9 +482,9 @@ function stringifyProperties(
 			return
 		}
 
-		// Drop messages once the backend has permanently rejected this session: queueing them
-		// would grow without bound because nothing is going to send them.
-		if (hasFailedUnrecoverably) {
+		// Drop messages once recording has stopped: queueing them would grow without bound
+		// because nothing is going to send them.
+		if (hasStoppedRecording) {
 			return
 		}
 

--- a/sdk/highlight-run/src/client/workers/highlight-client-worker.ts
+++ b/sdk/highlight-run/src/client/workers/highlight-client-worker.ts
@@ -211,6 +211,22 @@ function stringifyProperties(
 		}
 	}
 
+	/**
+	 * Accounts for a message we did send. The retry budget covers consecutive failures, so it
+	 * starts over.
+	 *
+	 * @param generation which session the sent request was issued for.
+	 */
+	const handleSentMessage = (generation: number) => {
+		// A request the backend accepted for a session that has ended says nothing about how the
+		// one recording now is faring, and restoring its budget would postpone a stop it is due.
+		if (generation !== sessionGeneration) {
+			return
+		}
+
+		numberOfFailedRequests = 0
+	}
+
 	const processAsyncEventsMessage = async (msg: AsyncEventsMessage) => {
 		const generation = sessionGeneration
 		const {
@@ -325,6 +341,9 @@ function stringifyProperties(
 		try {
 			await Promise.all([pushPayload, pushMetrics])
 			if (
+				// An upload that beat the timeout for a session that has ended says nothing
+				// about how the one recording now is faring.
+				generation === sessionGeneration &&
 				numberOfFailedPushPayloads &&
 				performance.now() - requestStart <= UPLOAD_TIMEOUT
 			) {
@@ -336,6 +355,12 @@ function stringifyProperties(
 		} finally {
 			requestStart = 0
 			clearInterval(int)
+		}
+
+		// The client counts these bytes towards its next full snapshot, and they were recorded by
+		// a session it is no longer replaying.
+		if (generation !== sessionGeneration) {
+			return
 		}
 
 		worker.postMessage({
@@ -448,7 +473,7 @@ function stringifyProperties(
 			const generation = sessionGeneration
 			try {
 				await processMessage(msg)
-				numberOfFailedRequests = 0
+				handleSentMessage(generation)
 			} catch (e) {
 				handleFailedMessage(e, generation)
 			}
@@ -522,7 +547,7 @@ function stringifyProperties(
 		const generation = sessionGeneration
 		try {
 			await processMessage(e.data.message)
-			numberOfFailedRequests = 0
+			handleSentMessage(generation)
 			await drainPendingMessages()
 		} catch (err) {
 			handleFailedMessage(err, generation)

--- a/sdk/highlight-run/src/client/workers/highlight-client-worker.ts
+++ b/sdk/highlight-run/src/client/workers/highlight-client-worker.ts
@@ -140,6 +140,9 @@ function stringifyProperties(
 	 * Asks the client to stop recording and stops accepting work until it initializes again.
 	 * Everything buffered here is dropped: the client stops handing us events, so a queue kept
 	 * across a stop would only hold memory for data that will never be uploaded.
+	 *
+	 * Only the first caller is served. Requests already in flight when we stop keep failing and
+	 * arrive here afterwards, and the client has nothing left to tear down by then.
 	 */
 	const stopRecording = (
 		reason: StopReason,
@@ -148,6 +151,10 @@ function stringifyProperties(
 			'requestStart' | 'asyncEventsResponse'
 		>,
 	) => {
+		if (hasStoppedRecording) {
+			return
+		}
+
 		hasStoppedRecording = true
 		pendingMessages.length = 0
 		metricsPayload.length = 0
@@ -158,14 +165,6 @@ function stringifyProperties(
 				reason,
 				...details,
 			},
-		})
-
-		processPropertiesMessage({
-			type: MessageType.Properties,
-			propertiesObject: {
-				stopReason: reason,
-			},
-			propertyType: { type: 'track' },
 		})
 	}
 

--- a/sdk/highlight-run/src/client/workers/highlight-client-worker.ts
+++ b/sdk/highlight-run/src/client/workers/highlight-client-worker.ts
@@ -104,6 +104,13 @@ function stringifyProperties(
 	let numberOfFailedRequests: number = 0
 	let numberOfFailedPushPayloads: number = 0
 	let hasStoppedRecording: boolean = false
+	/**
+	 * Counts the sessions this worker has served. Requests are stamped with the generation they
+	 * were issued for, because a request outlives the session that issued it: it can still be in
+	 * flight when recording stops, and what the backend answers about it says nothing about a
+	 * session that has started since.
+	 */
+	let sessionGeneration: number = 0
 	let debug: boolean = false
 	let recordingStartTime: number = 0
 	let logger = new Logger(false, '[worker]')
@@ -173,10 +180,19 @@ function stringifyProperties(
 	 * away, because the backend would reject every later request the same way. A recoverable one
 	 * spends part of the retry budget, and exhausting that budget also ends recording: the client
 	 * would otherwise keep producing payloads that pile up here unsent.
+	 *
+	 * @param generation which session the failed request was issued for.
 	 */
-	const handleFailedMessage = (e: unknown) => {
+	const handleFailedMessage = (e: unknown, generation: number) => {
 		if (debug) {
 			console.error(e)
+		}
+
+		// The session this request was issued for is over, and the one recording now neither sent
+		// it nor has any reason to be stopped by it.
+		if (generation !== sessionGeneration) {
+			logger.log('Ignoring a failure from a session that already ended.')
+			return
 		}
 
 		if (!isErrorRecoverable(e)) {
@@ -196,6 +212,7 @@ function stringifyProperties(
 	}
 
 	const processAsyncEventsMessage = async (msg: AsyncEventsMessage) => {
+		const generation = sessionGeneration
 		const {
 			id,
 			events,
@@ -274,6 +291,12 @@ function stringifyProperties(
 
 		let requestStart: number = performance.now()
 		const int = setInterval(() => {
+			// A slow upload can outlast the session it belongs to, and how long it takes is then
+			// no reason to stop the session recording now.
+			if (generation !== sessionGeneration) {
+				clearInterval(int)
+				return
+			}
 			if (
 				requestStart &&
 				performance.now() - requestStart > UPLOAD_TIMEOUT
@@ -422,11 +445,12 @@ function stringifyProperties(
 	const drainPendingMessages = async () => {
 		while (pendingMessages.length > 0 && shouldSendRequest()) {
 			const msg = pendingMessages.shift()!
+			const generation = sessionGeneration
 			try {
 				await processMessage(msg)
 				numberOfFailedRequests = 0
 			} catch (e) {
-				handleFailedMessage(e)
+				handleFailedMessage(e, generation)
 			}
 		}
 	}
@@ -441,6 +465,7 @@ function stringifyProperties(
 			// The client only initializes after `initializeSession` succeeded, so whatever made
 			// us stop no longer applies.
 			hasStoppedRecording = false
+			sessionGeneration += 1
 			numberOfFailedRequests = 0
 			numberOfFailedPushPayloads = 0
 			graphqlSDK = getSdk(
@@ -462,6 +487,7 @@ function stringifyProperties(
 			numberOfFailedRequests = 0
 			numberOfFailedPushPayloads = 0
 			hasStoppedRecording = false
+			sessionGeneration += 1
 			// Reset sessionSecureID and recordingStartTime so that messages arriving
 			// between Reset and new Initialize are queued rather than processed with
 			// the old session SecureID
@@ -493,12 +519,13 @@ function stringifyProperties(
 			return
 		}
 
+		const generation = sessionGeneration
 		try {
 			await processMessage(e.data.message)
 			numberOfFailedRequests = 0
 			await drainPendingMessages()
-		} catch (e) {
-			handleFailedMessage(e)
+		} catch (err) {
+			handleFailedMessage(err, generation)
 		}
 	}
 }

--- a/sdk/highlight-run/src/client/workers/highlight-client-worker.ts
+++ b/sdk/highlight-run/src/client/workers/highlight-client-worker.ts
@@ -10,6 +10,7 @@ import { payloadToBase64 } from '../utils/payload'
 import { ReplayEventsInput } from '../graph/generated/schemas'
 import { Logger } from '../logger'
 import { MetricCategory } from '../types/client'
+import { isErrorRecoverable } from '../utils/error-recoverability'
 import { getGraphQLRequestWrapper } from '../utils/graph'
 import {
 	MAX_PUBLIC_GRAPH_RETRY_ATTEMPTS,
@@ -26,6 +27,8 @@ import {
 	MessageType,
 	MetricsMessage,
 	PropertiesMessage,
+	StopEventResponse,
+	StopReason,
 } from './types'
 
 export interface HighlightClientRequestWorker {
@@ -100,6 +103,7 @@ function stringifyProperties(
 	let sessionSecureID: string
 	let numberOfFailedRequests: number = 0
 	let numberOfFailedPushPayloads: number = 0
+	let hasFailedUnrecoverably: boolean = false
 	let debug: boolean = false
 	let recordingStartTime: number = 0
 	let logger = new Logger(false, '[worker]')
@@ -116,6 +120,7 @@ function stringifyProperties(
 
 	const shouldSendRequest = (): boolean => {
 		return (
+			!hasFailedUnrecoverably &&
 			recordingStartTime !== 0 &&
 			numberOfFailedRequests < MAX_PUBLIC_GRAPH_RETRY_ATTEMPTS &&
 			!!sessionSecureID?.length
@@ -130,6 +135,53 @@ function stringifyProperties(
 				payload: payload,
 			},
 		})
+	}
+
+	const stopRecording = (
+		reason: StopReason,
+		details?: Pick<
+			StopEventResponse,
+			'requestStart' | 'asyncEventsResponse'
+		>,
+	) => {
+		worker.postMessage({
+			response: {
+				type: MessageType.Stop,
+				reason,
+				...details,
+			},
+		})
+
+		processPropertiesMessage({
+			type: MessageType.Properties,
+			propertiesObject: {
+				stopReason: reason,
+			},
+			propertyType: { type: 'track' },
+		})
+	}
+
+	/**
+	 * Accounts for a message we could not send. A recoverable failure spends part of the retry
+	 * budget, while an unrecoverable one ends recording for this page load: the backend would
+	 * reject every later request the same way, so continuing only buffers events that can never
+	 * be uploaded.
+	 */
+	const handleFailedMessage = (e: unknown) => {
+		if (debug) {
+			console.error(e)
+		}
+
+		if (isErrorRecoverable(e)) {
+			numberOfFailedRequests += 1
+			return
+		}
+
+		console.warn(`Session data was rejected, stopping recording.`, e)
+		hasFailedUnrecoverably = true
+		pendingMessages.length = 0
+		metricsPayload.length = 0
+		stopRecording(StopReason.UnrecoverableError)
 	}
 
 	const processAsyncEventsMessage = async (msg: AsyncEventsMessage) => {
@@ -229,20 +281,9 @@ function stringifyProperties(
 						`Uploading pushPayload took too long, stopping recording to avoid OOM.`,
 					)
 
-					worker.postMessage({
-						response: {
-							type: MessageType.Stop,
-							requestStart,
-							asyncEventsResponse: response,
-						},
-					})
-
-					processPropertiesMessage({
-						type: MessageType.Properties,
-						propertiesObject: {
-							stopReason: 'Push Payload Timeout',
-						},
-						propertyType: { type: 'track' },
+					stopRecording(StopReason.PushPayloadTimeout, {
+						requestStart,
+						asyncEventsResponse: response,
 					})
 				}
 			}
@@ -374,10 +415,7 @@ function stringifyProperties(
 				await processMessage(msg)
 				numberOfFailedRequests = 0
 			} catch (e) {
-				if (debug) {
-					console.error(e)
-				}
-				numberOfFailedRequests += 1
+				handleFailedMessage(e)
 			}
 		}
 	}
@@ -389,6 +427,9 @@ function stringifyProperties(
 			debug = e.data.message.debug
 			recordingStartTime = e.data.message.recordingStartTime
 			logger.debug = debug
+			// The client only initializes after `initializeSession` succeeded, so an earlier
+			// rejection no longer applies.
+			hasFailedUnrecoverably = false
 			graphqlSDK = getSdk(
 				new GraphQLClient(backend, {
 					headers: {},
@@ -407,6 +448,7 @@ function stringifyProperties(
 			metricsPayload.length = 0
 			numberOfFailedRequests = 0
 			numberOfFailedPushPayloads = 0
+			hasFailedUnrecoverably = false
 			// Reset sessionSecureID and recordingStartTime so that messages arriving
 			// between Reset and new Initialize are queued rather than processed with
 			// the old session SecureID
@@ -427,6 +469,12 @@ function stringifyProperties(
 			return
 		}
 
+		// Drop messages once the backend has permanently rejected this session: queueing them
+		// would grow without bound because nothing is going to send them.
+		if (hasFailedUnrecoverably) {
+			return
+		}
+
 		if (!shouldSendRequest()) {
 			pendingMessages.push(e.data.message)
 			return
@@ -437,10 +485,7 @@ function stringifyProperties(
 			numberOfFailedRequests = 0
 			await drainPendingMessages()
 		} catch (e) {
-			if (debug) {
-				console.error(e)
-			}
-			numberOfFailedRequests += 1
+			handleFailedMessage(e)
 		}
 	}
 }

--- a/sdk/highlight-run/src/client/workers/highlight-client-worker.ts
+++ b/sdk/highlight-run/src/client/workers/highlight-client-worker.ts
@@ -443,6 +443,7 @@ function stringifyProperties(
 			// us stop no longer applies.
 			hasStoppedRecording = false
 			numberOfFailedRequests = 0
+			numberOfFailedPushPayloads = 0
 			graphqlSDK = getSdk(
 				new GraphQLClient(backend, {
 					headers: {},

--- a/sdk/highlight-run/src/client/workers/types.ts
+++ b/sdk/highlight-run/src/client/workers/types.ts
@@ -100,10 +100,18 @@ export type CustomEventResponse = {
 	payload: any
 }
 
+export enum StopReason {
+	/** Uploads are outrunning the recording, so events would pile up in memory. */
+	PushPayloadTimeout = 'Push Payload Timeout',
+	/** The backend rejected the session data permanently; retrying cannot help. */
+	UnrecoverableError = 'Unrecoverable Error',
+}
+
 export type StopEventResponse = {
 	type: MessageType.Stop
-	requestStart: number
-	asyncEventsResponse: AsyncEventsResponse
+	reason: StopReason
+	requestStart?: number
+	asyncEventsResponse?: AsyncEventsResponse
 }
 
 export type HighlightClientWorkerParams = {

--- a/sdk/highlight-run/src/client/workers/types.ts
+++ b/sdk/highlight-run/src/client/workers/types.ts
@@ -105,6 +105,8 @@ export enum StopReason {
 	PushPayloadTimeout = 'Push Payload Timeout',
 	/** The backend rejected the session data permanently; retrying cannot help. */
 	UnrecoverableError = 'Unrecoverable Error',
+	/** Enough uploads failed in a row that the backend is not answering us at all. */
+	RetriesExhausted = 'Retries Exhausted',
 }
 
 export type StopEventResponse = {

--- a/sdk/highlight-run/src/sdk/record.ts
+++ b/sdk/highlight-run/src/sdk/record.ts
@@ -79,7 +79,7 @@ import { getDefaultDataURLOptions } from '../client/utils/utils'
 import { type HighlightClientRequestWorker } from '../client/workers/highlight-client-worker'
 import { payloadToBase64 } from '../client/utils/payload'
 import HighlightClientWorker from '../client/workers/highlight-client-worker?worker&inline'
-import { MessageType, PropertyType } from '../client/workers/types'
+import { MessageType, PropertyType, StopReason } from '../client/workers/types'
 import { IntegrationClient } from '../integrations'
 import { Record } from '../api/record'
 import { internalLog } from './util'
@@ -184,13 +184,20 @@ export class RecordSDK implements Record {
 					e.data.response.payload,
 				)
 			} else if (e.data.response?.type === MessageType.Stop) {
+				const { reason } = e.data.response
 				internalLog(
 					'worker.onmessage',
 					'warn',
-					'Stopping recording due to worker failure',
+					`Stopping recording due to worker failure: ${reason}`,
 					e.data.response,
 				)
 				this.stop(false)
+				if (reason === StopReason.UnrecoverableError) {
+					// Nothing more will be uploaded during this page load, so detach the recorder
+					// and drop what it buffered instead of growing the buffer forever.
+					this._stopRecorder()
+					this.events = []
+				}
 			}
 		}
 
@@ -950,14 +957,24 @@ SessionSecureID: ${this.sessionData.sessionSecureID}`,
 			)
 		}
 		this.state = 'NotRecording'
-		// stop rrweb recording mutation observers
-		if (manual && this._recordStop) {
-			this._recordStop()
-			this._recordStop = undefined
+		if (manual) {
+			this._stopRecorder()
 		}
 		// stop all other event listeners, to be restarted on initialize()
 		this.listeners.forEach((stop) => stop())
 		this.listeners = []
+	}
+
+	/**
+	 * Stops rrweb's recording mutation observers. `stop` only does this on a manual stop because
+	 * rrweb's stop -> restart path is unreliable (eg. iframe listeners), so call this only when
+	 * recording will not resume during this page load.
+	 */
+	_stopRecorder() {
+		if (this._recordStop) {
+			this._recordStop()
+			this._recordStop = undefined
+		}
 	}
 
 	/**

--- a/sdk/highlight-run/src/sdk/record.ts
+++ b/sdk/highlight-run/src/sdk/record.ts
@@ -79,7 +79,7 @@ import { getDefaultDataURLOptions } from '../client/utils/utils'
 import { type HighlightClientRequestWorker } from '../client/workers/highlight-client-worker'
 import { payloadToBase64 } from '../client/utils/payload'
 import HighlightClientWorker from '../client/workers/highlight-client-worker?worker&inline'
-import { MessageType, PropertyType, StopReason } from '../client/workers/types'
+import { MessageType, PropertyType } from '../client/workers/types'
 import { IntegrationClient } from '../integrations'
 import { Record } from '../api/record'
 import { internalLog } from './util'
@@ -184,20 +184,18 @@ export class RecordSDK implements Record {
 					e.data.response.payload,
 				)
 			} else if (e.data.response?.type === MessageType.Stop) {
-				const { reason } = e.data.response
 				internalLog(
 					'worker.onmessage',
 					'warn',
-					`Stopping recording due to worker failure: ${reason}`,
+					`Stopping recording due to worker failure: ${e.data.response.reason}`,
 					e.data.response,
 				)
 				this.stop(false)
-				if (reason === StopReason.UnrecoverableError) {
-					// Nothing more will be uploaded during this page load, so detach the recorder
-					// and drop what it buffered instead of growing the buffer forever.
-					this._stopRecorder()
-					this.events = []
-				}
+				// The worker only asks us to stop when it cannot upload what we record, and
+				// `_save` no longer runs once we are not recording, so detach the recorder and
+				// drop its buffer instead of filling memory for the rest of this page load.
+				this._stopRecorder()
+				this.events = []
 			}
 		}
 

--- a/sdk/highlight-run/src/sdk/record.ts
+++ b/sdk/highlight-run/src/sdk/record.ts
@@ -116,6 +116,10 @@ export class RecordSDK implements Record {
 	events!: eventWithTime[]
 	sessionData!: SessionData
 	ready!: boolean
+	/**
+	 * Recording must not resume on its own: either the app stopped us, or the worker gave up on
+	 * uploading. Starting again explicitly clears it.
+	 */
 	manualStopped!: boolean
 	state!: 'NotRecording' | 'Recording'
 	logger!: Logger
@@ -194,6 +198,9 @@ export class RecordSDK implements Record {
 				// The worker only asks us to stop when it cannot upload what we record, and
 				// `_save` no longer runs once we are not recording, so detach the recorder and
 				// drop its buffer instead of filling memory for the rest of this page load.
+				// The visibility listener outlives a stop by design, so mark the stop as one it
+				// must not undo.
+				this.manualStopped = true
 				this._stopRecorder()
 				this.events = []
 			}


### PR DESCRIPTION
Brings the browser SDK in line with the iOS and Android work on unrecoverable Session Replay errors, and closes the memory paths that surfaced along the way.

## Why

Every public graph failure was retried three times with backoff, permanent ones included, and the only thing that ever stopped recording was an upload timeout. So:

- A refused environment (bad SDK key, replay disabled, quota) cost four doomed requests and roughly 6.5s of backoff on **every page load**.
- The timeout stop left rrweb attached while `_save` no longer ran, so events accumulated for the rest of the page load, which is the opposite of what that stop was for.
- Five failed sends in a row closed the worker's send gate without stopping anything, and every later payload was queued for good.

## What changed

**Error classification** (`src/client/utils/error-recoverability.ts`) mirrors the Swift `ErrorRecoverability`: 400, 408, 429 and anything outside the 4xx range are recoverable, the rest of the 4xx range is not, an explicit `extensions.retryable` overrides the status either way, and a `200` carrying GraphQL errors is treated like a generic 4xx. `BillingQuotaExceeded` stays permanent regardless, which is the one case the old message-matching handled. Anything that is not a `ClientError` (offline, DNS, aborted fetch) stays recoverable.

**The retry wrapper** asks the classifier instead of comparing error message strings, so a refusal throws on the first attempt. This covers `initializeSession` on the main thread and the worker's uploads, since both share the wrapper.

**The worker** turns an unrecoverable failure, and an exhausted retry budget, into the stop signal that previously only fired on timeouts. `stopRecording()` now owns stopping: it drops the pending queue and batched metrics, posts the stop with a `StopReason`, records the reason as a track property, and stops accepting work until the client initializes again.

**The client** detaches rrweb and clears its event buffer for any stop the worker asks for, in both `RecordSDK` and the legacy `Highlight` class. `stop()` keeps its existing behavior for manual stops; the teardown moved into a shared `_stopRecorder()`.

## Notes

- An unrecoverable failure on any worker operation (identify, session properties, feedback) stops recording, not just payload pushes. The realistic causes are environment-wide, so they get the same verdict.
- `identify` and friends called after a stop are now dropped instead of queued forever.
- Unlike mobile, there is no disk-cached refusal and no eager probe: a page load is the natural fresh launch, and `initializeSession` already runs before capture starts.

## Test plan

- [x] `yarn turbo run test --filter highlight.run` (lint, build, enforce-size, tests) green
- [x] 461 tests across 26 files, `tsc --noEmit` clean
- [x] New coverage: the classifier, the retry wrapper (no retry when unrecoverable, full budget when not), the worker end to end against a mocked graph SDK (403 stops once and drops later messages, 503 does not stop, exhausted budget stops, a new `Initialize` resumes), and `RecordSDK` releasing rrweb plus clearing its buffer for all three stop reasons

Made with [Cursor](https://cursor.com)