### PR TITLE
chore: block third-party install scripts by default

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -2,6 +2,9 @@ compressionLevel: mixed
 
 enableGlobalCache: true
 
+# Third-party install scripts are opt-in via dependenciesMeta.*.built in package.json.
+enableScripts: false
+
 nodeLinker: node-modules
 
 yarnPath: .yarn/releases/yarn-4.13.0.cjs

--- a/package.json
+++ b/package.json
@@ -210,8 +210,65 @@
 		"@opentelemetry/sdk-node@^0.203.0": "^0.217.0"
 	},
 	"dependenciesMeta": {
+		"@apollo/protobufjs": {
+			"built": true
+		},
+		"@nestjs/core": {
+			"built": true
+		},
+		"@prisma/client": {
+			"built": true
+		},
+		"@prisma/engines": {
+			"built": true
+		},
+		"@swc/core": {
+			"built": true
+		},
+		"babylonjs": {
+			"built": true
+		},
+		"dtrace-provider": {
+			"built": true
+		},
+		"esbuild": {
+			"built": true
+		},
+		"lefthook": {
+			"built": true
+		},
+		"lmdb": {
+			"built": true
+		},
+		"msgpackr-extract": {
+			"built": true
+		},
+		"prisma": {
+			"built": true
+		},
+		"protobufjs": {
+			"built": true
+		},
 		"puppeteer@9.1.1": {
 			"built": false
+		},
+		"puppeteer": {
+			"built": true
+		},
+		"sharp": {
+			"built": true
+		},
+		"spawn-sync": {
+			"built": true
+		},
+		"svelte-preprocess": {
+			"built": true
+		},
+		"unrs-resolver": {
+			"built": true
+		},
+		"workerd": {
+			"built": true
 		}
 	},
 	"packageManager": "yarn@4.13.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9242,8 +9242,46 @@ __metadata:
     turbo: "npm:2.8.7"
     typescript: "npm:^5.8.3"
   dependenciesMeta:
+    "@apollo/protobufjs":
+      built: true
+    "@nestjs/core":
+      built: true
+    "@prisma/client":
+      built: true
+    "@prisma/engines":
+      built: true
+    "@swc/core":
+      built: true
+    babylonjs:
+      built: true
+    dtrace-provider:
+      built: true
+    esbuild:
+      built: true
+    lefthook:
+      built: true
+    lmdb:
+      built: true
+    msgpackr-extract:
+      built: true
+    prisma:
+      built: true
+    protobufjs:
+      built: true
+    puppeteer:
+      built: true
     puppeteer@9.1.1:
       built: false
+    sharp:
+      built: true
+    spawn-sync:
+      built: true
+    svelte-preprocess:
+      built: true
+    unrs-resolver:
+      built: true
+    workerd:
+      built: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Summary

Yarn 4 runs `preinstall`/`install`/`postinstall` from third-party packages by default (`yarn config get enableScripts` → `true` here). That is the execution vector for the npm hijack campaign in [SEC-8921](https://launchdarkly.atlassian.net/browse/SEC-8921) / [wiz-adv-2026-138](https://app.wiz.io/boards/threat-center/wiz-adv-2026-138), where malicious versions of `keyv`, `cache-manager`, `cacheable-request` and `@cacheable/utils` drop an infostealer from an install hook. This repo isn't affected today — the resolved versions are all majors below the hijacked ones — but nothing currently stops a future dependency from executing code at install time.

This flips `enableScripts` off and converts install scripts to an allowlist. Per Yarn's docs, when `enableScripts` is off the `dependenciesMeta.<pkg>.built` field inverts from a deny-list into an allow-list, so the packages that legitimately need to build are opted back in explicitly:

```diff
# .yarnrc.yml
+enableScripts: false

  "dependenciesMeta": {
+   "esbuild": { "built": true },
+   "sharp": { "built": true },
+   ...
    "puppeteer@9.1.1": { "built": false }
  }
```

The allowlist is exactly the set of packages Yarn reported as needing a build on a clean install, so nothing that builds today stops building. The pre-existing `puppeteer@9.1.1` exclusion is kept and still wins over the new blanket `puppeteer` entry — verified separately that a version-qualified `built: false` overrides a bare `built: true` for the same package.

## How did you test this change?

- `yarn install` on a cleared build state reports **zero** `YN0004` ("lists build scripts, but all build scripts have been disabled") lines, i.e. no package that builds today is silently skipped.
- Cross-checked the allowlist against every package in `node_modules` declaring a `preinstall`/`install`/`postinstall` hook, which caught `@prisma/client` that the install log alone had missed.
- Confirmed enforcement in a scratch project rather than assuming it: with `enableScripts: false` and only `esbuild` allowlisted, `esbuild` built while `dtrace-provider` reported `YN0004` and produced no build output.
- `yarn config get enableScripts` → `false`; `prettier --check` clean on the changed files.

## Risks / follow-ups

- The allowlist needs a new entry whenever a dependency that genuinely needs an install script is added. The failure mode is a visible `YN0004` notice at install time, not a silent break.
- A local `rrvideo` workspace build failed during testing on a stale Playwright browser lock (`~/.cache/ms-playwright/__dirlock`) left behind by a killed install. Unrelated to this change; workspace scripts are unaffected by `enableScripts` by design.
- This repo is consumed as a submodule by `launchdarkly/observability`, which carries the same change in a companion PR. That repo's `yarn.lock` records this workspace's `dependenciesMeta`, so its lockfile needs regenerating when its submodule pointer is bumped past this commit.
- Yarn has no `minimumReleaseAge`/cooldown equivalent, so this closes the execution vector but not the "install a version published minutes ago" vector. Tracked in SEC-8921.


Link to Devin session: https://app.devin.ai/sessions/6bf8e18507f94eed85e5c0a806f691ed
Requested by: @kparkinson-ld

[SEC-8921]: https://launchdarkly.atlassian.net/browse/SEC-8921?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes install behavior for all developers and CI; missing allowlist entries can break native/postinstall builds, but failures are usually visible at `yarn install` rather than silent runtime breaks.
> 
> **Overview**
> Disables Yarn’s default execution of third-party `preinstall`/`install`/`postinstall` hooks by setting **`enableScripts: false`** in `.yarnrc.yml`, closing the install-time code execution path used in recent npm supply-chain attacks.
> 
> With scripts off, **`dependenciesMeta.<pkg>.built`** becomes an allowlist: the PR adds explicit **`built: true`** entries for packages that still need native builds or postinstall steps (e.g. `esbuild`, `sharp`, `prisma`, `@swc/core`, `workerd`), derived from a clean install. The existing **`puppeteer@9.1.1`** **`built: false`** override remains. The same **`dependenciesMeta`** block is reflected in **`yarn.lock`** for the root workspace.
> 
> New dependencies that require install scripts will need a new allowlist entry or installs will surface **`YN0004`** warnings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 436282ea410c2d6aee198a6d7ba4a0d6c0c77fab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->