### PR TITLE
fix: sanitize page URLs recorded into telemetry

### DIFF
--- a/sdk/highlight-run/src/client/index.tsx
+++ b/sdk/highlight-run/src/client/index.tsx
@@ -57,7 +57,10 @@ import {
 } from './listeners/jank-listener/jank-listener'
 import { HighlightFetchWindow } from './listeners/network-listener/utils/fetch-listener'
 import { RequestResponsePair } from './listeners/network-listener/utils/models'
-import { sanitizeUrl } from './listeners/network-listener/utils/network-sanitizer'
+import {
+	sanitizeUrl,
+	sanitizedLocationHref,
+} from './listeners/network-listener/utils/network-sanitizer'
 import { PageVisibilityListener } from './listeners/page-visibility-listener'
 import {
 	PerformanceListener,
@@ -555,7 +558,7 @@ export class Highlight {
 		const errorMsg: ErrorMessage = {
 			event,
 			type: type ?? 'custom',
-			url: window.location.href,
+			url: sanitizedLocationHref(),
 			source: source ?? '',
 			lineNumber: res[0]?.lineNumber ? res[0]?.lineNumber : 0,
 			columnNumber: res[0]?.columnNumber ? res[0]?.columnNumber : 0,
@@ -818,7 +821,7 @@ SessionSecureID: ${this.sessionData.sessionSecureID}`,
 					name: MetricName.DeviceMemory,
 					value: getDeviceDetails().deviceMemory,
 					category: MetricCategory.Device,
-					group: window.location.href,
+					group: sanitizedLocationHref(),
 				})
 			}
 
@@ -913,11 +916,9 @@ SessionSecureID: ${this.sessionData.sessionSecureID}`,
 						document.referrer.includes(window.location.origin)
 					)
 				) {
-					this.addCustomEvent<string>('Referrer', document.referrer)
-					this.addProperties(
-						{ referrer: document.referrer },
-						{ type: 'session' },
-					)
+					const referrer = sanitizeUrl(document.referrer)
+					this.addCustomEvent<string>('Referrer', referrer)
+					this.addProperties({ referrer }, { type: 'session' })
 				}
 			}
 
@@ -1075,15 +1076,18 @@ SessionSecureID: ${this.sessionData.sessionSecureID}`,
 			}
 			this.listeners.push(
 				PathListener((url: string) => {
+					// PathListener hands back the raw href for change detection;
+					// redact before it lands in a recorded custom event.
+					const sanitized = sanitizeUrl(url)
 					if (this.reloaded) {
-						this.addCustomEvent<string>('Reload', url)
+						this.addCustomEvent<string>('Reload', sanitized)
 						this.reloaded = false
 						highlightThis.addProperties(
 							{ reload: true },
 							{ type: 'session' },
 						)
 					} else {
-						this.addCustomEvent<string>('Navigate', url)
+						this.addCustomEvent<string>('Navigate', sanitized)
 					}
 				}),
 			)
@@ -1171,7 +1175,7 @@ SessionSecureID: ${this.sessionData.sessionSecureID}`,
 					this.recordGauge({
 						name,
 						value,
-						group: window.location.href,
+						group: sanitizedLocationHref(),
 						category: MetricCategory.WebVital,
 						tags: tags.length ? tags : undefined,
 					})
@@ -1206,7 +1210,7 @@ SessionSecureID: ${this.sessionData.sessionSecureID}`,
 									name,
 									value: value as number,
 									category: MetricCategory.Performance,
-									group: window.location.href,
+									group: sanitizedLocationHref(),
 									tags,
 								})
 							}
@@ -1238,7 +1242,7 @@ SessionSecureID: ${this.sessionData.sessionSecureID}`,
 										name,
 										value,
 										category: MetricCategory.Performance,
-										group: window.location.href,
+										group: sanitizedLocationHref(),
 									}),
 							)
 					}, this._recordingStartTime),
