### PR TITLE
fix(highlight.run): recover CSS-in-JS rules when another script unhooks rrweb

### DIFF
--- a/sdk/highlight-run/README.md
+++ b/sdk/highlight-run/README.md
@@ -4,6 +4,11 @@ The official Javascript SDK for [Highlight](https://highlight.run).
 
 Session replay recording is powered by the [launchdarkly/rrweb](https://github.com/launchdarkly/rrweb) fork, currently synced with upstream rrweb v2.0.1.
 
+Recording reconciles CSS-in-JS stylesheets (emotion, styled-components) against
+what it has reported every few seconds, so rules still reach the replay when
+another script on the page displaces rrweb's `CSSStyleSheet.prototype.insertRule`
+patch.
+
 ## Next Steps
 
 -   [Documentation](https://docs.highlight.run)


### PR DESCRIPTION
Bumps the rrweb submodule to [fe8256d5](https://github.com/launchdarkly/rrweb/commit/fe8256d5a7a3dabb542ad2b41fd6fc6058ad3a89) ([launchdarkly/rrweb#38](https://github.com/launchdarkly/rrweb/pull/38)) so recording recovers CSS-in-JS rules when another script on the page displaces rrweb's `CSSStyleSheet.prototype.insertRule` patch. A production session kept 734 of 2929 emotion rules that way and replayed a MUI-heavy UI completely unstyled.

The README touch is what gives release-please a path inside `sdk/highlight-run/` to attribute the release to — same approach as #615. `highlight.run` gets a patch bump, and `@launchdarkly/session-replay` / `@launchdarkly/observability` follow via the node-workspace plugin.

Also picks up launchdarkly/rrweb#36 and #37; both are replay-side and inert for the recorder bundles these packages ship. No dependency changes in the bumped range, so `yarn.lock` is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Bumps the **launchdarkly/rrweb** submodule (via upstream PR #38) so session replay **periodically reconciles CSS-in-JS stylesheets** (emotion, styled-components) against what recording has already reported. That recovers style rules when another on-page script **replaces rrweb’s `CSSStyleSheet.prototype.insertRule` hook**, which previously left MUI-heavy replays largely unstyled.
> 
> The **README** adds a short note describing that behavior and gives **release-please** a file under `sdk/highlight-run/` to attribute a patch release (same pattern as #615). Related rrweb replay-only fixes (#36, #37) ride along but do not change recorder bundles; **no `yarn.lock` changes** in the bumped range.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7492160ec895a2ea678138ccd0de8e8801b7189a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->