### PR TITLE
feat: expose native Flutter observability options

### DIFF
--- a/sdk/@launchdarkly/flutter/example/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/sdk/@launchdarkly/flutter/example/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/kstenerud/KSCrash.git",
       "state" : {
-        "revision" : "95a8895d75f3c22aa9ad9f2a15d2fbd97b0a55e2",
-        "version" : "2.5.1"
+        "revision" : "fb26b1b62eca4bbf71ae441b312d0126e6ce75cf",
+        "version" : "2.6.0-beta.3"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/launchdarkly/swift-launchdarkly-observability.git",
       "state" : {
-        "revision" : "5e53279e7a4067b0665210ef0f651cbf280fee30",
-        "version" : "0.46.3"
+        "revision" : "6d28f81c4bf47e4c1e22ae1b2e22433d03b58855",
+        "version" : "0.50.0"
       }
     }
   ],

--- a/sdk/@launchdarkly/flutter/example/ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/sdk/@launchdarkly/flutter/example/ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/kstenerud/KSCrash.git",
       "state" : {
-        "revision" : "95a8895d75f3c22aa9ad9f2a15d2fbd97b0a55e2",
-        "version" : "2.5.1"
+        "revision" : "fb26b1b62eca4bbf71ae441b312d0126e6ce75cf",
+        "version" : "2.6.0-beta.3"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/launchdarkly/swift-launchdarkly-observability.git",
       "state" : {
-        "revision" : "5e53279e7a4067b0665210ef0f651cbf280fee30",
-        "version" : "0.46.3"
+        "revision" : "6d28f81c4bf47e4c1e22ae1b2e22433d03b58855",
+        "version" : "0.50.0"
       }
     }
   ],

--- a/sdk/@launchdarkly/flutter/packages/observability/README.md
+++ b/sdk/@launchdarkly/flutter/packages/observability/README.md
@@ -154,6 +154,7 @@ On `ObservabilityOptions`:
 
 On `SessionReplayOptions`:
 
+- `sampleRate` (`double`): probability from `0.0` to `1.0` that replay starts when enabled. Defaults to `1.0`.
 - `frameRate` (`double`): target capture rate in frames per second. Defaults to `1.0`.
 - `scale` (`double?`): replay capture resolution multiplier — `1.0` = 1x (160 DPI), `2.0` = 2x, etc. Higher values capture more detail but produce larger frames. `null` is treated as `1.0`. Defaults to `1.0`.
 
@@ -174,7 +175,11 @@ LDObserve.init(
       crashReporting: true,
     ),
   ),
