### PR TITLE
feat(android): deduplicate flag evaluation telemetry with SDK DedupingHook

### DIFF
--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/plugin/Observability.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/plugin/Observability.kt
@@ -12,6 +12,7 @@ import com.launchdarkly.observability.client.buildObservabilityResource
 import com.launchdarkly.observability.client.readInjectedSymbolsId
 import com.launchdarkly.observability.sdk.LDObserve
 import com.launchdarkly.sdk.android.LDClient
+import com.launchdarkly.sdk.android.integrations.DedupingHook
 import com.launchdarkly.sdk.android.integrations.EnvironmentMetadata
 import com.launchdarkly.sdk.android.integrations.Hook
 import com.launchdarkly.sdk.android.integrations.Plugin
@@ -91,7 +92,9 @@ class Observability(
     }
 
     override fun getHooks(metadata: EnvironmentMetadata?): MutableList<Hook> {
-        return Collections.singletonList(observabilityHook)
+        // Deduplicate repeated identical evaluations (default 10-minute window).
+        // Resets after identify or when the evaluation result changes.
+        return Collections.singletonList(DedupingHook(observabilityHook))
     }
 
     override fun onPluginsReady(result: RegistrationCompleteResult?, metadata: EnvironmentMetadata?) {

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/plugin/SessionReplay.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/plugin/SessionReplay.kt
@@ -52,6 +52,10 @@ class SessionReplay(
         sessionReplayHook.delegate = impl.sessionReplayService
     }
 
+    // Note: this hook is intentionally not wrapped in DedupingHook. Deduplication only
+    // suppresses evaluation stages, and [SessionReplayHook] implements identify only, which
+    // DedupingHook always forwards. Evaluation spans come from ObservabilityHook, which is
+    // wrapped there instead.
     override fun getHooks(metadata: EnvironmentMetadata?): MutableList<Hook> {
         return Collections.singletonList(sessionReplayHook)
     }

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/plugin/SessionReplay.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/plugin/SessionReplay.kt
@@ -4,7 +4,6 @@ import com.launchdarkly.observability.BuildConfig
 import com.launchdarkly.observability.replay.ReplayOptions
 import com.launchdarkly.observability.sdk.LDObserve
 import com.launchdarkly.sdk.android.LDClient
-import com.launchdarkly.sdk.android.integrations.DedupingHook
 import com.launchdarkly.sdk.android.integrations.EnvironmentMetadata
 import com.launchdarkly.sdk.android.integrations.Hook
 import com.launchdarkly.sdk.android.integrations.Plugin
@@ -54,9 +53,7 @@ class SessionReplay(
     }
 
     override fun getHooks(metadata: EnvironmentMetadata?): MutableList<Hook> {
-        // Deduplicate repeated identical evaluations (default 10-minute window).
-        // Resets after identify or when the evaluation result changes.
-        return Collections.singletonList(DedupingHook(sessionReplayHook))
+        return Collections.singletonList(sessionReplayHook)
     }
 
     override fun onPluginsReady(result: RegistrationCompleteResult?, metadata: EnvironmentMetadata?) {

--- a/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/plugin/SessionReplay.kt
+++ b/sdk/@launchdarkly/observability-android/lib/src/main/kotlin/com/launchdarkly/observability/replay/plugin/SessionReplay.kt
@@ -4,6 +4,7 @@ import com.launchdarkly.observability.BuildConfig
 import com.launchdarkly.observability.replay.ReplayOptions
 import com.launchdarkly.observability.sdk.LDObserve
 import com.launchdarkly.sdk.android.LDClient
+import com.launchdarkly.sdk.android.integrations.DedupingHook
 import com.launchdarkly.sdk.android.integrations.EnvironmentMetadata
 import com.launchdarkly.sdk.android.integrations.Hook
 import com.launchdarkly.sdk.android.integrations.Plugin
@@ -53,7 +54,9 @@ class SessionReplay(
     }
 
     override fun getHooks(metadata: EnvironmentMetadata?): MutableList<Hook> {
-        return Collections.singletonList(sessionReplayHook)
+        // Deduplicate repeated identical evaluations (default 10-minute window).
+        // Resets after identify or when the evaluation result changes.
+        return Collections.singletonList(DedupingHook(sessionReplayHook))
     }
 
     override fun onPluginsReady(result: RegistrationCompleteResult?, metadata: EnvironmentMetadata?) {


### PR DESCRIPTION
## Summary

- Wrap `ObservabilityHook` and `SessionReplayHook` in the Android client SDK's `DedupingHook`, so identical flag evaluations produce telemetry once per window (default 10 minutes) instead of on every per-key `variation` call.
- Deduplication resets after `identify` and as soon as the evaluation result changes.

`DedupingHook` was introduced in `launchdarkly-android-client-sdk` 5.14.0, which the library already depends on, so no dependency bump is needed here.

This does not change LaunchDarkly's own evaluation events or counts — feature, debug, and summary events are still recorded for every evaluation. Only the OTel spans emitted by our hooks are deduplicated.

This is the Android counterpart to launchdarkly/swift-launchdarkly-observability#266.

## Test plan

- [x] `./gradlew :lib:compileDebugKotlin`
- [ ] Verify repeated `boolVariation` calls for the same flag/value emit a single `evaluation` span per window
- [ ] Verify a variation change or `identify` emits a new span
- [ ] Confirm Session Replay flag-evaluation telemetry follows the same behavior

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> **Observability** now returns `DedupingHook(observabilityHook)` instead of the raw hook, so repeated identical flag evaluations emit **one** OTel evaluation span per dedupe window (SDK default ~10 minutes), with the window resetting on `identify` or when the evaluated value changes.
> 
> **Session Replay** keeps `SessionReplayHook` unwrapped; a comment documents that deduplication only affects evaluation stages and that evaluation spans are produced by `ObservabilityHook` on the Observability plugin.
> 
> LaunchDarkly evaluation **events** (feature/debug/summary) are unchanged—only hook-driven OTel spans are deduplicated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fd80f84d50f98657a62e893e5c811aa694a6edd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->