### PR TITLE
feat(react-native): expose session replay imageQuality and bump native SDKs

### DIFF
--- a/sdk/@launchdarkly/react-native-ld-session-replay/README.md
+++ b/sdk/@launchdarkly/react-native-ld-session-replay/README.md
@@ -83,14 +83,15 @@ unset. Both are applied on iOS and Android.
 
 ## Capture and sampling options
 
-These options control how often frames are captured, at what resolution, and whether
-this session is selected for recording. All are forwarded to the native session replay
-SDK on **iOS and Android**.
+These options control how often frames are captured, at what resolution and JPEG
+quality, and whether this session is selected for recording. All are forwarded to
+the native session replay SDK on **iOS and Android**.
 
 | Option | Type | Default | Description |
 | --- | --- | --- | --- |
 | `frameRate` | `number` | `1.0` | Target capture rate in frames per second. |
 | `scale` | `number` | `1.0` | Capture/export resolution multiplier (`1.0` = 1x / 160 DPI, `2.0` = 2x, etc.). Non-positive values are treated as `1.0`. |
+| `imageQuality` | `number` | `0.3` | JPEG encoding quality of exported frames (`0.0` = lowest quality / smallest payload, `1.0` = highest quality / largest payload). Values outside that range are clamped by the native SDK. |
 | `sampleRate` | `number` | `1.0` | Probability from `0.0` to `1.0` that replay starts when `isEnabled` is `true`. `0.0` never records; `1.0` always records. Evaluated once per enable cycle and reset when replay is stopped. |
 
 ```js
@@ -98,6 +99,7 @@ const plugin = createSessionReplayPlugin({
   isEnabled: true,
   frameRate: 2.0,
   scale: 1.0,
+  imageQuality: 0.2,
   sampleRate: 0.25, // record roughly 25% of sessions
 });
 ```

--- a/sdk/@launchdarkly/react-native-ld-session-replay/SessionReplayReactNative.podspec
+++ b/sdk/@launchdarkly/react-native-ld-session-replay/SessionReplayReactNative.podspec
@@ -24,7 +24,7 @@ Pod::Spec.new do |s|
     "DEFINES_MODULE" => "YES"
   }
 
-  s.dependency 'LaunchDarklySessionReplay', '~> 0.47.0'
+  s.dependency 'LaunchDarklySessionReplay', '~> 0.53.0'
 
   install_modules_dependencies(s)
 end

