### PR TITLE
fix(go): Honor unsampled parent in span-kind sampler

### DIFF
--- a/go/trace_sampler.go
+++ b/go/trace_sampler.go
@@ -22,6 +22,17 @@ func (ts traceSampler) ShouldSample(p sdktrace.SamplingParameters) sdktrace.Samp
 			Tracestate: psc.TraceState(),
 		}
 	}
+	// A valid unsampled parent already decided this trace. Do not let the
+	// child's SpanKind re-roll — that would sample-in Producer children of
+	// dropped Internal/Consumer work (e.g. kafka.submit under GraphQL).
+	// Kind rates apply only to roots (no parent), which is how customer
+	// replay spans and explicit sample-in hacks start.
+	if psc.IsValid() {
+		return sdktrace.SamplingResult{
+			Decision:   sdktrace.Drop,
+			Tracestate: psc.TraceState(),
+		}
+	}
 	bound, ok := ts.traceIDUpperBounds[p.Kind]
 	if !ok {
 		bound, ok = ts.traceIDUpperBounds[trace.SpanKindUnspecified]

--- a/go/trace_sampler_test.go
+++ b/go/trace_sampler_test.go
@@ -46,39 +46,32 @@ func TestTraceSampler_ShouldSample_WithSampledParent(t *testing.T) {
 }
 
 func TestTraceSampler_ShouldSample_WithUnsampledParent(t *testing.T) {
-	// Create a sampler with specific rates
 	rates := map[trace.SpanKind]float64{
-		trace.SpanKindServer: 0.5,
+		trace.SpanKindServer:   0.5,
+		trace.SpanKindProducer: 1.0,
 	}
 	sampler := getSampler(rates)
 
-	// Create a parent context without sampled trace
-	parentTraceID := trace.TraceID{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
-	parentSpanID := trace.SpanID{1, 2, 3, 4, 5, 6, 7, 8}
 	parentContext := trace.NewSpanContext(trace.SpanContextConfig{
-		TraceID:    parentTraceID,
-		SpanID:     parentSpanID,
-		TraceFlags: 0, // Not sampled
+		TraceID:    trace.TraceID{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
+		SpanID:     trace.SpanID{1, 2, 3, 4, 5, 6, 7, 8},
+		TraceFlags: 0,
 	})
 	ctx := trace.ContextWithSpanContext(context.Background(), parentContext)
 
-	// Test with trace ID that should be sampled (lower than threshold)
-	// For 0.5 rate, threshold is 0.5 * (1 << 63) = 0x4000000000000000
-	// We'll use a trace ID with upper 8 bytes that when shifted right by 1 gives a value < threshold
-	traceID := trace.TraceID{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x20} // Small value
+	// Trace ID would sample at any positive rate, and Producer is 100%.
+	traceID := trace.TraceID{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x20}
 
-	params := sdktrace.SamplingParameters{
-		ParentContext: ctx,
-		TraceID:       traceID,
-		Name:          "test-span",
-		Kind:          trace.SpanKindServer,
-	}
-
-	result := sampler.ShouldSample(params)
-
-	// Should sample based on trace ID ratio
-	if result.Decision != sdktrace.RecordAndSample {
-		t.Errorf("Expected decision %v, got %v", sdktrace.RecordAndSample, result.Decision)
+	for _, kind := range []trace.SpanKind{trace.SpanKindServer, trace.SpanKindProducer} {
+		result := sampler.ShouldSample(sdktrace.SamplingParameters{
+			ParentContext: ctx,
+			TraceID:       traceID,
+			Name:          "test-span",
+			Kind:          kind,
+		})
+		if result.Decision != sdktrace.Drop {
+			t.Errorf("kind %v: expected Drop when parent is unsampled, got %v", kind, result.Decision)
+		}
 	}
 }
 
@@ -88,16 +81,6 @@ func TestTraceSampler_ShouldSample_WithUnsampledParent_AboveThreshold(t *testing
 		trace.SpanKindServer: 0.5,
 	}
 	sampler := getSampler(rates)
-
-	// Create a parent context without sampled trace
-	parentTraceID := trace.TraceID{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
-	parentSpanID := trace.SpanID{1, 2, 3, 4, 5, 6, 7, 8}
-	parentContext := trace.NewSpanContext(trace.SpanContextConfig{
-		TraceID:    parentTraceID,
-		SpanID:     parentSpanID,
-		TraceFlags: 0, // Not sampled
-	})
-	ctx := trace.ContextWithSpanContext(context.Background(), parentContext)
 
 	// Test with trace ID that should NOT be sampled (above threshold)
 	// For 0.5 rate, threshold is 0.5 * (1 << 63) = 0x4000000000000000
@@ -113,7 +96,7 @@ func TestTraceSampler_ShouldSample_WithUnsampledParent_AboveThreshold(t *testing
 	copy(traceID[:], traceIDBytes)
 
 	params := sdktrace.SamplingParameters{
-		ParentContext: ctx,
+		ParentContext: context.Background(),
 		TraceID:       traceID,
 		Name:          "test-span",
 		Kind:          trace.SpanKindServer,
@@ -157,19 +140,9 @@ func TestTraceSampler_ShouldSample_WithUnsampledParent_UnspecifiedKind(t *testin
 	}
 	sampler := getSampler(rates)
 
-	// Create a parent context without sampled trace
-	parentTraceID := trace.TraceID{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
-	parentSpanID := trace.SpanID{1, 2, 3, 4, 5, 6, 7, 8}
-	parentContext := trace.NewSpanContext(trace.SpanContextConfig{
-		TraceID:    parentTraceID,
-		SpanID:     parentSpanID,
-		TraceFlags: 0, // Not sampled
-	})
-	ctx := trace.ContextWithSpanContext(context.Background(), parentContext)
-
 	// Test with Unspecified kind
 	params := sdktrace.SamplingParameters{
-		ParentContext: ctx,
+		ParentContext: context.Background(),
 		TraceID:       trace.TraceID{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
 		Name:          "test-span",
 		Kind:          trace.SpanKindUnspecified,
@@ -191,19 +164,9 @@ func TestTraceSampler_ShouldSample_WithUnsampledParent_UnspecifiedKindWithDefaul
 	}
 	sampler := getSampler(rates)
 
-	// Create a parent context without sampled trace
-	parentTraceID := trace.TraceID{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
-	parentSpanID := trace.SpanID{1, 2, 3, 4, 5, 6, 7, 8}
-	parentContext := trace.NewSpanContext(trace.SpanContextConfig{
-		TraceID:    parentTraceID,
-		SpanID:     parentSpanID,
-		TraceFlags: 0, // Not sampled
-	})
-	ctx := trace.ContextWithSpanContext(context.Background(), parentContext)
-
 	// Test with Unspecified kind
 	params := sdktrace.SamplingParameters{
-		ParentContext: ctx,
+		ParentContext: context.Background(),
 		TraceID:       trace.TraceID{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
 		Name:          "test-span",
 		Kind:          trace.SpanKindUnspecified,
@@ -224,19 +187,9 @@ func TestTraceSampler_ShouldSample_WithUnsampledParent_UnknownKind(t *testing.T)
 	}
 	sampler := getSampler(rates)
 
-	// Create a parent context without sampled trace
-	parentTraceID := trace.TraceID{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
-	parentSpanID := trace.SpanID{1, 2, 3, 4, 5, 6, 7, 8}
-	parentContext := trace.NewSpanContext(trace.SpanContextConfig{
-		TraceID:    parentTraceID,
-		SpanID:     parentSpanID,
-		TraceFlags: 0, // Not sampled
-	})
-	ctx := trace.ContextWithSpanContext(context.Background(), parentContext)
-
 	// Test with Client kind (not in rates)
 	params := sdktrace.SamplingParameters{
-		ParentContext: ctx,
+		ParentContext: context.Background(),
 		TraceID:       trace.TraceID{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
 		Name:          "test-span",
 		Kind:          trace.SpanKindClient,
@@ -258,19 +211,9 @@ func TestTraceSampler_ShouldSample_WithUnsampledParent_UnknownKindWithUnspecifie
 	}
 	sampler := getSampler(rates)
 
-	// Create a parent context without sampled trace
-	parentTraceID := trace.TraceID{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
-	parentSpanID := trace.SpanID{1, 2, 3, 4, 5, 6, 7, 8}
-	parentContext := trace.NewSpanContext(trace.SpanContextConfig{
-		TraceID:    parentTraceID,
-		SpanID:     parentSpanID,
-		TraceFlags: 0, // Not sampled
-	})
-	ctx := trace.ContextWithSpanContext(context.Background(), parentContext)
-
 	// Test with Client kind (not in rates, but should fall back to Unspecified rate)
 	params := sdktrace.SamplingParameters{
-		ParentContext: ctx,
+		ParentContext: context.Background(),
 		TraceID:       trace.TraceID{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
 		Name:          "test-span",
 		Kind:          trace.SpanKindClient,
@@ -292,16 +235,6 @@ func TestTraceSampler_ShouldSample_WithUnsampledParent_UnknownKindWithUnspecifie
 	}
 	sampler := getSampler(rates)
 
-	// Create a parent context without sampled trace
-	parentTraceID := trace.TraceID{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
-	parentSpanID := trace.SpanID{1, 2, 3, 4, 5, 6, 7, 8}
-	parentContext := trace.NewSpanContext(trace.SpanContextConfig{
-		TraceID:    parentTraceID,
-		SpanID:     parentSpanID,
-		TraceFlags: 0, // Not sampled
-	})
-	ctx := trace.ContextWithSpanContext(context.Background(), parentContext)
-
 	// Test with Client kind (not in rates, but should fall back to Unspecified rate)
 	// For 0.25 rate, threshold is 0.25 * (1 << 63) = 0x2000000000000000
 	// We need (x >> 1) >= threshold, so x >= threshold * 2
@@ -315,7 +248,7 @@ func TestTraceSampler_ShouldSample_WithUnsampledParent_UnknownKindWithUnspecifie
 	copy(traceID[:], traceIDBytes)
 
 	params := sdktrace.SamplingParameters{
-		ParentContext: ctx,
+		ParentContext: context.Background(),
 		TraceID:       traceID,
 		Name:          "test-span",
 		Kind:          trace.SpanKindClient,
@@ -405,18 +338,8 @@ func TestTraceSampler_ShouldSample_EdgeCase_ZeroRate(t *testing.T) {
 	}
 	sampler := getSampler(rates)
 
-	// Create a parent context without sampled trace
-	parentTraceID := trace.TraceID{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
-	parentSpanID := trace.SpanID{1, 2, 3, 4, 5, 6, 7, 8}
-	parentContext := trace.NewSpanContext(trace.SpanContextConfig{
-		TraceID:    parentTraceID,
-		SpanID:     parentSpanID,
-		TraceFlags: 0, // Not sampled
-	})
-	ctx := trace.ContextWithSpanContext(context.Background(), parentContext)
-
 	params := sdktrace.SamplingParameters{
-		ParentContext: ctx,
+		ParentContext: context.Background(),
 		TraceID:       trace.TraceID{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
 		Name:          "test-span",
 		Kind:          trace.SpanKindServer,
@@ -437,18 +360,8 @@ func TestTraceSampler_ShouldSample_EdgeCase_OneRate(t *testing.T) {
 	}
 	sampler := getSampler(rates)
 
-	// Create a parent context without sampled trace
-	parentTraceID := trace.TraceID{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
-	parentSpanID := trace.SpanID{1, 2, 3, 4, 5, 6, 7, 8}
-	parentContext := trace.NewSpanContext(trace.SpanContextConfig{
-		TraceID:    parentTraceID,
-		SpanID:     parentSpanID,
-		TraceFlags: 0, // Not sampled
-	})
-	ctx := trace.ContextWithSpanContext(context.Background(), parentContext)
-
 	params := sdktrace.SamplingParameters{
-		ParentContext: ctx,
+		ParentContext: context.Background(),
 		TraceID:       trace.TraceID{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
 		Name:          "test-span",
 		Kind:          trace.SpanKindServer,
@@ -469,16 +382,6 @@ func TestTraceSampler_ShouldSample_TraceIDCalculation(t *testing.T) {
 	}
 	sampler := getSampler(rates)
 
-	// Create a parent context without sampled trace
-	parentTraceID := trace.TraceID{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
-	parentSpanID := trace.SpanID{1, 2, 3, 4, 5, 6, 7, 8}
-	parentContext := trace.NewSpanContext(trace.SpanContextConfig{
-		TraceID:    parentTraceID,
-		SpanID:     parentSpanID,
-		TraceFlags: 0, // Not sampled
-	})
-	ctx := trace.ContextWithSpanContext(context.Background(), parentContext)
-
 	// Test the exact calculation from the code
 	// The code does: binary.BigEndian.Uint64(p.TraceID[8:16]) >> 1
 	// For 0.5 rate, threshold is 0.5 * (1 << 63) = 0x4000000000000000
@@ -496,7 +399,7 @@ func TestTraceSampler_ShouldSample_TraceIDCalculation(t *testing.T) {
 	copy(traceID[:], traceIDBytes)
 
 	params := sdktrace.SamplingParameters{
-		ParentContext: ctx,
+		ParentContext: context.Background(),
 		TraceID:       traceID,
 		Name:          "test-span",
 		Kind:          trace.SpanKindServer,
@@ -518,16 +421,6 @@ func TestTraceSampler_ShouldSample_TraceIDCalculation_JustBelowThreshold(t *test
 	}
 	sampler := getSampler(rates)
 
-	// Create a parent context without sampled trace
-	parentTraceID := trace.TraceID{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
-	parentSpanID := trace.SpanID{1, 2, 3, 4, 5, 6, 7, 8}
-	parentContext := trace.NewSpanContext(trace.SpanContextConfig{
-		TraceID:    parentTraceID,
-		SpanID:     parentSpanID,
-		TraceFlags: 0, // Not sampled
-	})
-	ctx := trace.ContextWithSpanContext(context.Background(), parentContext)
-
 	// Test with a value just below the threshold
 	threshold := uint64(0.5 * (1 << 63))
 	// We need (x >> 1) < threshold, so x < threshold * 2
@@ -540,7 +433,7 @@ func TestTraceSampler_ShouldSample_TraceIDCalculation_JustBelowThreshold(t *test
 	copy(traceID[:], traceIDBytes)
 
 	params := sdktrace.SamplingParameters{
-		ParentContext: ctx,
+		ParentContext: context.Background(),
 		TraceID:       traceID,
 		Name:          "test-span",
 		Kind:          trace.SpanKindServer,
@@ -561,16 +454,6 @@ func TestTraceSampler_ShouldSample_TraceIDCalculation_JustAboveThreshold(t *test
 	}
 	sampler := getSampler(rates)
 
-	// Create a parent context without sampled trace
-	parentTraceID := trace.TraceID{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
-	parentSpanID := trace.SpanID{1, 2, 3, 4, 5, 6, 7, 8}
-	parentContext := trace.NewSpanContext(trace.SpanContextConfig{
-		TraceID:    parentTraceID,
-		SpanID:     parentSpanID,
-		TraceFlags: 0, // Not sampled
-	})
-	ctx := trace.ContextWithSpanContext(context.Background(), parentContext)
-
 	// Test with a value just above the threshold
 	threshold := uint64(0.5 * (1 << 63))
 	// We need (x >> 1) >= threshold, so x >= threshold * 2
@@ -583,7 +466,7 @@ func TestTraceSampler_ShouldSample_TraceIDCalculation_JustAboveThreshold(t *test
 	copy(traceID[:], traceIDBytes)
 
 	params := sdktrace.SamplingParameters{
-		ParentContext: ctx,
+		ParentContext: context.Background(),
 		TraceID:       traceID,
 		Name:          "test-span",
 		Kind:          trace.SpanKindServer,


### PR DESCRIPTION
## Summary

The Go plugin's span-kind sampler treated an unsampled parent as "no parent" and re-rolled using the child's `SpanKind`. A `SpanKindProducer` child of dropped Internal/Consumer work was therefore sampled at 100% and could pull the rest of the trace in via context propagation.

Kind-based rates now apply only to **root** spans. If a valid parent exists and was not sampled, the child is dropped. Sampled parents still force-sample children. Root Producer spans (customer session replay, explicit sample-in) are unchanged.

Needed so [observability#1751](https://github.com/launchdarkly/observability/pull/1751) can set `kafka.submit` to `SpanKindProducer` without a self-telemetry volume spike.

## How did you test this change?

- [x] `go test .` in `go/` — unsampled parent is dropped even at Producer 100%; sampled parent still keeps children; root ratio tests unchanged

## Are there any deployment considerations?

Backend dogfood must pick up this SDK revision before deploying Producer Kafka produce spans. Customer-facing SDK sampling for roots is unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> The Go **span-kind trace sampler** now **drops** child spans when the parent span context is **valid but not sampled**, instead of applying per-kind trace-ID ratio sampling on the child. That prevents high-rate kinds (e.g. **Producer at 100%**) from sampling in children under dropped parent work and pulling the rest of a trace via context propagation.
> 
> **Span-kind sampling rates apply only to root spans** (no valid parent). Sampled parents still force children to **RecordAndSample**. Tests were updated so unsampled-parent cases expect **Drop** (including Producer), and ratio/threshold tests use **root** parent context.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92ec74188169130dc3179d48628b5d4a93180b28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->