### PR TITLE
chore: require npm versions to be 7 days old before resolution

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -7,8 +7,8 @@ enableScripts: false
 
 nodeLinker: node-modules
 
-# Only resolve package versions published more than 3 days ago. Exempt packages
+# Only resolve package versions published more than 7 days ago. Exempt packages
 # via npmPreapprovedPackages.
-npmMinimalAgeGate: 3d
+npmMinimalAgeGate: 7d
 
 yarnPath: .yarn/releases/yarn-4.13.0.cjs

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -7,4 +7,8 @@ enableScripts: false
 
 nodeLinker: node-modules
 
+# Only resolve package versions published more than 3 days ago. Exempt packages
+# via npmPreapprovedPackages.
+npmMinimalAgeGate: 3d
+
 yarnPath: .yarn/releases/yarn-4.13.0.cjs


### PR DESCRIPTION
## Summary

Follow-up to #705, from the [SEC-8921](https://launchdarkly.atlassian.net/browse/SEC-8921) investigation of the npm account-takeover campaign that hijacked `keyv`, `cache-manager`, `cacheable-request` and ~39 other packages (Wiz `wiz-adv-2026-138`). #705 stopped hijacked packages from *executing* install scripts; this stops us from *resolving* a version that was published minutes ago, which is the window these campaigns live in — malicious versions are typically yanked within hours.

```diff
  nodeLinker: node-modules

+ # Only resolve package versions published more than 7 days ago. Exempt packages
+ # via npmPreapprovedPackages.
+ npmMinimalAgeGate: 7d
+
  yarnPath: .yarn/releases/yarn-4.13.0.cjs
```

`npmMinimalAgeGate` is native to yarn (added in 4.10.0); this repo is already on 4.13.0, so no yarn bump is needed here. 7 days per @pkaeding's review — it matches the `default-days: 7` dependabot cooldown used in 15 of the 16 org repos that configure one, and comfortably covers npm's 72-hour unpublish window, so we also stop depending on versions that can still vanish. (gonfalon's renovate hold is 3 days and is the outlier; worth reconciling separately.)

What it does and doesn't do:

- **Resolution-time only.** Existing `yarn.lock` entries install normally, including versions younger than the gate. Nothing already pinned breaks.
- Applies to *every* install path — `yarn add` on a laptop as well as CI — unlike a renovate/dependabot cooldown, which only gates bot PRs.
- Adding a dependency whose only matching version is too new fails loudly: `YN0016: ... All versions satisfying "x.y.z" are quarantined`. `npmPreapprovedPackages` is the documented escape hatch; nothing needs it today.
- Workspace packages are unaffected — the e2e apps consume `highlight.run` / `@launchdarkly/*` via `workspace:*`, not from the registry, so our own just-published releases are never gated. No workflow here installs a freshly published version from npm.

Cost: picking up a genuine upstream fix (including a Dependabot security bump) can be delayed up to 7 days. Preapprove the package or lower the value if that ever bites.

## How did you test this change?

- `yarn config get npmMinimalAgeGate` → `10080` (minutes).
- `yarn install --immutable` — clean, no lockfile churn, no quarantine errors.
- `yarn dedupe --check` and `yarn format-check` — both pass (the CI steps most likely to be perturbed by a resolver change).
- Separately, in a scratch project on the same yarn 4.13.0 binary: `yarn add @aws-sdk/client-s3` resolved an older version and refused a recently published one, confirming the gate is actually enforced rather than silently ignored.

## Are there any deployment considerations?

No. Config-only; no runtime or published-artifact change.


Link to Devin session: https://app.devin.ai/sessions/6bf8e18507f94eed85e5c0a806f691ed
Requested by: @kparkinson-ld

[SEC-8921]: https://launchdarkly.atlassian.net/browse/SEC-8921?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Adds **`npmMinimalAgeGate: 7d`** to `.yarnrc.yml` so Yarn only **resolves** npm package versions published at least seven days ago, complementing the existing **`enableScripts: false`** supply-chain controls.
> 
> **Existing `yarn.lock` pins are unchanged**; the gate applies when adding or bumping dependencies (local `yarn add` and CI alike). Versions that are too new fail with a quarantine error unless exempted via **`npmPreapprovedPackages`**. Workspace `workspace:*` packages are not affected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ee65a3d8339902837a89296d604399b4c192609. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->