### PR TITLE
fix: carry render scale into Flutter iOS replay frames

### DIFF
--- a/sdk/@launchdarkly/flutter/packages/observability/ios/launchdarkly_flutter_observability/Sources/launchdarkly_flutter_observability/FlutterImageCaptureService.swift
+++ b/sdk/@launchdarkly/flutter/packages/observability/ios/launchdarkly_flutter_observability/Sources/launchdarkly_flutter_observability/FlutterImageCaptureService.swift
@@ -69,7 +69,12 @@ final class FlutterImageCaptureService: ImageCaptureServicing {
             let data = payload["bytes"] as? FlutterStandardTypedData,
             let width = (payload["width"] as? NSNumber)?.intValue,
             let height = (payload["height"] as? NSNumber)?.intValue,
-            let image = Self.image(fromRGBA: data.data, width: width, height: height)
+            let image = Self.image(
+                fromRGBA: data.data,
+                width: width,
+                height: height,
+                scale: scale > 0 ? CGFloat(scale) : 1.0
+            )
         else {
             return nil
         }
@@ -88,9 +93,17 @@ final class FlutterImageCaptureService: ImageCaptureServicing {
     }
 
     /// Wraps Flutter's raw RGBA bytes (8 bits/channel, premultiplied alpha,
-    /// row-major) into a `UIImage` at scale 1, matching the device-pixel
-    /// resolution the Dart side rendered at. Avoids decoding a PNG on the wire.
-    private static func image(fromRGBA data: Data, width: Int, height: Int) -> UIImage? {
+    /// row-major) into a `UIImage`. Avoids decoding a PNG on the wire.
+    ///
+    /// The bytes are `scale`x pixels (Dart rasterized the boundary at that
+    /// pixel ratio), so the `UIImage` must carry the same `scale` to keep
+    /// `size` in points. `TileDiffManager` treats `RawFrame.image.size` as
+    /// points — it becomes the replay viewport and it divides pixel crop rects
+    /// by `scale` to place incremental tiles inside it. A scale-1 image here
+    /// would report a viewport `scale`x too large while partial-frame tiles
+    /// stayed in point space, so anything captured as a diff (a dialog, sheet
+    /// or popup appearing) would land at 1/scale of its real size and position.
+    private static func image(fromRGBA data: Data, width: Int, height: Int, scale: CGFloat) -> UIImage? {
         guard width > 0, height > 0 else { return nil }
 
         let bytesPerRow = width * 4
@@ -115,6 +128,6 @@ final class FlutterImageCaptureService: ImageCaptureServicing {
             return nil
         }
 
-        return UIImage(cgImage: cgImage, scale: 1.0, orientation: .up)
+        return UIImage(cgImage: cgImage, scale: scale, orientation: .up)
     }
 }


### PR DESCRIPTION
Dart rasterizes the capture boundary at the configured pixel ratio, but the bridge wrapped those bytes in a UIImage at scale 1, so image.size reported pixels instead of points. TileDiffManager treats RawFrame.image.size as the point-space replay viewport while dividing pixel crop rects by scale, so at scale != 1 the viewport was scale-x too large and incremental tiles (dialogs, sheets, popups appearing mid-session) landed at 1/scale of their real size and position. Build the UIImage with the same scale to keep both in points.

## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Fixes **Flutter iOS session replay** when capture runs at a pixel ratio other than 1x.
> 
> Dart sends RGBA at the configured **scale**, but the bridge built `UIImage` at **scale 1**, so `image.size` was in pixels while `TileDiffManager` expects **points** for the replay viewport and scales diff tiles accordingly. On 2x/3x devices, incremental captures (dialogs, sheets, popups) appeared at the wrong size and position.
> 
> `image(fromRGBA:)` now takes **scale** (from the existing service property, with a `> 0` fallback to 1.0) and passes it into `UIImage(cgImage:scale:orientation:)`, aligning viewport and tile placement in point space.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5ddf7f44e1c62b92ea462e1b1c78b8e612bef30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->