### PR TITLE
fix(deps): bump mobile bridges to observability-android 0.65.0 and client SDK 5.14.0

### DIFF
--- a/sdk/@launchdarkly/flutter/packages/observability/android/build.gradle
+++ b/sdk/@launchdarkly/flutter/packages/observability/android/build.gradle
@@ -64,7 +64,7 @@ dependencies {
     // touches LDValue at runtime, so provide the lightweight java-sdk-common
     // (model types only, NOT the feature-flag client). `runtimeOnly` keeps it off
     // this plugin's compile classpath so the plugin stays independent of the
-    // flagging SDK. Version mirrors what launchdarkly-android-client-sdk:5.13.3
+    // flagging SDK. Version mirrors what launchdarkly-android-client-sdk:5.14.0
     // resolves.
     runtimeOnly "com.launchdarkly:launchdarkly-java-sdk-common:2.4.0"
 }

--- a/sdk/@launchdarkly/flutter/packages/observability/android/build.gradle
+++ b/sdk/@launchdarkly/flutter/packages/observability/android/build.gradle
@@ -54,7 +54,7 @@ dependencies {
     // Native dependencies mirrored from the LaunchDarkly mobile SDKs (the same
     // stack used by sdk/@launchdarkly/react-native-ld-session-replay and the
     // .NET MAUI bridge in sdk/@launchdarkly/mobile-dotnet).
-    implementation "com.launchdarkly:launchdarkly-observability-android:0.64.0"
+    implementation "com.launchdarkly:launchdarkly-observability-android:0.65.0"
     // OTel Attributes appears in ObservabilityOptions parameter types; provided
     // at runtime transitively through launchdarkly-observability-android.
     implementation "io.opentelemetry:opentelemetry-api:1.62.0"
@@ -64,7 +64,7 @@ dependencies {
     // touches LDValue at runtime, so provide the lightweight java-sdk-common
     // (model types only, NOT the feature-flag client). `runtimeOnly` keeps it off
     // this plugin's compile classpath so the plugin stays independent of the
-    // flagging SDK. Version mirrors what launchdarkly-android-client-sdk:5.12.2
+    // flagging SDK. Version mirrors what launchdarkly-android-client-sdk:5.13.3
     // resolves.
     runtimeOnly "com.launchdarkly:launchdarkly-java-sdk-common:2.4.0"
 }

--- a/sdk/@launchdarkly/observability-android/lib/build.gradle.kts
+++ b/sdk/@launchdarkly/observability-android/lib/build.gradle.kts
@@ -56,10 +56,10 @@ configurations.all {
 
 dependencies {
     if (isClientSdkProvidedByHost) {
-        compileOnly("com.launchdarkly:launchdarkly-android-client-sdk:5.13.1")
-        testImplementation("com.launchdarkly:launchdarkly-android-client-sdk:5.13.1")
+        compileOnly("com.launchdarkly:launchdarkly-android-client-sdk:5.13.3")
+        testImplementation("com.launchdarkly:launchdarkly-android-client-sdk:5.13.3")
     } else {
-        implementation("com.launchdarkly:launchdarkly-android-client-sdk:5.13.1")
+        implementation("com.launchdarkly:launchdarkly-android-client-sdk:5.13.3")
     }
 
     // AndroidX

--- a/sdk/@launchdarkly/observability-android/lib/build.gradle.kts
+++ b/sdk/@launchdarkly/observability-android/lib/build.gradle.kts
@@ -56,10 +56,10 @@ configurations.all {
 
 dependencies {
     if (isClientSdkProvidedByHost) {
-        compileOnly("com.launchdarkly:launchdarkly-android-client-sdk:5.13.3")
-        testImplementation("com.launchdarkly:launchdarkly-android-client-sdk:5.13.3")
+        compileOnly("com.launchdarkly:launchdarkly-android-client-sdk:5.14.0")
+        testImplementation("com.launchdarkly:launchdarkly-android-client-sdk:5.14.0")
     } else {
-        implementation("com.launchdarkly:launchdarkly-android-client-sdk:5.13.3")
+        implementation("com.launchdarkly:launchdarkly-android-client-sdk:5.14.0")
     }
 
     // AndroidX

--- a/sdk/@launchdarkly/react-native-ld-session-replay/android/build.gradle
+++ b/sdk/@launchdarkly/react-native-ld-session-replay/android/build.gradle
@@ -94,8 +94,8 @@ def kotlin_version = getExtOrDefault("kotlinVersion")
 dependencies {
   implementation "com.facebook.react:react-android"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  implementation "com.launchdarkly:launchdarkly-observability-android:0.61.1"
-  implementation "com.launchdarkly:launchdarkly-android-client-sdk:5.13.1"
+  implementation "com.launchdarkly:launchdarkly-observability-android:0.65.0"
+  implementation "com.launchdarkly:launchdarkly-android-client-sdk:5.13.3"
   // compileOnly: OTel Attributes appears in ObservabilityOptions parameter types; provided at
   // runtime transitively through launchdarkly-observability-android.
   compileOnly "io.opentelemetry:opentelemetry-api:1.51.0"

--- a/sdk/@launchdarkly/react-native-ld-session-replay/android/build.gradle
+++ b/sdk/@launchdarkly/react-native-ld-session-replay/android/build.gradle
@@ -95,7 +95,7 @@ dependencies {
   implementation "com.facebook.react:react-android"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   implementation "com.launchdarkly:launchdarkly-observability-android:0.65.0"
-  implementation "com.launchdarkly:launchdarkly-android-client-sdk:5.13.3"
+  implementation "com.launchdarkly:launchdarkly-android-client-sdk:5.14.0"
   // compileOnly: OTel Attributes appears in ObservabilityOptions parameter types; provided at
   // runtime transitively through launchdarkly-observability-android.
   compileOnly "io.opentelemetry:opentelemetry-api:1.51.0"

--- a/sdk/@launchdarkly/react-native-ld-session-replay/android/src/main/java/com/sessionreplayreactnative/SessionReplayClientAdapter.kt
+++ b/sdk/@launchdarkly/react-native-ld-session-replay/android/src/main/java/com/sessionreplayreactnative/SessionReplayClientAdapter.kt
@@ -299,7 +299,7 @@ internal class SessionReplayClientAdapter private constructor() {
             enabled = isEnabled,
             sampleRate = sampleRate,
             frameRate = frameRate,
-            scale = replayScale.toFloat(),
+            scale = replayScale,
             privacyProfile = PrivacyProfile(
                 maskTextInputs = maskTextInputs,
                 maskWebViews = maskWebViews,

--- a/sdk/@launchdarkly/react-native-ld-session-replay/android/src/test/java/com/sessionreplayreactnative/SessionReplayClientAdapterTest.kt
+++ b/sdk/@launchdarkly/react-native-ld-session-replay/android/src/test/java/com/sessionreplayreactnative/SessionReplayClientAdapterTest.kt
@@ -27,7 +27,7 @@ class SessionReplayClientAdapterTest {
 
         assertTrue(options.enabled)
         assertEquals(1.0, options.frameRate)
-        assertEquals(1.0f, options.scale)
+        assertEquals(1.0, options.scale)
         assertEquals(1.0, options.sampleRate)
         assertTrue(options.privacyProfile.maskTextInputs)
         assertFalse(options.privacyProfile.maskWebViews)
@@ -82,7 +82,7 @@ class SessionReplayClientAdapterTest {
         val options = adapter.replayOptionsFrom(map)
 
         assertEquals(2.0, options.frameRate)
-        assertEquals(2.5f, options.scale)
+        assertEquals(2.5, options.scale)
         assertEquals(0.05f, options.privacyProfile.minimumAlpha)
         assertEquals(0.25, options.sampleRate)
     }
@@ -107,7 +107,7 @@ class SessionReplayClientAdapterTest {
 
         val options = adapter.replayOptionsFrom(map)
 
-        assertEquals(1.0f, options.scale)
+        assertEquals(1.0, options.scale)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Bump the Flutter and React Native native bridges to \`com.launchdarkly:launchdarkly-observability-android:0.65.0\` (latest on Maven Central).
- Bump \`observability-android\` and the React Native bridge to \`com.launchdarkly:launchdarkly-android-client-sdk:5.14.0\` (latest on Maven Central).
- 0.65.0 widened \`ReplayOptions.scale\` from \`Float\` to a nullable \`Double\`, so the React Native bridge stops narrowing the JS-provided scale to \`Float\` and its unit tests assert \`Double\` values. The Flutter bridge already passed a \`Double\`.

## Test plan

- [x] \`./gradlew test\` in \`sdk/@launchdarkly/observability-android\`
- [x] RN bridge compile/unit tests previously green on 0.65.0 + 5.13.3; local RN re-check blocked by an unrelated Gradle 9 / foojay \`IBM_SEMERU\` toolchain error
- [ ] CI: Android observability, Android e2e, Flutter, and React Native session replay workflows

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> **Dependency alignment** across Flutter observability, `observability-android`, and the React Native session replay bridge: `launchdarkly-observability-android` **0.65.0** and `launchdarkly-android-client-sdk` **5.14.0** (with Flutter’s `java-sdk-common` comment updated to match 5.14.0).
> 
> **React Native bridge fix for 0.65.0:** observability **0.65.0** changed `ReplayOptions.scale` from `Float` to nullable `Double`. The adapter now passes the JS `scale` as `Double` without `.toFloat()`, and unit tests assert `Double` expectations instead of `Float`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 267450e35cec4c4b53d673a35f0a156833c7d2bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->