@@ -1334,31 +1338,31 @@ SessionSecureID: ${this.sessionData.sessionSecureID}`,
 			name: MetricName.ViewportHeight,
 			value: height,
 			category: MetricCategory.Device,
-			group: window.location.href,
+			group: sanitizedLocationHref(),
 		})
 		this.recordGauge({
 			name: MetricName.ViewportWidth,
 			value: width,
 			category: MetricCategory.Device,
-			group: window.location.href,
+			group: sanitizedLocationHref(),
 		})
 		this.recordGauge({
 			name: MetricName.ScreenHeight,
 			value: availHeight,
 			category: MetricCategory.Device,
-			group: window.location.href,
+			group: sanitizedLocationHref(),
 		})
 		this.recordGauge({
 			name: MetricName.ScreenWidth,
 			value: availWidth,
 			category: MetricCategory.Device,
-			group: window.location.href,
+			group: sanitizedLocationHref(),
 		})
 		this.recordGauge({
 			name: MetricName.ViewportArea,
 			value: height * width,
 			category: MetricCategory.Device,
-			group: window.location.href,
+			group: sanitizedLocationHref(),
 		})
 	}
 

--- a/sdk/highlight-run/src/client/listeners/error-listener.test.ts
+++ b/sdk/highlight-run/src/client/listeners/error-listener.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { ErrorListener } from './error-listener'
+import { ErrorMessage } from '../types/shared-types'
+
+/**
+ * Regression coverage for SEC-7654: the recorded error URL used to be
+ * `window.location.href` verbatim, so any secret sitting in the query string
+ * or fragment (OAuth tokens, magic links, password reset tokens) was uploaded
+ * alongside the error.
+ */
+describe('ErrorListener recorded url', () => {
+	const cleanups: (() => void)[] = []
+
+	const listen = () => {
+		const captured: ErrorMessage[] = []
+		cleanups.push(
+			ErrorListener((e) => captured.push(e), {
+				enablePromisePatch: false,
+			}),
+		)
+		return captured
+	}
+
+	afterEach(() => {
+		while (cleanups.length) cleanups.pop()!()
+		window.history.replaceState({}, '', '/')
+	})
+
+	it('redacts secret query parameters from the error url', () => {
+		window.history.replaceState({}, '', '/victim?access_token=SECRET_QUERY')
+		const captured = listen()
+
+		window.onerror?.('boom', 'app.js', 1, 1, new Error('boom'))
+
+		expect(captured).toHaveLength(1)
+		expect(captured[0].url).not.toContain('SECRET_QUERY')
+		expect(captured[0].url).toContain('access_token=REDACTED')
+	})
+
+	it('strips token-bearing fragments from the error url', () => {
+		window.history.replaceState({}, '', '/victim#id_token=SECRET_HASH')
+		const captured = listen()
+
+		window.onerror?.('boom', 'app.js', 1, 1, new Error('boom'))
+
+		expect(captured).toHaveLength(1)
+		expect(captured[0].url).not.toContain('SECRET_HASH')
+	})
+
+	it('preserves the path and harmless params', () => {
+		window.history.replaceState({}, '', '/dashboard?page=2#section')
+		const captured = listen()
+
+		window.onerror?.('boom', 'app.js', 1, 1, new Error('boom'))
+
+		expect(captured[0].url).toContain('/dashboard')
+		expect(captured[0].url).toContain('page=2')
+		expect(captured[0].url).toContain('#section')
+	})
+})

--- a/sdk/highlight-run/src/client/listeners/error-listener.tsx
+++ b/sdk/highlight-run/src/client/listeners/error-listener.tsx
@@ -2,6 +2,7 @@ import type { StackFrame } from 'error-stack-parser'
 import stringify from 'json-stringify-safe'
 import { ErrorMessage } from '../types/shared-types'
 import { parseError } from '../utils/errors'
+import { sanitizedLocationHref } from './network-listener/utils/network-sanitizer'
 import randomUuidV4 from '../utils/randomUuidV4'
 
 interface HighlightPromise<T> extends Promise<T> {
@@ -29,7 +30,7 @@ function handleError(
 		error: e,
 		event: stringify(event),
 		type: 'window.onerror',
-		url: window.location.href,
+		url: sanitizedLocationHref(),
 		source: source ?? '',
 		lineNumber: framesToUse[0]?.lineNumber ? framesToUse[0]?.lineNumber : 0,
 		columnNumber: framesToUse[0]?.columnNumber

--- a/sdk/highlight-run/src/client/listeners/first-load-listeners.tsx
+++ b/sdk/highlight-run/src/client/listeners/first-load-listeners.tsx
@@ -13,7 +13,10 @@ import {
 	WebSocketEvent,
 	WebSocketRequest,
 } from './network-listener/utils/models'
-import { DEFAULT_URL_BLOCKLIST } from './network-listener/utils/network-sanitizer'
+import {
+	DEFAULT_URL_BLOCKLIST,
+	sanitizedLocationHref,
+} from './network-listener/utils/network-sanitizer'
 import {
 	matchPerformanceTimingsWithRequestResponsePair,
 	shouldNetworkRequestBeRecorded,
@@ -95,7 +98,7 @@ export class FirstLoadListeners {
 							highlightThis.errors.push({
 								event: errorValue,
 								type: 'console.error',
-								url: window.location.href,
+								url: sanitizedLocationHref(),
 								source: c.trace[0]?.fileName
 									? c.trace[0].fileName
 									: '',

--- a/sdk/highlight-run/src/client/listeners/jank-listener/jank-listener.ts
+++ b/sdk/highlight-run/src/client/listeners/jank-listener/jank-listener.ts
@@ -1,4 +1,5 @@
 import { getSimpleSelector } from '../../utils/dom'
+import { sanitizedLocationHref } from '../network-listener/utils/network-sanitizer'
 
 // samples taken to calculate expected RAF
 const RAF_SAMPLES = 30
@@ -70,7 +71,7 @@ export const JankListener = (
 			querySelector: generateQuerySelector(),
 			newLocation:
 				window.location.href != jankState.location
-					? window.location.href
+					? sanitizedLocationHref()
 					: undefined,
 		})
 	}

--- a/sdk/highlight-run/src/client/listeners/network-listener/utils/network-sanitizer.ts
+++ b/sdk/highlight-run/src/client/listeners/network-listener/utils/network-sanitizer.ts
@@ -216,3 +216,17 @@ export const sanitizeUrl = (url: string): string => {
 		return url
 	}
 }
+
+/**
+ * The current page URL, with sensitive query parameters and fragments redacted.
+ *
+ * Use this instead of `window.location.href` anywhere the value is recorded
+ * into telemetry (error URLs, span attributes, metric groups, custom events).
+ * `window.location.href` carries the raw query string and fragment, which
+ * commonly hold OAuth tokens, magic links, and password reset tokens.
+ *
+ * Comparisons and change detection should keep using the raw
+ * `window.location.href` so that redaction never collapses two distinct URLs.
+ */
+export const sanitizedLocationHref = (): string =>
+	sanitizeUrl(globalThis.location?.href ?? '')

--- a/sdk/highlight-run/src/client/otel/instrumentation.test.ts
+++ b/sdk/highlight-run/src/client/otel/instrumentation.test.ts
@@ -1,8 +1,9 @@
-import { describe, it, expect, vi } from 'vitest'
+import { afterEach, describe, it, expect, vi } from 'vitest'
 import {
 	safeParseUrl,
 	sanitizeHeaders,
 	sanitizeUrl,
+	sanitizedLocationHref,
 } from '../listeners/network-listener/utils/network-sanitizer'
 import {
 	enhanceSpanWithHttpRequestAttributes,
@@ -1530,6 +1531,30 @@ describe('Network Instrumentation Custom Attributes', () => {
 					'https://example.com/#/users?page=2&sort=name',
 				)
 			})
+		})
+	})
+
+	describe('sanitizedLocationHref', () => {
+		afterEach(() => {
+			window.history.replaceState({}, '', '/')
+		})
+
+		it('should redact sensitive query params from the current URL', () => {
+			window.history.replaceState({}, '', '/cb?access_token=SECRET')
+			expect(sanitizedLocationHref()).not.toContain('SECRET')
+			expect(sanitizedLocationHref()).toContain('access_token=REDACTED')
+		})
+
+		it('should strip token-bearing fragments from the current URL', () => {
+			window.history.replaceState({}, '', '/cb#id_token=SECRET')
+			expect(sanitizedLocationHref()).not.toContain('SECRET')
+		})
+
+		it('should preserve a harmless current URL', () => {
+			window.history.replaceState({}, '', '/users?page=2#section')
+			const result = sanitizedLocationHref()
+			expect(result).toContain('/users?page=2')
+			expect(result).toContain('#section')
 		})
 	})
 

--- a/sdk/highlight-run/src/client/otel/location-change.ts
+++ b/sdk/highlight-run/src/client/otel/location-change.ts
@@ -6,6 +6,7 @@ import { Attributes } from '@opentelemetry/api'
 import * as SemanticAttributes from '@opentelemetry/semantic-conventions'
 import { LD_PAGE_VIEW_SPAN_NAME } from '../../integrations/launchdarkly'
 import { PathListener } from '../listeners/path-listener'
+import { sanitizeUrl } from '../listeners/network-listener/utils/network-sanitizer'
 
 export type LocationChangeConfig = InstrumentationConfig & {
 	getLDContextKeyAttributes?: () => Attributes | undefined
@@ -45,12 +46,15 @@ export class LocationChangeInstrumentation extends InstrumentationBase {
 			if (previousUrl === currentUrl) {
 				return
 			}
+			// Change detection compares the raw URLs above; only the recorded
+			// values are sanitized.
+			const sanitizedCurrentUrl = sanitizeUrl(currentUrl)
 			try {
 				const span = this.tracer.startSpan(LD_PAGE_VIEW_SPAN_NAME, {
 					attributes: {
-						[SemanticAttributes.ATTR_URL_FULL]: currentUrl,
-						'page_view.previous_url': previousUrl,
-						'page_view.url': currentUrl,
+						[SemanticAttributes.ATTR_URL_FULL]: sanitizedCurrentUrl,
+						'page_view.previous_url': sanitizeUrl(previousUrl),
+						'page_view.url': sanitizedCurrentUrl,
 					},
 				})
 				const contextKeys = this._getLDContextKeyAttributes?.()

--- a/sdk/highlight-run/src/client/otel/user-interaction.ts
+++ b/sdk/highlight-run/src/client/otel/user-interaction.ts
@@ -15,6 +15,10 @@ import { getElementXPath } from '@opentelemetry/sdk-trace-web'
 import { AsyncTask } from '@opentelemetry/instrumentation-user-interaction/build/esnext/internal-types'
 import { ProductAnalyticsEvents } from '../types/observe'
 import * as SemanticAttributes from '@opentelemetry/semantic-conventions'
+import {
+	sanitizeUrl,
+	sanitizedLocationHref,
+} from '../listeners/network-listener/utils/network-sanitizer'
 const ZONE_CONTEXT_KEY = 'OT_ZONE_CONTEXT'
 const EVENT_NAVIGATION_NAME = 'Navigation:'
 
@@ -134,14 +138,14 @@ export class UserInteractionInstrumentation extends InstrumentationBase {
 				{
 					attributes: {
 						[SemanticAttributes.ATTR_URL_FULL]:
-							window.location.href,
+							sanitizedLocationHref(),
 						['event.type']: eventName,
 						['event.tag']: element.tagName,
 						['event.xpath']: xpath,
 						['event.id']: element.id,
 						['event.classname']: element.className,
 						['event.text']: element.textContent ?? '',
-						['event.url']: window.location.href,
+						['event.url']: sanitizedLocationHref(),
 						['viewport.width']: window.innerWidth,
 						['viewport.height']: window.innerHeight,
 					},
@@ -477,7 +481,8 @@ export class UserInteractionInstrumentation extends InstrumentationBase {
 				const result = original.apply(this, args)
 				const urlAfter = `${location.pathname}${location.hash}${location.search}`
 				if (url !== urlAfter) {
-					plugin._updateInteractionName(urlAfter)
+					// Compare the raw URLs, but keep tokens out of the span name.
+					plugin._updateInteractionName(sanitizeUrl(urlAfter))
 				}
 				return result
 			}

--- a/sdk/highlight-run/src/index.tsx
+++ b/sdk/highlight-run/src/index.tsx
@@ -13,6 +13,7 @@
 import type { HighlightClassOptions, RequestResponsePair } from './client'
 import { GenerateSecureID, Highlight } from './client'
 import { FirstLoadListeners } from './client/listeners/first-load-listeners'
+import { sanitizedLocationHref } from './client/listeners/network-listener/utils/network-sanitizer'
 import type {
 	HighlightOptions,
 	HighlightPublicInterface,
@@ -387,7 +388,7 @@ const H: HighlightPublicInterface = {
 				highlight_obj.recordGauge({
 					...metric,
 					tags: metric.tags ?? [],
-					group: window.location.href,
+					group: sanitizedLocationHref(),
 					category: MetricCategory.Frontend,
 				})
 			})

--- a/sdk/highlight-run/src/plugins/observe.ts
+++ b/sdk/highlight-run/src/plugins/observe.ts
@@ -31,6 +31,7 @@ import {
 	ATTR_URL_FULL,
 } from '@opentelemetry/semantic-conventions'
 import { Attributes } from '@opentelemetry/api'
+import { sanitizedLocationHref } from '../client/listeners/network-listener/utils/network-sanitizer'
 import { internalLog } from '../sdk/util'
 import { LDEvaluationReason } from '@launchdarkly/js-sdk-common/dist/cjs/api/data/LDEvaluationReason'
 
@@ -251,7 +252,7 @@ export class Observe extends Plugin<ObserveOptions> implements LDPlugin {
 					}
 
 					const trackAttrs: Attributes = {
-						[ATTR_URL_FULL]: window.location.href,
+						[ATTR_URL_FULL]: sanitizedLocationHref(),
 						...(this.observe?.getLDContextKeyAttributes() ?? {}),
 						...metaAttrs,
 						key: hookContext.key,

--- a/sdk/highlight-run/src/sdk/observe.ts
+++ b/sdk/highlight-run/src/sdk/observe.ts
@@ -83,7 +83,10 @@ import { recordException } from '../client/otel/recordException'
 import { ObserveOptions, ProductAnalyticsEvents } from '../client/types/observe'
 import { isMetricSafeNumber } from '../client/utils/utils'
 import * as SemanticAttributes from '@opentelemetry/semantic-conventions'
-import { sanitizeUrl } from '../client/listeners/network-listener/utils/network-sanitizer'
+import {
+	sanitizeUrl,
+	sanitizedLocationHref,
+} from '../client/listeners/network-listener/utils/network-sanitizer'
 
 export class ObserveSDK implements Observe {
 	/** Verbose project ID that is exposed to users. Legacy users may still be using ints. */
@@ -271,7 +274,7 @@ export class ObserveSDK implements Observe {
 						error: err,
 						event: err.message,
 						type: 'custom',
-						url: window.location.href,
+						url: sanitizedLocationHref(),
 						source: 'frontend',
 						lineNumber: trace[0]?.lineNumber ?? 0,
 						columnNumber: trace[0]?.columnNumber ?? 0,
@@ -348,7 +351,7 @@ export class ObserveSDK implements Observe {
 			error,
 			event,
 			type: type ?? 'custom',
-			url: window.location.href,
+			url: sanitizedLocationHref(),
 			source: source ?? 'frontend',
 			lineNumber: res[0]?.lineNumber ? res[0]?.lineNumber : 0,
 			columnNumber: res[0]?.columnNumber ? res[0]?.columnNumber : 0,
@@ -561,7 +564,7 @@ export class ObserveSDK implements Observe {
 			value: height,
 			attributes: {
 				category: MetricCategory.Device,
-				group: window.location.href,
+				group: sanitizedLocationHref(),
 			},
 		})
 		this.recordGauge({
@@ -569,7 +572,7 @@ export class ObserveSDK implements Observe {
 			value: width,
 			attributes: {
 				category: MetricCategory.Device,
-				group: window.location.href,
+				group: sanitizedLocationHref(),
 			},
 		})
 		this.recordGauge({
@@ -577,7 +580,7 @@ export class ObserveSDK implements Observe {
 			value: availHeight,
 			attributes: {
 				category: MetricCategory.Device,
-				group: window.location.href,
+				group: sanitizedLocationHref(),
 			},
 		})
 		this.recordGauge({
@@ -585,7 +588,7 @@ export class ObserveSDK implements Observe {
 			value: availWidth,
 			attributes: {
 				category: MetricCategory.Device,
-				group: window.location.href,
+				group: sanitizedLocationHref(),
 			},
 		})
 		this.recordGauge({
@@ -593,7 +596,7 @@ export class ObserveSDK implements Observe {
 			value: height * width,
 			attributes: {
 				category: MetricCategory.Device,
-				group: window.location.href,
+				group: sanitizedLocationHref(),
 			},
 		})
 	}
@@ -634,7 +637,7 @@ export class ObserveSDK implements Observe {
 								value,
 								attributes: {
 									category: MetricCategory.Performance,
-									group: window.location.href,
+									group: sanitizedLocationHref(),
 								},
 							}),
 					)
@@ -744,7 +747,7 @@ export class ObserveSDK implements Observe {
 		NetworkPerformanceListener((payload: NetworkPerformancePayload) => {
 			const attributes: Attributes = {
 				category: MetricCategory.Performance,
-				group: window.location.href,
+				group: sanitizedLocationHref(),
 			}
 			if (payload.saveData !== undefined) {
 				attributes['saveData'] = payload.saveData.toString()
@@ -775,7 +778,7 @@ export class ObserveSDK implements Observe {
 				value: getDeviceDetails().deviceMemory,
 				attributes: {
 					category: MetricCategory.Device,
-					group: window.location.href,
+					group: sanitizedLocationHref(),
 				},
 			})
 		}

--- a/sdk/highlight-run/src/sdk/record.ts
+++ b/sdk/highlight-run/src/sdk/record.ts
@@ -15,6 +15,7 @@ import {
 	Sdk,
 } from '../client/graph/generated/operations'
 import { PathListener } from '../client/listeners/path-listener'
+import { sanitizeUrl } from '../client/listeners/network-listener/utils/network-sanitizer'
 import { DebugOptions, SessionShortcutOptions } from '../client/types/client'
 import {
 	type Metadata,
@@ -679,11 +680,9 @@ SessionSecureID: ${this.sessionData.sessionSecureID}`,
 						document.referrer.includes(window.location.origin)
 					)
 				) {
-					this.addCustomEvent<string>('Referrer', document.referrer)
-					this.addProperties(
-						{ referrer: document.referrer },
-						{ type: 'session' },
-					)
+					const referrer = sanitizeUrl(document.referrer)
+					this.addCustomEvent<string>('Referrer', referrer)
+					this.addProperties({ referrer }, { type: 'session' })
 				}
 			}
 
