### PR TITLE
feat(flutter): expose session replay imageQuality and bump native SDKs

### DIFF
--- a/sdk/@launchdarkly/flutter/example/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/sdk/@launchdarkly/flutter/example/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/launchdarkly/swift-launchdarkly-observability.git",
       "state" : {
-        "revision" : "6d28f81c4bf47e4c1e22ae1b2e22433d03b58855",
-        "version" : "0.50.0"
+        "revision" : "1872c3f7f60d21f364afa3b4de85a5e8c5ee2f79",
+        "version" : "0.52.0"
       }
     }
   ],

--- a/sdk/@launchdarkly/flutter/example/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/sdk/@launchdarkly/flutter/example/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -44,15 +44,6 @@
         "revision" : "57051701c58a93603ffa2051f8e9cf0c8cff7814",
         "version" : "3.3.0"
       }
-    },
-    {
-      "identity" : "swift-launchdarkly-observability",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/launchdarkly/swift-launchdarkly-observability.git",
-      "state" : {
-        "revision" : "1872c3f7f60d21f364afa3b4de85a5e8c5ee2f79",
-        "version" : "0.52.0"
-      }
     }
   ],
   "version" : 2

--- a/sdk/@launchdarkly/flutter/example/ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/sdk/@launchdarkly/flutter/example/ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/launchdarkly/swift-launchdarkly-observability.git",
       "state" : {
-        "revision" : "6d28f81c4bf47e4c1e22ae1b2e22433d03b58855",
-        "version" : "0.50.0"
+        "revision" : "1872c3f7f60d21f364afa3b4de85a5e8c5ee2f79",
+        "version" : "0.52.0"
       }
     }
   ],

--- a/sdk/@launchdarkly/flutter/example/ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/sdk/@launchdarkly/flutter/example/ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -44,15 +44,6 @@
         "revision" : "57051701c58a93603ffa2051f8e9cf0c8cff7814",
         "version" : "3.3.0"
       }
-    },
-    {
-      "identity" : "swift-launchdarkly-observability",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/launchdarkly/swift-launchdarkly-observability.git",
-      "state" : {
-        "revision" : "1872c3f7f60d21f364afa3b4de85a5e8c5ee2f79",
-        "version" : "0.52.0"
-      }
     }
   ],
   "version" : 2