--- a/sdk/@launchdarkly/react-native-ld-session-replay/android/build.gradle
+++ b/sdk/@launchdarkly/react-native-ld-session-replay/android/build.gradle
@@ -94,7 +94,7 @@ def kotlin_version = getExtOrDefault("kotlinVersion")
 dependencies {
   implementation "com.facebook.react:react-android"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  implementation "com.launchdarkly:launchdarkly-observability-android:0.65.0"
+  implementation "com.launchdarkly:launchdarkly-observability-android:0.66.0"
   implementation "com.launchdarkly:launchdarkly-android-client-sdk:5.14.0"
   // compileOnly: OTel Attributes appears in ObservabilityOptions parameter types; provided at
   // runtime transitively through launchdarkly-observability-android.

--- a/sdk/@launchdarkly/react-native-ld-session-replay/android/src/main/java/com/sessionreplayreactnative/SessionReplayClientAdapter.kt
+++ b/sdk/@launchdarkly/react-native-ld-session-replay/android/src/main/java/com/sessionreplayreactnative/SessionReplayClientAdapter.kt
@@ -288,6 +288,11 @@ internal class SessionReplayClientAdapter private constructor() {
         } else {
             1.0
         }
+        val imageQuality = if (map.hasKey("imageQuality")) {
+            map.getDouble("imageQuality")
+        } else {
+            0.3
+        }
         val minimumAlpha = if (map.hasKey("minimumAlpha")) {
             map.getDouble("minimumAlpha").toFloat()
         } else {
@@ -300,6 +305,7 @@ internal class SessionReplayClientAdapter private constructor() {
             sampleRate = sampleRate,
             frameRate = frameRate,
             scale = replayScale,
+            imageQuality = imageQuality,
             privacyProfile = PrivacyProfile(
                 maskTextInputs = maskTextInputs,
                 maskWebViews = maskWebViews,

--- a/sdk/@launchdarkly/react-native-ld-session-replay/android/src/test/java/com/sessionreplayreactnative/SessionReplayClientAdapterTest.kt
+++ b/sdk/@launchdarkly/react-native-ld-session-replay/android/src/test/java/com/sessionreplayreactnative/SessionReplayClientAdapterTest.kt
@@ -28,6 +28,7 @@ class SessionReplayClientAdapterTest {
         assertTrue(options.enabled)
         assertEquals(1.0, options.frameRate)
         assertEquals(1.0, options.scale)
+        assertEquals(0.3, options.imageQuality)
         assertEquals(1.0, options.sampleRate)
         assertTrue(options.privacyProfile.maskTextInputs)
         assertFalse(options.privacyProfile.maskWebViews)
@@ -49,6 +50,7 @@ class SessionReplayClientAdapterTest {
             every { hasKey("unmaskTestIDs") } returns false
             every { hasKey("frameRate") } returns false
             every { hasKey("scale") } returns false
+            every { hasKey("imageQuality") } returns false
             every { hasKey("minimumAlpha") } returns false
             every { hasKey("sampleRate") } returns false
         }
@@ -59,7 +61,7 @@ class SessionReplayClientAdapterTest {
     }
 
     @Test
-    fun `replayOptionsFrom maps frameRate scale sampleRate and minimumAlpha`() {
+    fun `replayOptionsFrom maps frameRate scale imageQuality sampleRate and minimumAlpha`() {
         val adapter = newAdapter()
         val map = mockk<ReadableMap> {
             every { hasKey("isEnabled") } returns false
@@ -73,6 +75,8 @@ class SessionReplayClientAdapterTest {
             every { getDouble("frameRate") } returns 2.0
             every { hasKey("scale") } returns true
             every { getDouble("scale") } returns 2.5
+            every { hasKey("imageQuality") } returns true
+            every { getDouble("imageQuality") } returns 0.75
             every { hasKey("minimumAlpha") } returns true
             every { getDouble("minimumAlpha") } returns 0.05
             every { hasKey("sampleRate") } returns true
@@ -83,6 +87,7 @@ class SessionReplayClientAdapterTest {
 
         assertEquals(2.0, options.frameRate)
         assertEquals(2.5, options.scale)
+        assertEquals(0.75, options.imageQuality)
         assertEquals(0.05f, options.privacyProfile.minimumAlpha)
         assertEquals(0.25, options.sampleRate)
     }
@@ -101,6 +106,7 @@ class SessionReplayClientAdapterTest {
             every { hasKey("frameRate") } returns false
             every { hasKey("scale") } returns true
             every { getDouble("scale") } returns 0.0
+            every { hasKey("imageQuality") } returns false
             every { hasKey("minimumAlpha") } returns false
             every { hasKey("sampleRate") } returns false
         }

--- a/sdk/@launchdarkly/react-native-ld-session-replay/ios/SessionReplayClientAdapter.swift
+++ b/sdk/@launchdarkly/react-native-ld-session-replay/ios/SessionReplayClientAdapter.swift
@@ -306,7 +306,8 @@ extension SessionReplayClientAdapter {
         serviceName: "sessionreplay-react-native",
         privacy: privacy,
         frameRate: 1.0,
-        scale: 1.0
+        scale: 1.0,
+        imageQuality: 0.3
       )
     }
 
@@ -342,7 +343,8 @@ extension SessionReplayClientAdapter {
       serviceName: dictionary["serviceName"] as? String ?? "sessionreplay-react-native",
       privacy: privacy,
       frameRate: doubleOption(dictionary, key: "frameRate", default: 1.0),
-      scale: scaleOption(dictionary)
+      scale: scaleOption(dictionary),
+      imageQuality: CGFloat(doubleOption(dictionary, key: "imageQuality", default: 0.3))
     )
   }
 }

--- a/sdk/@launchdarkly/react-native-ld-session-replay/src/NativeSessionReplayReactNative.ts
+++ b/sdk/@launchdarkly/react-native-ld-session-replay/src/NativeSessionReplayReactNative.ts
@@ -60,6 +60,14 @@ export type SessionReplayOptions = {
   scale?: number;
 
   /**
+   * JPEG encoding quality of exported frames, from `0.0` (lowest quality,
+   * smallest payload) to `1.0` (highest quality, largest payload). Values
+   * outside that range are clamped by the native SDK. Applied on iOS and
+   * Android. Defaults to `0.3`.
+   */
+  imageQuality?: number;
+
+  /**
    * Mask views whose effective opacity is below this threshold (0.0–1.0).
    * Defaults to `0.02`.
    */

--- a/sdk/@launchdarkly/react-native-ld-session-replay/src/__tests__/index.test.tsx
+++ b/sdk/@launchdarkly/react-native-ld-session-replay/src/__tests__/index.test.tsx
@@ -22,10 +22,11 @@ describe('configureSessionReplay', () => {
     await expect(configureSessionReplay('   ')).rejects.toThrow();
   });
 
-  it('forwards frameRate, scale, and sampleRate to native configure', async () => {
+  it('forwards frameRate, scale, imageQuality, and sampleRate to native configure', async () => {
     await configureSessionReplay('mob-key-123', {
       frameRate: 2,
       scale: 2.5,
+      imageQuality: 0.75,
       sampleRate: 0.25,
     });
     expect(NativeSessionReplayReactNative.configure).toHaveBeenCalledWith(
@@ -33,6 +34,7 @@ describe('configureSessionReplay', () => {
       expect.objectContaining({
         frameRate: 2,
         scale: 2.5,
+        imageQuality: 0.75,
         sampleRate: 0.25,
         maskTestIDs: ['__LD_INTERNAL_MASK__'],
         unmaskTestIDs: ['__LD_INTERNAL_UNMASK__'],
@@ -207,6 +209,7 @@ describe('SessionReplayPluginAdapter', () => {
     const plugin = createSessionReplayPlugin({
       frameRate: 4,
       scale: 2,
+      imageQuality: 0.2,
       sampleRate: 0.5,
     });
     plugin.register(
@@ -224,6 +227,7 @@ describe('SessionReplayPluginAdapter', () => {
       expect.objectContaining({
         frameRate: 4,
         scale: 2,
+        imageQuality: 0.2,
         sampleRate: 0.5,
         maskTestIDs: ['__LD_INTERNAL_MASK__'],
         unmaskTestIDs: ['__LD_INTERNAL_UNMASK__'],


### PR DESCRIPTION
## Summary
- Expose `imageQuality` on React Native `SessionReplayOptions` (default `0.3`) and carry it over the JS → Android/iOS bridges into native `ReplayOptions` / `SessionReplayOptions`, matching Flutter's capture option set.
- Bump native pins to `launchdarkly-observability-android` **0.66.0** and CocoaPods `LaunchDarklySessionReplay` **~> 0.53.0** (latest available); Android client SDK remains at `5.14.0`.

## Test plan
- [x] JS: `yarn test --watchman=false --testPathPattern='src/__tests__/index.test'` in `sdk/@launchdarkly/react-native-ld-session-replay` (18 passed)
- [ ] Android: `./gradlew :launchdarkly_session-replay-react-native:testDebugUnitTest --tests 'com.sessionreplayreactnative.SessionReplayClientAdapterTest'` in `example/android`
- [ ] iOS: pod install in example app resolves `LaunchDarklySessionReplay` 0.53.x and builds
- [ ] CI: React Native session replay workflows
- [ ] Manual: low vs high `imageQuality` visibly changes replay frame size


Made with [Cursor](https://cursor.com)