@@ -815,15 +814,18 @@ SessionSecureID: ${this.sessionData.sessionSecureID}`,
 			}
 			this.listeners.push(
 				PathListener((url: string) => {
+					// PathListener hands back the raw href for change detection;
+					// redact before it lands in a recorded custom event.
+					const sanitized = sanitizeUrl(url)
 					if (this.reloaded) {
-						this.addCustomEvent<string>('Reload', url)
+						this.addCustomEvent<string>('Reload', sanitized)
 						this.reloaded = false
 						highlightThis.addProperties(
 							{ reload: true },
 							{ type: 'session' },
 						)
 					} else {
-						this.addCustomEvent<string>('Navigate', url)
+						this.addCustomEvent<string>('Navigate', sanitized)
 					}
 				}),
 			)


### PR DESCRIPTION
## Summary

`ErrorMessage.url` was set from `window.location.href` verbatim, so any secret sitting in the query string or fragment (OAuth `access_token`/`id_token`, magic links, password reset tokens) was uploaded to the backend with the error event.

`sanitizeUrl` already redacts sensitive query params and strips token-bearing fragments — that landed in #595 — but it was only ever wired into the network listener. The error path is separate code (`client/index.tsx`, not `network-sanitizer.ts`) and was never covered.

This adds `sanitizedLocationHref()` next to `sanitizeUrl` and routes every telemetry-bound page URL through it.

## What changed

**Error URLs**
- `Highlight._recordErrorMessage` — `client/index.tsx`
- `ObserveSDK` error recording, both call sites — `sdk/observe.ts`
- `ErrorListener` — `window.onerror` and unhandled rejections
- the `console.error` capture in `FirstLoadListeners`

**Span attributes and names**
- `url.full` and `event.url` on user-interaction spans
- `url.full` on `ld.track` spans
- `url.full`, `page_view.url`, `page_view.previous_url` on the page-view span — this one fires on every SPA navigation, including OAuth callbacks
- the history-navigation span name built in `_updateInteractionName`

**Metric `group` attributes** across viewport, device, web-vital, performance, and network-performance gauges, in both SDK generations (`client/index.tsx` and `sdk/observe.ts`) plus `H.recordMetric`

**Custom events and session properties**
- `Navigate` / `Reload` custom events
- the `Referrer` custom event and `referrer` session property (`document.referrer` carries the previous page's query string)
- the jank listener's emitted `newLocation`

## Deliberately unchanged

- Comparisons and change detection still read the raw `window.location.href` (`LocationChangeInstrumentation._lastUrl`, `jankState.location`, the pre/post URLs in `_patchHistoryMethod`). Sanitizing those would let redaction collapse two distinct URLs into one and silently drop legitimate page views. Only the recorded value is sanitized.
- `window.location.pathname` sites — no query or fragment to leak.
- `SegmentIntegrationListener`'s initial `callback(window.location.href)`. Its consumers branch on `obj.type`, so a bare string is dropped and never recorded.

## How did you test this change?

- New `error-listener.test.ts` drives the real `window.onerror` handler with `?access_token=…` and `#id_token=…` in the URL and asserts the secret is absent from the recorded `ErrorMessage.url`, plus a case confirming benign paths, params, and anchors survive.
- New `sanitizedLocationHref` cases alongside the existing `sanitizeUrl` suite.
- Verified the new tests are genuine regression coverage: stashed the fix, confirmed they fail on the unsanitized URL, restored, confirmed they pass.
- `yarn turbo run lint enforce-size test --filter highlight.run` — 25 files, 452 tests pass; bundle 169.83 kB brotli against the 256 kB limit.
- `yarn format-check` and `yarn dedupe --check` clean.

## Are there any deployment considerations?

Patch-level. One behavior change worth flagging: metric `group` values and page-view URLs are now redacted, so aggregation keys shift for any URL that contained sensitive params. Metrics from such URLs will group under the redacted form rather than the raw one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