-  replay: const SessionReplayOptions(isEnabled: true, frameRate: 2.0),
+  replay: const SessionReplayOptions(
+    isEnabled: true,
+    sampleRate: 0.25,
+    frameRate: 2.0,
+  ),
 );
 ```
 

--- a/sdk/@launchdarkly/flutter/packages/observability/android/build.gradle
+++ b/sdk/@launchdarkly/flutter/packages/observability/android/build.gradle
@@ -54,7 +54,7 @@ dependencies {
     // Native dependencies mirrored from the LaunchDarkly mobile SDKs (the same
     // stack used by sdk/@launchdarkly/react-native-ld-session-replay and the
     // .NET MAUI bridge in sdk/@launchdarkly/mobile-dotnet).
-    implementation "com.launchdarkly:launchdarkly-observability-android:0.60.0"
+    implementation "com.launchdarkly:launchdarkly-observability-android:0.64.0"
     // OTel Attributes appears in ObservabilityOptions parameter types; provided
     // at runtime transitively through launchdarkly-observability-android.
     implementation "io.opentelemetry:opentelemetry-api:1.62.0"

--- a/sdk/@launchdarkly/flutter/packages/observability/android/src/main/kotlin/com/launchdarkly/launchdarkly_flutter_observability/LDNativeApiImpl.kt
+++ b/sdk/@launchdarkly/flutter/packages/observability/android/src/main/kotlin/com/launchdarkly/launchdarkly_flutter_observability/LDNativeApiImpl.kt
@@ -78,6 +78,7 @@ internal class LDNativeApiImpl(
             enabled = observability.isEnabled ?: true,
             serviceName = observability.serviceName ?: DEFAULT_SERVICE_NAME,
             serviceVersion = observability.serviceVersion ?: DEFAULT_SERVICE_VERSION,
+            contextFriendlyName = observability.contextFriendlyName,
             resourceAttributes = resourceAttributes,
             customHeaders = observability.customHeaders ?: emptyMap(),
             sessionBackgroundTimeout = observability.sessionBackgroundTimeoutMillis
@@ -127,6 +128,7 @@ internal class LDNativeApiImpl(
         val replayScale = replay.scale?.takeIf { it > 0 } ?: 1.0
         val nativeReplayOptions = ReplayOptions(
             enabled = replay.isEnabled ?: true,
+            sampleRate = replay.sampleRate ?: 1.0,
             frameRate = replay.frameRate ?: 1.0,
             scale = replayScale.toFloat(),
             privacyProfile = PrivacyProfile(

--- a/sdk/@launchdarkly/flutter/packages/observability/android/src/main/kotlin/com/launchdarkly/launchdarkly_flutter_observability/Messages.g.kt
+++ b/sdk/@launchdarkly/flutter/packages/observability/android/src/main/kotlin/com/launchdarkly/launchdarkly_flutter_observability/Messages.g.kt
@@ -294,6 +294,7 @@ data class LDPrivacyOptions (
 data class LDSessionReplayOptions (
   val isEnabled: Boolean? = null,
   val serviceName: String? = null,
+  val sampleRate: Double? = null,
   val frameRate: Double? = null,
   val scale: Double? = null,
   val privacy: LDPrivacyOptions? = null
@@ -303,16 +304,18 @@ data class LDSessionReplayOptions (
     fun fromList(pigeonVar_list: List<Any?>): LDSessionReplayOptions {
       val isEnabled = pigeonVar_list[0] as Boolean?
       val serviceName = pigeonVar_list[1] as String?
-      val frameRate = pigeonVar_list[2] as Double?
-      val scale = pigeonVar_list[3] as Double?
-      val privacy = pigeonVar_list[4] as LDPrivacyOptions?
-      return LDSessionReplayOptions(isEnabled, serviceName, frameRate, scale, privacy)
+      val sampleRate = pigeonVar_list[2] as Double?
+      val frameRate = pigeonVar_list[3] as Double?
+      val scale = pigeonVar_list[4] as Double?
+      val privacy = pigeonVar_list[5] as LDPrivacyOptions?
+      return LDSessionReplayOptions(isEnabled, serviceName, sampleRate, frameRate, scale, privacy)
     }
   }
   fun toList(): List<Any?> {
     return listOf(
       isEnabled,
       serviceName,
+      sampleRate,
       frameRate,
       scale,
       privacy,

--- a/sdk/@launchdarkly/flutter/packages/observability/ios/launchdarkly_flutter_observability/Package.swift
+++ b/sdk/@launchdarkly/flutter/packages/observability/ios/launchdarkly_flutter_observability/Package.swift
@@ -20,7 +20,7 @@ let swiftObservabilityDependency: Package.Dependency = if useLocalNativeSdk {
 } else {
     .package(
         url: "https://github.com/launchdarkly/swift-launchdarkly-observability.git",
-        .upToNextMinor(from: "0.46.3")
+        .upToNextMinor(from: "0.50.0")
     )
 }
 

--- a/sdk/@launchdarkly/flutter/packages/observability/ios/launchdarkly_flutter_observability/Sources/launchdarkly_flutter_observability/LDNativeApiImpl.swift
+++ b/sdk/@launchdarkly/flutter/packages/observability/ios/launchdarkly_flutter_observability/Sources/launchdarkly_flutter_observability/LDNativeApiImpl.swift
@@ -213,10 +213,12 @@ final class LDNativeApiImpl: NSObject, LDNativeApi {
         )
 
         let observabilityOptions = ObservabilityOptions(
+            isEnabled: observability.isEnabled ?? true,
             serviceName: serviceName,
             serviceVersion: serviceVersion,
             otlpEndpoint: otlpEndpoint,
             backendUrl: backendUrl,
+            contextFriendlyName: observability.contextFriendlyName,
             resourceAttributes: resourceAttributes,
             customHeaders: customHeaders,
             sessionBackgroundTimeout: sessionBackgroundTimeout,
@@ -274,6 +276,7 @@ final class LDNativeApiImpl: NSObject, LDNativeApi {
 
         return LaunchDarklySessionReplay.SessionReplayOptions(
             isEnabled: replay.isEnabled ?? true,
+            sampleRate: replay.sampleRate ?? 1.0,
             privacy: .init(
                 maskTextInputs: privacy?.maskTextInputs ?? true,
                 maskWebViews: privacy?.maskWebViews ?? false,

--- a/sdk/@launchdarkly/flutter/packages/observability/ios/launchdarkly_flutter_observability/Sources/launchdarkly_flutter_observability/Messages.g.swift
+++ b/sdk/@launchdarkly/flutter/packages/observability/ios/launchdarkly_flutter_observability/Sources/launchdarkly_flutter_observability/Messages.g.swift
@@ -353,6 +353,7 @@ struct LDPrivacyOptions: Hashable {
 struct LDSessionReplayOptions: Hashable {
   var isEnabled: Bool? = nil
   var serviceName: String? = nil
+  var sampleRate: Double? = nil
   var frameRate: Double? = nil
   var scale: Double? = nil
   var privacy: LDPrivacyOptions? = nil
@@ -362,13 +363,15 @@ struct LDSessionReplayOptions: Hashable {
   static func fromList(_ pigeonVar_list: [Any?]) -> LDSessionReplayOptions? {
     let isEnabled: Bool? = nilOrValue(pigeonVar_list[0])
     let serviceName: String? = nilOrValue(pigeonVar_list[1])
-    let frameRate: Double? = nilOrValue(pigeonVar_list[2])
-    let scale: Double? = nilOrValue(pigeonVar_list[3])
-    let privacy: LDPrivacyOptions? = nilOrValue(pigeonVar_list[4])
+    let sampleRate: Double? = nilOrValue(pigeonVar_list[2])
+    let frameRate: Double? = nilOrValue(pigeonVar_list[3])
+    let scale: Double? = nilOrValue(pigeonVar_list[4])
+    let privacy: LDPrivacyOptions? = nilOrValue(pigeonVar_list[5])
 
     return LDSessionReplayOptions(
       isEnabled: isEnabled,
       serviceName: serviceName,
+      sampleRate: sampleRate,
       frameRate: frameRate,
       scale: scale,
       privacy: privacy
@@ -378,6 +381,7 @@ struct LDSessionReplayOptions: Hashable {
     return [
       isEnabled,
       serviceName,
+      sampleRate,
       frameRate,
       scale,
       privacy,

--- a/sdk/@launchdarkly/flutter/packages/observability/lib/src/options/session_replay_options.dart
+++ b/sdk/@launchdarkly/flutter/packages/observability/lib/src/options/session_replay_options.dart
@@ -12,6 +12,11 @@ class SessionReplayOptions {
   final bool isEnabled;
   final String serviceName;
 
+  /// Probability from `0.0` to `1.0` that Session Replay starts when enabled.
+  /// Values at or below zero never record; values at or above one always
+  /// record. The native SDK makes a new decision each time replay is enabled.
+  final double sampleRate;
+
   /// Target capture rate in frames per second. Mirrors Android/iOS
   /// `frameRate`. Native-only. Defaults to `1.0`.
   final double frameRate;
@@ -28,6 +33,7 @@ class SessionReplayOptions {
   const SessionReplayOptions({
     this.isEnabled = true,
     this.serviceName = 'sessionreplay-flutter',
+    this.sampleRate = 1.0,
     this.frameRate = 1.0,
     this.scale = 1.0,
     this.privacy = const PrivacyOptions(),

--- a/sdk/@launchdarkly/flutter/packages/observability/lib/src/platform/io/messages.g.dart
+++ b/sdk/@launchdarkly/flutter/packages/observability/lib/src/platform/io/messages.g.dart
@@ -349,6 +349,7 @@ class LDSessionReplayOptions {
   LDSessionReplayOptions({
     this.isEnabled,
     this.serviceName,
+    this.sampleRate,
     this.frameRate,
     this.scale,
     this.privacy,
@@ -358,6 +359,8 @@ class LDSessionReplayOptions {
 
   String? serviceName;
 
+  double? sampleRate;
+
   double? frameRate;
 
   double? scale;
@@ -365,7 +368,14 @@ class LDSessionReplayOptions {
   LDPrivacyOptions? privacy;
 
   List<Object?> _toList() {
-    return <Object?>[isEnabled, serviceName, frameRate, scale, privacy];
+    return <Object?>[
+      isEnabled,
+      serviceName,
+      sampleRate,
+      frameRate,
+      scale,
+      privacy,
+    ];
   }
 
   Object encode() {
@@ -377,9 +387,10 @@ class LDSessionReplayOptions {
     return LDSessionReplayOptions(
       isEnabled: result[0] as bool?,
       serviceName: result[1] as String?,
-      frameRate: result[2] as double?,
-      scale: result[3] as double?,
-      privacy: result[4] as LDPrivacyOptions?,
+      sampleRate: result[2] as double?,
+      frameRate: result[3] as double?,
+      scale: result[4] as double?,
+      privacy: result[5] as LDPrivacyOptions?,
     );
   }
 

--- a/sdk/@launchdarkly/flutter/packages/observability/lib/src/platform/io/native_options_codec.dart
+++ b/sdk/@launchdarkly/flutter/packages/observability/lib/src/platform/io/native_options_codec.dart
@@ -54,6 +54,7 @@ extension SessionReplayOptionsWire on SessionReplayOptions {
   wire.LDSessionReplayOptions toWire() => wire.LDSessionReplayOptions(
     isEnabled: isEnabled,
     serviceName: serviceName,
+    sampleRate: sampleRate,
     frameRate: frameRate,
     scale: scale,
     privacy: privacy.toWire(),

--- a/sdk/@launchdarkly/flutter/packages/observability/pigeons/messages.dart
+++ b/sdk/@launchdarkly/flutter/packages/observability/pigeons/messages.dart
@@ -70,6 +70,7 @@ class LDPrivacyOptions {
 class LDSessionReplayOptions {
   bool? isEnabled;
   String? serviceName;
+  double? sampleRate;
   double? frameRate;
   double? scale;
   LDPrivacyOptions? privacy;

--- a/sdk/@launchdarkly/flutter/packages/observability/test/native_options_codec_test.dart
+++ b/sdk/@launchdarkly/flutter/packages/observability/test/native_options_codec_test.dart
@@ -24,6 +24,8 @@ void main() {
 
     test('propagates custom values', () {
       final wire = const ObservabilityOptions(
+        isEnabled: false,
+        contextFriendlyName: 'checkout user',
         customHeaders: {'x-proxy': 'value'},
         sessionBackgroundTimeout: Duration(minutes: 5),
         logsApiLevel: ObservabilityLogLevel.none,
@@ -39,6 +41,8 @@ void main() {
         instrumentation: InstrumentationOptions(crashReporting: false),
       ).toWire();
 
+      expect(wire.isEnabled, isFalse);
+      expect(wire.contextFriendlyName, 'checkout user');
       expect(wire.customHeaders, {'x-proxy': 'value'});
       expect(wire.sessionBackgroundTimeoutMillis, 5 * 60 * 1000);
       expect(wire.logsApiLevel, 0x7fffffff);
@@ -63,11 +67,18 @@ void main() {
   });
 
   group('SessionReplayOptions.toWire', () {
-    test('uses default frame rate and scale', () {
+    test('uses default sample rate, frame rate, and scale', () {
       final wire = const SessionReplayOptions().toWire();
 
+      expect(wire.sampleRate, 1.0);
       expect(wire.frameRate, 1.0);
       expect(wire.scale, 1.0);
+    });
+
+    test('propagates a custom sample rate', () {
+      final wire = const SessionReplayOptions(sampleRate: 0.25).toWire();
+
+      expect(wire.sampleRate, 0.25);
     });
 
     test('propagates a custom frame rate', () {


### PR DESCRIPTION
## Summary
- forward `isEnabled` and `contextFriendlyName` consistently to the native observability SDKs
- expose Session Replay `sampleRate` through the Flutter API and generated Android/iOS bridges
- update native dependencies to Android 0.64.0 and Swift 0.50.0

## Test plan
- [x] `flutter test`
- [x] `flutter analyze`
- [x] `./gradlew :app:compileDebugKotlin`
- [x] `flutter build ios --no-codesign`

Made with [Cursor](https://cursor.com)