--- a/sdk/@launchdarkly/flutter/example/lib/main.dart
+++ b/sdk/@launchdarkly/flutter/example/lib/main.dart
@@ -115,6 +115,7 @@ void _startObservability() {
   );
   const replay = SessionReplayOptions(
     isEnabled: true,
+    imageQuality: 0.2,
     privacy: PrivacyOptions(
       maskTextInputs: true,
       maskWebViews: true,

--- a/sdk/@launchdarkly/flutter/packages/observability/CHANGELOG.md
+++ b/sdk/@launchdarkly/flutter/packages/observability/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the LaunchDarkly Observability SDK for Flutter will be documented in this file. This project adheres to [Semantic Versioning](https://semver.org).
 
+## [0.15.2](https://github.com/launchdarkly/observability-sdk/compare/launchdarkly_flutter_observability-0.15.1...launchdarkly_flutter_observability-0.15.2) (2026-08-13)
+
+
+### Features
+
+* expose Session Replay `imageQuality` and bump native SDKs to observability-android 0.66.0 and swift-launchdarkly-observability 0.52.0 ([#730](https://github.com/launchdarkly/observability-sdk/pull/730))
+
 ## [0.15.1](https://github.com/launchdarkly/observability-sdk/compare/launchdarkly_flutter_observability-0.15.0...launchdarkly_flutter_observability-0.15.1) (2026-08-13)
 
 

--- a/sdk/@launchdarkly/flutter/packages/observability/README.md
+++ b/sdk/@launchdarkly/flutter/packages/observability/README.md
@@ -157,6 +157,7 @@ On `SessionReplayOptions`:
 - `sampleRate` (`double`): probability from `0.0` to `1.0` that replay starts when enabled. Defaults to `1.0`.
 - `frameRate` (`double`): target capture rate in frames per second. Defaults to `1.0`.
 - `scale` (`double?`): replay capture resolution multiplier — `1.0` = 1x (160 DPI), `2.0` = 2x, etc. Higher values capture more detail but produce larger frames. `null` is treated as `1.0`. Defaults to `1.0`.
+- `imageQuality` (`double`): JPEG encoding quality of exported frames, from `0.0` (lowest quality, smallest payload) to `1.0` (highest quality, largest payload). Values outside that range are clamped. Defaults to `0.3`.
 
 ```dart
 LDObserve.init(
@@ -179,6 +180,7 @@ LDObserve.init(
     isEnabled: true,
     sampleRate: 0.25,
     frameRate: 2.0,
+    imageQuality: 0.2,
   ),
 );
 ```

--- a/sdk/@launchdarkly/flutter/packages/observability/android/build.gradle
+++ b/sdk/@launchdarkly/flutter/packages/observability/android/build.gradle
@@ -54,7 +54,7 @@ dependencies {
     // Native dependencies mirrored from the LaunchDarkly mobile SDKs (the same
     // stack used by sdk/@launchdarkly/react-native-ld-session-replay and the
     // .NET MAUI bridge in sdk/@launchdarkly/mobile-dotnet).
-    implementation "com.launchdarkly:launchdarkly-observability-android:0.65.0"
+    implementation "com.launchdarkly:launchdarkly-observability-android:0.66.0"
     // OTel Attributes appears in ObservabilityOptions parameter types; provided
     // at runtime transitively through launchdarkly-observability-android.
     implementation "io.opentelemetry:opentelemetry-api:1.62.0"

--- a/sdk/@launchdarkly/flutter/packages/observability/android/src/main/kotlin/com/launchdarkly/launchdarkly_flutter_observability/LDNativeApiImpl.kt
+++ b/sdk/@launchdarkly/flutter/packages/observability/android/src/main/kotlin/com/launchdarkly/launchdarkly_flutter_observability/LDNativeApiImpl.kt
@@ -131,6 +131,7 @@ internal class LDNativeApiImpl(
             sampleRate = replay.sampleRate ?: 1.0,
             frameRate = replay.frameRate ?: 1.0,
             scale = replayScale,
+            imageQuality = replay.imageQuality ?: 0.3,
             privacyProfile = PrivacyProfile(
                 maskTextInputs = maskTextInputs,
                 maskText = privacy?.maskLabels ?: false,

--- a/sdk/@launchdarkly/flutter/packages/observability/android/src/main/kotlin/com/launchdarkly/launchdarkly_flutter_observability/Messages.g.kt
+++ b/sdk/@launchdarkly/flutter/packages/observability/android/src/main/kotlin/com/launchdarkly/launchdarkly_flutter_observability/Messages.g.kt
@@ -297,6 +297,7 @@ data class LDSessionReplayOptions (
   val sampleRate: Double? = null,
   val frameRate: Double? = null,
   val scale: Double? = null,
+  val imageQuality: Double? = null,
   val privacy: LDPrivacyOptions? = null
 )
  {
@@ -307,8 +308,9 @@ data class LDSessionReplayOptions (
       val sampleRate = pigeonVar_list[2] as Double?
       val frameRate = pigeonVar_list[3] as Double?
       val scale = pigeonVar_list[4] as Double?
-      val privacy = pigeonVar_list[5] as LDPrivacyOptions?
-      return LDSessionReplayOptions(isEnabled, serviceName, sampleRate, frameRate, scale, privacy)
+      val imageQuality = pigeonVar_list[5] as Double?
+      val privacy = pigeonVar_list[6] as LDPrivacyOptions?
+      return LDSessionReplayOptions(isEnabled, serviceName, sampleRate, frameRate, scale, imageQuality, privacy)
     }
   }
   fun toList(): List<Any?> {
@@ -318,6 +320,7 @@ data class LDSessionReplayOptions (
       sampleRate,
       frameRate,
       scale,
+      imageQuality,
       privacy,
     )
   }

--- a/sdk/@launchdarkly/flutter/packages/observability/ios/launchdarkly_flutter_observability/Package.swift
+++ b/sdk/@launchdarkly/flutter/packages/observability/ios/launchdarkly_flutter_observability/Package.swift
@@ -20,7 +20,7 @@ let swiftObservabilityDependency: Package.Dependency = if useLocalNativeSdk {
 } else {
     .package(
         url: "https://github.com/launchdarkly/swift-launchdarkly-observability.git",
-        .upToNextMinor(from: "0.50.0")
+        .upToNextMinor(from: "0.52.0")
     )
 }
 

--- a/sdk/@launchdarkly/flutter/packages/observability/ios/launchdarkly_flutter_observability/Package.swift
+++ b/sdk/@launchdarkly/flutter/packages/observability/ios/launchdarkly_flutter_observability/Package.swift
@@ -12,11 +12,22 @@ func isTruthy(_ value: String?) -> Bool {
 }
 
 let useLocalNativeSdk = isTruthy(ProcessInfo.processInfo.environment["LD_USE_LOCAL_NATIVE"])
+
+// Flutter's Swift Package Manager integration exposes this manifest to Xcode
+// through a symlink under `<app>/ios/Flutter/ephemeral/Packages/.packages`, and
+// SwiftPM resolves a relative dependency path against that symlink instead of
+// this directory. Resolve the manifest's real location first so the sibling
+// checkout is found however the package was reached.
+let localSwiftObservabilityPath = ProcessInfo.processInfo.environment["LD_SWIFT_OBSERVABILITY_PATH"]
+    ?? URL(fileURLWithPath: #filePath)
+        .resolvingSymlinksInPath()
+        .deletingLastPathComponent()
+        .appendingPathComponent("../../../../../../../../swift-launchdarkly-observability")
+        .standardizedFileURL
+        .path
+
 let swiftObservabilityDependency: Package.Dependency = if useLocalNativeSdk {
-    .package(
-        path: ProcessInfo.processInfo.environment["LD_SWIFT_OBSERVABILITY_PATH"]
-            ?? "../../../../../../../../swift-launchdarkly-observability"
-    )
+    .package(path: localSwiftObservabilityPath)
 } else {
     .package(
         url: "https://github.com/launchdarkly/swift-launchdarkly-observability.git",

--- a/sdk/@launchdarkly/flutter/packages/observability/ios/launchdarkly_flutter_observability/Sources/launchdarkly_flutter_observability/LDNativeApiImpl.swift
+++ b/sdk/@launchdarkly/flutter/packages/observability/ios/launchdarkly_flutter_observability/Sources/launchdarkly_flutter_observability/LDNativeApiImpl.swift
@@ -284,7 +284,8 @@ final class LDNativeApiImpl: NSObject, LDNativeApi {
                 maskImages: privacy?.maskImages ?? false
             ),
             frameRate: replay.frameRate ?? 1.0,
-            scale: resolvedScale
+            scale: resolvedScale,
+            imageQuality: CGFloat(replay.imageQuality ?? 0.3)
         )
     }
 

--- a/sdk/@launchdarkly/flutter/packages/observability/ios/launchdarkly_flutter_observability/Sources/launchdarkly_flutter_observability/Messages.g.swift
+++ b/sdk/@launchdarkly/flutter/packages/observability/ios/launchdarkly_flutter_observability/Sources/launchdarkly_flutter_observability/Messages.g.swift
@@ -356,6 +356,7 @@ struct LDSessionReplayOptions: Hashable {
   var sampleRate: Double? = nil
   var frameRate: Double? = nil
   var scale: Double? = nil
+  var imageQuality: Double? = nil
   var privacy: LDPrivacyOptions? = nil
 
 
@@ -366,7 +367,8 @@ struct LDSessionReplayOptions: Hashable {
     let sampleRate: Double? = nilOrValue(pigeonVar_list[2])
     let frameRate: Double? = nilOrValue(pigeonVar_list[3])
     let scale: Double? = nilOrValue(pigeonVar_list[4])
-    let privacy: LDPrivacyOptions? = nilOrValue(pigeonVar_list[5])
+    let imageQuality: Double? = nilOrValue(pigeonVar_list[5])
+    let privacy: LDPrivacyOptions? = nilOrValue(pigeonVar_list[6])
 
     return LDSessionReplayOptions(
       isEnabled: isEnabled,
@@ -374,6 +376,7 @@ struct LDSessionReplayOptions: Hashable {
       sampleRate: sampleRate,
       frameRate: frameRate,
       scale: scale,
+      imageQuality: imageQuality,
       privacy: privacy
     )
   }
@@ -384,6 +387,7 @@ struct LDSessionReplayOptions: Hashable {
       sampleRate,
       frameRate,
       scale,
+      imageQuality,
       privacy,
     ]
   }

--- a/sdk/@launchdarkly/flutter/packages/observability/lib/src/options/session_replay_options.dart
+++ b/sdk/@launchdarkly/flutter/packages/observability/lib/src/options/session_replay_options.dart
@@ -28,6 +28,13 @@ class SessionReplayOptions {
   /// treated as `1.0`. Defaults to `1.0`.
   final double? scale;
 
+  /// JPEG encoding quality of exported frames, from `0.0` (lowest quality,
+  /// smallest payload) to `1.0` (highest quality, largest payload). Values
+  /// outside that range are clamped by the native SDK. Mirrors Android
+  /// `ReplayOptions.imageQuality` and iOS `SessionReplayOptions.imageQuality`.
+  /// Native-only. Defaults to `0.3`.
+  final double imageQuality;
+
   final PrivacyOptions privacy;
 
   const SessionReplayOptions({
@@ -36,6 +43,7 @@ class SessionReplayOptions {
     this.sampleRate = 1.0,
     this.frameRate = 1.0,
     this.scale = 1.0,
+    this.imageQuality = 0.3,
     this.privacy = const PrivacyOptions(),
   });
 }

--- a/sdk/@launchdarkly/flutter/packages/observability/lib/src/platform/io/ld_observability_bridge.dart
+++ b/sdk/@launchdarkly/flutter/packages/observability/lib/src/platform/io/ld_observability_bridge.dart
@@ -9,7 +9,7 @@ import 'native_options_codec.dart';
 /// The version of this Flutter package, surfaced in the resource attributes
 /// the native bridge attaches as `telemetry.distro.version`. Kept in sync
 /// with `pubspec.yaml` by release-please.
-const String _packageVersion = '0.15.1'; // x-release-please-version
+const String _packageVersion = '0.15.2'; // x-release-please-version
 
 /// Internal entry point for starting the LaunchDarkly observability +
 /// session replay native stack from Flutter. Mirrors the C#

--- a/sdk/@launchdarkly/flutter/packages/observability/lib/src/platform/io/messages.g.dart
+++ b/sdk/@launchdarkly/flutter/packages/observability/lib/src/platform/io/messages.g.dart
@@ -352,6 +352,7 @@ class LDSessionReplayOptions {
     this.sampleRate,
     this.frameRate,
     this.scale,
+    this.imageQuality,
     this.privacy,
   });
 
@@ -365,6 +366,8 @@ class LDSessionReplayOptions {
 
   double? scale;
 
+  double? imageQuality;
+
   LDPrivacyOptions? privacy;
 
   List<Object?> _toList() {
@@ -374,6 +377,7 @@ class LDSessionReplayOptions {
       sampleRate,
       frameRate,
       scale,
+      imageQuality,
       privacy,
     ];
   }
@@ -390,7 +394,8 @@ class LDSessionReplayOptions {
       sampleRate: result[2] as double?,
       frameRate: result[3] as double?,
       scale: result[4] as double?,
-      privacy: result[5] as LDPrivacyOptions?,
+      imageQuality: result[5] as double?,
+      privacy: result[6] as LDPrivacyOptions?,
     );
   }
 

--- a/sdk/@launchdarkly/flutter/packages/observability/lib/src/platform/io/native_options_codec.dart
+++ b/sdk/@launchdarkly/flutter/packages/observability/lib/src/platform/io/native_options_codec.dart
@@ -57,6 +57,7 @@ extension SessionReplayOptionsWire on SessionReplayOptions {
     sampleRate: sampleRate,
     frameRate: frameRate,
     scale: scale,
+    imageQuality: imageQuality,
     privacy: privacy.toWire(),
   );
 }

--- a/sdk/@launchdarkly/flutter/packages/observability/pigeons/messages.dart
+++ b/sdk/@launchdarkly/flutter/packages/observability/pigeons/messages.dart
@@ -73,6 +73,7 @@ class LDSessionReplayOptions {
   double? sampleRate;
   double? frameRate;
   double? scale;
+  double? imageQuality;
   LDPrivacyOptions? privacy;
 }
 

--- a/sdk/@launchdarkly/flutter/packages/observability/pubspec.yaml
+++ b/sdk/@launchdarkly/flutter/packages/observability/pubspec.yaml
@@ -1,6 +1,6 @@
 name: launchdarkly_flutter_observability
 description: 'The LaunchDarkly Observability and Session Replay plugin for Flutter. Get started using LaunchDarkly today!'
-version: 0.15.1
+version: 0.15.2
 homepage: https://github.com/launchdarkly/observability-sdk
 repository: https://github.com/launchdarkly/observability-sdk/tree/main/sdk/@launchdarkly/flutter/packages/observability
 

--- a/sdk/@launchdarkly/flutter/packages/observability/test/native_options_codec_test.dart
+++ b/sdk/@launchdarkly/flutter/packages/observability/test/native_options_codec_test.dart
@@ -67,12 +67,13 @@ void main() {
   });
 
   group('SessionReplayOptions.toWire', () {
-    test('uses default sample rate, frame rate, and scale', () {
+    test('uses default sample rate, frame rate, scale, and image quality', () {
       final wire = const SessionReplayOptions().toWire();
 
       expect(wire.sampleRate, 1.0);
       expect(wire.frameRate, 1.0);
       expect(wire.scale, 1.0);
+      expect(wire.imageQuality, 0.3);
     });
 
     test('propagates a custom sample rate', () {
@@ -91,6 +92,12 @@ void main() {
       final wire = const SessionReplayOptions(scale: 2.0).toWire();
 
       expect(wire.scale, 2.0);
+    });
+
+    test('propagates a custom image quality', () {
+      final wire = const SessionReplayOptions(imageQuality: 0.75).toWire();
+
+      expect(wire.imageQuality, 0.75);
     });
 
     test('propagates a null scale to disable the scaling override', () {


### PR DESCRIPTION
## Summary

- Adds `imageQuality` to Flutter `SessionReplayOptions` (defaults to `0.3`, matching native) and carries it over the Pigeon bridge into Android `ReplayOptions.imageQuality` and iOS `SessionReplayOptions.imageQuality`, so apps can trade replay fidelity against payload size. Values outside `0.0...1.0` are clamped by the native encoders, so the bridge passes the value through untouched.
- Bumps the native pins to `launchdarkly-observability-android` 0.66.0 and `swift-launchdarkly-observability` 0.52.0 — the first releases that accept the option — and updates the example app's `Package.resolved`.
- Documents the option in the package README and covers the wire mapping (default and custom value) in `native_options_codec_test.dart`.

## Test plan

- [x] `flutter analyze` and `dart format --set-exit-if-changed .` clean
- [x] `flutter test` — 159 tests pass
- [x] `flutter build apk --debug` for the example app (Android bridge compiles against 0.66.0)
- [x] `flutter build ios --debug --no-codesign` for the example app (iOS bridge compiles against 0.52.0)
- [ ] Manual check that a low vs. high `imageQuality` visibly changes replay frame size in a recorded session

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Adds **`imageQuality`** to Flutter **`SessionReplayOptions`** (default `0.3`) so apps can tune JPEG quality for exported replay frames and balance fidelity vs. payload size. The value is carried through the Pigeon bridge to Android **`ReplayOptions.imageQuality`** and iOS **`SessionReplayOptions.imageQuality`**; out-of-range values are clamped on the native side.
> 
> Bumps **`launchdarkly-observability-android`** to **0.66.0** and **`swift-launchdarkly-observability`** to **0.52.0** (minimum versions that support the option). The iOS **`Package.swift`** resolves the local observability checkout via the manifest’s real path so SwiftPM finds sibling checkouts when the package is symlinked from Flutter’s ephemeral Packages layout.
> 
> Package release **0.15.2**, README and codec tests updated; the example app sets **`imageQuality: 0.2`** in its replay config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61f667e184855c41090be0e9b3445c1cffb221d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->